### PR TITLE
Fix duplicate file key error in documentation trie

### DIFF
--- a/app/bcr/documentation.js
+++ b/app/bcr/documentation.js
@@ -343,7 +343,9 @@ class ModuleVersionSymbolsSelect extends ContentSelect {
 	 * @param {!File} file
 	 */
 	addFile(file) {
-		this.fileTrie_.add(this.getFilePrefix(file), file);
+		const prefix = this.getFilePrefix(file);
+		// Use set instead of add to handle duplicate file paths
+		this.fileTrie_.set(prefix, file);
 	}
 
 	/**


### PR DESCRIPTION
Use Trie.set() instead of Trie.add() to handle cases where the same file path appears multiple times in the documentation. The add() method throws an error on duplicate keys, while set() overwrites them gracefully.

Fixes the "collection already contains the key" error when loading module documentation with duplicate file entries.

Fixes #121 