### PR TITLE
Use BCR_AUTOMATION_TOKEN for github workflows

### DIFF
--- a/.github/workflows/deploy-and-merge-bcr-pr.yaml
+++ b/.github/workflows/deploy-and-merge-bcr-pr.yaml
@@ -21,14 +21,14 @@ jobs:
       pull-requests: write
       packages: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BCR_AUTOMATION_TOKEN }}
 
       - name: Get BCR commit hash
         id: bcr_commit
@@ -49,7 +49,7 @@ jobs:
             --squash \
             --delete-branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}
 
       - name: Clean and initialize BCR
         run: make bcr_clean bcr_init bcr_update
@@ -81,4 +81,4 @@ jobs:
           bazel run @multitool//tools/gh:gh -- pr comment ${{ github.event.pull_request.number }} \
             --body "❌ Deployment failed for BCR commit \`${{ steps.bcr_commit.outputs.sha }}\`. Auto-merge has been disabled. Please review the logs and merge manually after fixing."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}

--- a/.github/workflows/trigger-via-bcr.yml
+++ b/.github/workflows/trigger-via-bcr.yml
@@ -11,12 +11,12 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BCR_AUTOMATION_TOKEN }}
 
       - name: Update submodule to specified commit
         run: |

--- a/.github/workflows/update-bcr-submodule.yaml
+++ b/.github/workflows/update-bcr-submodule.yaml
@@ -23,13 +23,13 @@ jobs:
       packages: write
       pull-requests: write
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BCR_AUTOMATION_TOKEN }}
 
       - name: Check for BCR updates
         id: check_updates


### PR DESCRIPTION
To facilitate auto-merge PRs and keep branch protection on `main`.
