### PR TITLE
use "copy" instead of "paperclip" for copying the MODULE.bazel snippet

### DIFF
--- a/app/bcr/registry.soy
+++ b/app/bcr/registry.soy
@@ -8,6 +8,7 @@ import {
     octiconCode16,
     octiconContainer16,
     octiconContainer24,
+    octiconCopy16,
     octiconDotFill16,
     octiconFileAdded16,
     octiconFileDiff16,
@@ -19,7 +20,6 @@ import {
     octiconMail16,
     octiconMarkGithub16,
     octiconMarkGithub24,
-    octiconPaperclip16,
     octiconSparkleFill16,
     octiconSquareFill16,
     octiconSquareFill24,
@@ -98,7 +98,7 @@ bazel_dep(name = "{$name}", version = "{$version}")
 {template copyToClipboardButton}
   {@param content: string}
 <button class="btn btn-octicon" aria-label="Copy to clipboard" data-clippy='{$content}'>
-    {octiconPaperclip16()}
+    {octiconCopy16()}
 </button>
 {/template}
 


### PR DESCRIPTION
<img width="1932" height="576" alt="image" src="https://github.com/user-attachments/assets/7ed44404-ff27-499c-9566-ad003d77e2f0" />
