### PR TITLE
Fix search bar autocomplete conflicts and add search result page inputs

### DIFF
--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -242,6 +242,9 @@ import {
 
 {template moduleSearchComponent}
 <div>
+  <div class="p-3">
+    <input type="text" class="js-search-input form-control width-full" placeholder="Search modules..." autocomplete="off">
+  </div>
   <div class="{css('content')}">
   </div>
 </div>
@@ -272,6 +275,9 @@ import {
 
 {template documentationSearchComponent}
 <div>
+  <div class="p-3">
+    <input type="text" class="js-search-input form-control width-full" placeholder="Search symbols..." autocomplete="off">
+  </div>
   <div class="{css('content')}">
   </div>
 </div>
@@ -357,7 +363,7 @@ import {
       {largeStatDisplay(value: $totalModuleVersions, label: 'Module Versions')}
       {largeStatDisplay(value: $totalMaintainers, label: 'Maintainers')}
     </div>
-    <div class="d-flex flex-row flex-wrap flex-items-center flex-justify-center mt-5" style="gap: 1.5rem">
+    <div class="js-symbol-stats d-flex flex-row flex-wrap flex-items-center flex-justify-center mt-5" style="gap: 1.5rem; display: none">
       {statDisplay(value: $totalRules, label: 'Rules', color: symbolColor(type: SymbolType.SYMBOL_TYPE_RULE))}
       {statDisplay(value: $totalFunctions, label: 'Functions', color: symbolColor(type: SymbolType.SYMBOL_TYPE_FUNCTION))}
       {statDisplay(value: $totalProviders, label: 'Providers', color: symbolColor(type: SymbolType.SYMBOL_TYPE_PROVIDER))}

--- a/app/bcr/body.js
+++ b/app/bcr/body.js
@@ -104,13 +104,8 @@ class BodySelect extends ContentSelect {
 	 */
 	selectFail(name, route) {
 		if (name === TabName.HOME) {
-			// Wait for symbols to be available before loading docs
-			getApplication(this)
-				.getRegistryWithSymbols()
-				.then(() => {
-					this.addTab(name, new HomeSelect(this.registry_, this.dom_));
-					this.select(name, route);
-				});
+			this.addTab(name, new HomeSelect(this.registry_, this.dom_));
+			this.select(name, route);
 			return;
 		}
 		if (name === TabName.DOCS) {

--- a/app/bcr/documentation.js
+++ b/app/bcr/documentation.js
@@ -27,6 +27,7 @@ const SymbolType = goog.require("proto.build.stack.bazel.symbol.v1.SymbolType");
 const Trie = goog.require("goog.structs.Trie");
 const arrays = goog.require("goog.array");
 const dom = goog.require("goog.dom");
+const events = goog.require("goog.events");
 const path = goog.require("goog.string.path");
 const soy = goog.require("goog.soy");
 const { getApplication } = goog.require("bcrfrontend.common");
@@ -1824,6 +1825,9 @@ class DocumentationSearchComponent extends ContentComponent {
 
 		/** @private @const @type {!Registry} */
 		this.registry_ = registry;
+
+		/** @private @type {?HTMLInputElement} */
+		this.searchInput_ = null;
 	}
 
 	/**
@@ -1838,6 +1842,36 @@ class DocumentationSearchComponent extends ContentComponent {
 	 */
 	enterDocument() {
 		super.enterDocument();
+
+		this.searchInput_ = /** @type {?HTMLInputElement} */ (
+			this.getElementStrict().querySelector(".js-search-input")
+		);
+
+		if (this.searchInput_) {
+			this.getHandler().listen(
+				this.searchInput_,
+				events.EventType.INPUT,
+				this.handleSearchInput_,
+			);
+		}
+	}
+
+	/**
+	 * Handle input events on the dedicated search box.
+	 * @param {!events.Event} e
+	 * @private
+	 */
+	handleSearchInput_(e) {
+		const value = this.searchInput_.value.trim();
+		if (!value) {
+			const el = this.getContentElement();
+			dom.removeChildren(el);
+			return;
+		}
+		const tokens = value.split(/\s+/);
+		const results = this.searchSymbols(tokens);
+		const el = this.getContentElement();
+		soy.renderElement(el, searchSymbolsResultsList, { tokens, results });
 	}
 
 	/**
@@ -1849,6 +1883,12 @@ class DocumentationSearchComponent extends ContentComponent {
 		const results = this.searchSymbols(tokens);
 		const el = this.getContentElement();
 		soy.renderElement(el, searchSymbolsResultsList, { tokens, results });
+
+		// Pre-fill the search input with the query
+		if (this.searchInput_) {
+			this.searchInput_.value = tokens.join(" ");
+		}
+
 		route.done(this);
 	}
 

--- a/app/bcr/documentation_search.js
+++ b/app/bcr/documentation_search.js
@@ -149,6 +149,8 @@ class DocumentationSearchHandler extends EventTarget {
 			keyCode: events.KeyCodes.PERIOD,
 			load: goog.bind(this.load, this),
 		};
+		/** @private @type {!SearchProvider} */
+		this.provider_ = provider;
 		return provider;
 	}
 
@@ -160,6 +162,7 @@ class DocumentationSearchHandler extends EventTarget {
 		const registry = await this.registryWithSymbols_;
 		this.indexSymbols_(registry);
 		this.addAllSymbols();
+		this.provider_.desc = `Search ${this.symbols_.size} symbols in documentation`;
 	}
 
 	/**

--- a/app/bcr/home.js
+++ b/app/bcr/home.js
@@ -16,6 +16,7 @@ const { homeOverviewComponent, homeSelect } = goog.require(
 	"soy.bcrfrontend.app",
 );
 const { formatRelativePast } = goog.require("bcrfrontend.format");
+const { getApplication } = goog.require("bcrfrontend.common");
 const { Component, Route } = goog.require("stack.ui");
 
 /**
@@ -96,18 +97,6 @@ class HomeOverviewComponent extends Component {
 		const maintainers = createMaintainersMap(this.registry_);
 
 		let totalModuleVersions = 0;
-		const symbolCounts = {
-			rules: 0,
-			functions: 0,
-			providers: 0,
-			aspects: 0,
-			moduleExtensions: 0,
-			repositoryRules: 0,
-			macros: 0,
-			ruleMacros: 0,
-			loads: 0,
-			values: 0,
-		};
 
 		// Collect all module versions with commit dates for sorting
 		/** @type {!Array<!{m: !Module, v: !ModuleVersion}>} */
@@ -116,63 +105,15 @@ class HomeOverviewComponent extends Component {
 		for (const module of modules.values()) {
 			totalModuleVersions += module.getVersionsList().length;
 
-			// Collect versions with commit dates
 			for (const version of module.getVersionsList()) {
 				const commit = version.getCommit();
 				if (commit && commit.getDate()) {
 					allVersions.push({ m: module, v: version });
 				}
-
-				// Count symbols from all versions
-				const source = version.getSource();
-				if (!source) continue;
-
-				const docs = source.getDocumentation();
-				if (!docs) continue;
-
-				for (const file of docs.getFileList()) {
-					if (file.getError()) continue;
-
-					for (const sym of file.getSymbolList()) {
-						const type = sym.getType();
-						switch (type) {
-							case SymbolType.SYMBOL_TYPE_RULE:
-								symbolCounts.rules++;
-								break;
-							case SymbolType.SYMBOL_TYPE_FUNCTION:
-								symbolCounts.functions++;
-								break;
-							case SymbolType.SYMBOL_TYPE_PROVIDER:
-								symbolCounts.providers++;
-								break;
-							case SymbolType.SYMBOL_TYPE_ASPECT:
-								symbolCounts.aspects++;
-								break;
-							case SymbolType.SYMBOL_TYPE_MODULE_EXTENSION:
-								symbolCounts.moduleExtensions++;
-								break;
-							case SymbolType.SYMBOL_TYPE_REPOSITORY_RULE:
-								symbolCounts.repositoryRules++;
-								break;
-							case SymbolType.SYMBOL_TYPE_MACRO:
-								symbolCounts.macros++;
-								break;
-							case SymbolType.SYMBOL_TYPE_RULE_MACRO:
-								symbolCounts.ruleMacros++;
-								break;
-							case SymbolType.SYMBOL_TYPE_LOAD_STMT:
-								symbolCounts.loads++;
-								break;
-							case SymbolType.SYMBOL_TYPE_VALUE:
-								symbolCounts.values++;
-								break;
-						}
-					}
-				}
 			}
 		}
 
-		// Sort by commit date (most recent first) and take top 10
+		// Sort by commit date (most recent first) and take top 15
 		allVersions.sort((a, b) => {
 			return (
 				new Date(b.v.getCommit().getDate()) -
@@ -188,6 +129,7 @@ class HomeOverviewComponent extends Component {
 			};
 		});
 
+		// Render with 0 for symbol stats (populated async in enterDocument)
 		this.setElementInternal(
 			soy.renderAsElement(homeOverviewComponent, {
 				registry: this.registry_,
@@ -195,15 +137,112 @@ class HomeOverviewComponent extends Component {
 				totalModules: modules.size,
 				totalModuleVersions: totalModuleVersions,
 				totalMaintainers: maintainers.size,
-				totalRules: symbolCounts.rules + symbolCounts.ruleMacros,
-				totalFunctions: symbolCounts.functions,
-				totalProviders: symbolCounts.providers,
-				totalAspects: symbolCounts.aspects,
-				totalModuleExtensions: symbolCounts.moduleExtensions,
-				totalRepositoryRules: symbolCounts.repositoryRules,
-				totalMacros: symbolCounts.macros,
+				totalRules: 0,
+				totalFunctions: 0,
+				totalProviders: 0,
+				totalAspects: 0,
+				totalModuleExtensions: 0,
+				totalRepositoryRules: 0,
+				totalMacros: 0,
 				recentlyUpdated,
 			}),
 		);
+	}
+
+	/**
+	 * @override
+	 */
+	enterDocument() {
+		super.enterDocument();
+
+		// Lazy-load symbol stats after symbols.pb.gz is fetched and decoded
+		getApplication(this)
+			.getRegistryWithSymbols()
+			.then(() => this.updateSymbolStats_());
+	}
+
+	/**
+	 * Compute symbol counts from the now-decorated registry and update the DOM.
+	 * @private
+	 */
+	updateSymbolStats_() {
+		const el = this.getElement();
+		if (!el) return;
+
+		const container = el.querySelector(".js-symbol-stats");
+		if (!container) return;
+
+		const counts = {
+			rules: 0,
+			functions: 0,
+			providers: 0,
+			aspects: 0,
+			moduleExtensions: 0,
+			repositoryRules: 0,
+			macros: 0,
+			ruleMacros: 0,
+		};
+
+		for (const module of this.registry_.getModulesList()) {
+			for (const version of module.getVersionsList()) {
+				const source = version.getSource();
+				if (!source) continue;
+
+				const docs = source.getDocumentation();
+				if (!docs) continue;
+
+				for (const file of docs.getFileList()) {
+					if (file.getError()) continue;
+
+					for (const sym of file.getSymbolList()) {
+						switch (sym.getType()) {
+							case SymbolType.SYMBOL_TYPE_RULE:
+								counts.rules++;
+								break;
+							case SymbolType.SYMBOL_TYPE_FUNCTION:
+								counts.functions++;
+								break;
+							case SymbolType.SYMBOL_TYPE_PROVIDER:
+								counts.providers++;
+								break;
+							case SymbolType.SYMBOL_TYPE_ASPECT:
+								counts.aspects++;
+								break;
+							case SymbolType.SYMBOL_TYPE_MODULE_EXTENSION:
+								counts.moduleExtensions++;
+								break;
+							case SymbolType.SYMBOL_TYPE_REPOSITORY_RULE:
+								counts.repositoryRules++;
+								break;
+							case SymbolType.SYMBOL_TYPE_MACRO:
+								counts.macros++;
+								break;
+							case SymbolType.SYMBOL_TYPE_RULE_MACRO:
+								counts.ruleMacros++;
+								break;
+						}
+					}
+				}
+			}
+		}
+
+		// Update stat values in DOM order: Rules, Functions, Providers,
+		// Extensions, Repo Rules, Aspects, Macros
+		const values = [
+			counts.rules + counts.ruleMacros,
+			counts.functions,
+			counts.providers,
+			counts.moduleExtensions,
+			counts.repositoryRules,
+			counts.aspects,
+			counts.macros,
+		];
+		const statEls = container.querySelectorAll(".f2-mktg");
+		for (let i = 0; i < values.length && i < statEls.length; i++) {
+			statEls[i].textContent = String(values[i]);
+		}
+
+		// Show the symbol stats row
+		container.style.display = "";
 	}
 }

--- a/app/bcr/main.js
+++ b/app/bcr/main.js
@@ -80,7 +80,6 @@ function decorateRegistryWithSymbols(registry, symbolsRegistry) {
  * Creates a Promise that fetches symbols.pb.gz and decorates the registry.
  * @param {!Registry} registry The base registry to decorate
  * @returns {!Promise<!Registry>} Promise that resolves to decorated registry
- * @suppress {uselessCode}
  */
 function createRegistryWithSymbolsPromise(registry) {
 	return (async () => {
@@ -93,9 +92,7 @@ function createRegistryWithSymbolsPromise(registry) {
 			const decompressed = await gzipDecode(gzipData);
 			const symbolsRegistry =
 				ModuleRegistrySymbols.deserializeBinary(decompressed);
-			if (false) {
-				decorateRegistryWithSymbols(registry, symbolsRegistry);
-			}
+			decorateRegistryWithSymbols(registry, symbolsRegistry);
 			return registry;
 		} catch (/** @type {*} */ e) {
 			console.error("Failed to load symbols:", e);

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -1648,6 +1648,9 @@ class ModuleSearchComponent extends ContentComponent {
 
 		/** @private @const @type {!Registry} */
 		this.registry_ = registry;
+
+		/** @private @type {?HTMLInputElement} */
+		this.searchInput_ = null;
 	}
 
 	/**
@@ -1663,7 +1666,40 @@ class ModuleSearchComponent extends ContentComponent {
 	enterDocument() {
 		super.enterDocument();
 
+		this.searchInput_ = /** @type {?HTMLInputElement} */ (
+			this.getElementStrict().querySelector(".js-search-input")
+		);
+
+		if (this.searchInput_) {
+			this.getHandler().listen(
+				this.searchInput_,
+				events.EventType.INPUT,
+				this.handleSearchInput_,
+			);
+		}
+
 		highlightAll(this.getElementStrict());
+	}
+
+	/**
+	 * Handle input events on the dedicated search box.
+	 * @param {!events.Event} e
+	 * @private
+	 */
+	handleSearchInput_(e) {
+		const value = this.searchInput_.value.trim();
+		if (!value) {
+			const el = this.getContentElement();
+			dom.removeChildren(el);
+			return;
+		}
+		const tokens = value.split(/\s+/);
+		const results = this.searchModules(tokens);
+		const el = this.getContentElement();
+		soy.renderElement(el, searchModulesResultsList, {
+			tokens,
+			results,
+		});
 	}
 
 	/**
@@ -1678,6 +1714,12 @@ class ModuleSearchComponent extends ContentComponent {
 			tokens,
 			results,
 		});
+
+		// Pre-fill the search input with the query
+		if (this.searchInput_) {
+			this.searchInput_.value = tokens.join(" ");
+		}
+
 		route.done(this);
 	}
 

--- a/app/bcr/search.js
+++ b/app/bcr/search.js
@@ -81,6 +81,7 @@ class SearchComponent extends EventTarget {
 		 * @private @type {?ListenableKey}
 		 */
 		this.acListenerKey_ = null;
+
 	}
 
 	/**
@@ -153,16 +154,21 @@ class SearchComponent extends EventTarget {
 	 * @private
 	 */
 	handleFormSubmit(e) {
-		console.log(`handleFormSubmit`, e);
-
 		e.preventDefault();
 		e.stopPropagation();
+
+		// If the AC dropdown is open with a highlighted row, the user
+		// explicitly selected an item. Let handleAcUpdate navigate instead.
+		const ac = this.getCurrentAutoComplete_();
+		if (ac && ac.hasHighlight()) {
+			return;
+		}
 
 		setTimeout(() => {
 			document.execCommand("selectall", null, false);
 		}, 50);
 
-		// no row was selected.  Navigate to the full search results list
+		// No row was selected. Navigate to the full search results list.
 		const value = this.getValue();
 		const provider = this.currentProviderName_;
 		if (value && provider) {
@@ -192,18 +198,8 @@ class SearchComponent extends EventTarget {
 	handleAcUpdate(e) {
 		if (e.row) {
 			this.submit(e.row);
-		} else {
-			const value = this.getValue();
-			const provider = this.currentProviderName_;
-			if (value && provider) {
-				this.app_.setLocation(["search", provider, value]);
-			}
 		}
-
-		// Only blur and clear if this was a selection (Enter key), not navigation
-		// Navigation events don't trigger dismiss
 		if (e.type === "update" || !e.row) {
-			// This was a final selection, blur and clear
 			this.blurAndClear();
 		}
 	}
@@ -355,6 +351,18 @@ class SearchComponent extends EventTarget {
 		this.inputEl_.disabled = false;
 		this.currentProvider_ = provider;
 		this.currentProviderName_ = provider.name;
+	}
+
+	/**
+	 * Returns the current provider's AutoComplete instance, or null.
+	 * @return {?AutoComplete}
+	 * @private
+	 */
+	getCurrentAutoComplete_() {
+		if (!this.currentProvider_ || !this.currentProvider_.inputHandler) {
+			return null;
+		}
+		return this.currentProvider_.inputHandler.getAutoComplete() || null;
 	}
 
 	/**

--- a/app/bcr/search.js
+++ b/app/bcr/search.js
@@ -81,7 +81,6 @@ class SearchComponent extends EventTarget {
 		 * @private @type {?ListenableKey}
 		 */
 		this.acListenerKey_ = null;
-
 	}
 
 	/**


### PR DESCRIPTION
The search bar changes from d881500 introduced conflicting navigation: form submit and AC update both fired on Enter, and an AC else clause caused unexpected navigation on dismiss. Fix by checking hasHighlight() to let the AC handler take priority when a row is selected, and remove the else clause that duplicated form-submit navigation.

Add dedicated search inputs to module and symbol search result pages so users can re-query without the top bar. Enable lazy symbol stats on the home page and re-enable symbol decoration in main.js.