### PR TITLE
Replace "Recently Updated" table with vertical timeline

### DIFF
--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -107,15 +107,18 @@ import {
 } from 'app/bcr/registry.soy';
 import {
   fileInfoUrl,
+  githubAvatarUrl,
   githubRawUrl,
   githubRepoUrlFromModuleVersion,
   githubSourceUrl,
+  githubUserUrl,
   labelUri,
   loadLabelUrl,
   moduleLabelDocsUri,
   modulesUrl,
   moduleVersionDocsUrl,
   moduleVersionUrl,
+  registryPullRequestUrl,
   renderLabel,
   symbolInfoUrl
 } from 'app/bcr/uri.soy';
@@ -363,7 +366,7 @@ import {
       {sp}
       {octiconChevronLeft16()}
     </div>
-    <div class="js-symbol-stats d-flex flex-row flex-wrap flex-items-center flex-justify-center mt-5" style="gap: 1.5rem; display: none">
+    <div class="js-symbol-stats d-flex flex-row flex-wrap flex-items-center flex-justify-center mt-4" style="gap: 1.5rem; display: none">
       {statDisplay(value: $totalRules, label: 'Rules', color: symbolColor(type: SymbolType.SYMBOL_TYPE_RULE))}
       {statDisplay(value: $totalFunctions, label: 'Functions', color: symbolColor(type: SymbolType.SYMBOL_TYPE_FUNCTION))}
       {statDisplay(value: $totalProviders, label: 'Providers', color: symbolColor(type: SymbolType.SYMBOL_TYPE_PROVIDER))}
@@ -372,36 +375,64 @@ import {
       {statDisplay(value: $totalAspects, label: 'Aspects', color: symbolColor(type: SymbolType.SYMBOL_TYPE_ASPECT))}
       {statDisplay(value: $totalMacros, label: 'Macros', color: symbolColor(type: SymbolType.SYMBOL_TYPE_MACRO))}
     </div>
-    <div class="Box Box--condensed mt-4" style="width: 100%; max-width: 800px">
-      <div class="Box-header">
-        <div class="Box-title">
-          Recently Updated
-        </div>
-      </div>
+    <div class="mt-4 pt-4" style="width: 100%; max-width: 800px; border-top: 1px solid var(--borderColor-default, var(--color-border-default))">
+      <h3 class="f4 text-bold mb-2">Recently Updated</h3>
       {if length($recentlyUpdated) > 0}
-        {for $item in $recentlyUpdated}
-          <div class="Box-row d-flex flex-justify-between flex-items-center">
-            <div class="d-flex flex-items-center" style="min-width: 0; flex: 1">
-              <div style="width: 24px; flex-shrink: 0">
-                {if $item.isNew}
-                  <span title="New Module">{octiconStarFill16(fill: 'var(--color-success-fg)')}</span>
+        <div>
+          {for $item, $idx in $recentlyUpdated}
+            {let $commit: $item.moduleVersion.getCommit() /}
+            {let $hasUser: $commit?.getGithubUser() /}
+            <div class="TimelineItem{if $idx == 0} timeline-first{/if}{if $idx == length($recentlyUpdated) - 1} timeline-last{/if}">
+              {if $hasUser}
+                <a href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}"
+                   title="{$commit?.getGithubName() ? $commit?.getGithubName() : '@' + $commit?.getGithubUser()}"
+                   class="TimelineItem-badge timeline-avatar-badge">
+                  <img class="avatar circle" width="42" height="42"
+                       src="{githubAvatarUrl(name: $commit?.getGithubUser() ?? '')}"
+                       alt="@{$commit?.getGithubUser()}">
+                </a>
+              {else}
+                <div class="TimelineItem-badge timeline-avatar-badge">
+                  <img class="avatar circle" width="42" height="42"
+                       src="{githubAvatarUrl(name: '')}"
+                       alt="bazelbuild">
+                </div>
+              {/if}
+              <div class="TimelineItem-body">
+                <div class="d-flex flex-items-center">
+                  <div style="flex-shrink: 0">
+                    <a class="Link--primary text-bold" href="/#/modules/{$item.moduleVersion.getName()}/{$item.moduleVersion.getVersion()}">
+                      {$item.moduleVersion.getName()}
+                    </a>
+                    {sp}
+                    <span class="color-fg-muted">{$item.moduleVersion.getVersion()}</span>
+                    {if $item.isNew}
+                      {sp}
+                      <span title="New Module">{octiconStarFill16(fill: 'var(--color-success-fg)')}</span>
+                    {/if}
+                  </div>
+                  <span style="flex: 1; border-bottom: 1px dotted var(--color-border-muted); margin: 0 0.5em;"></span>
+                  <span class="color-fg-muted f6 text-right no-wrap">{$item.commitDate}</span>
+                </div>
+                {if $commit?.getPullRequest()}
+                  <div class="f6 color-fg-muted mt-1">
+                    <a class="Link--muted" href="{registryPullRequestUrl(pr: $commit?.getPullRequest() ?? '')}">
+                      #{$commit?.getPullRequest()}
+                    </a>
+                    {if $hasUser}
+                      {sp}by{sp}
+                      <a class="Link--muted text-bold" href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}">
+                        {$commit?.getGithubName() ? $commit?.getGithubName() : $commit?.getGithubUser()}
+                      </a>
+                    {/if}
+                  </div>
                 {/if}
               </div>
-              <div class="d-flex flex-column" style="min-width: 0">
-                <a class="Link--primary f5" href="/#/modules/{$item.moduleVersion.getName()}/{$item.moduleVersion.getVersion()}">
-                  <strong>{$item.moduleVersion.getName()}</strong>
-                  {sp}
-                  <span class="color-fg-muted">{$item.moduleVersion.getVersion()}</span>
-                </a>
-              </div>
             </div>
-            <div class="color-fg-muted f6 text-right" style="flex-shrink: 0; margin-left: 1rem">
-              {$item.commitDate}
-            </div>
-          </div>
-        {/for}
+          {/for}
+        </div>
       {else}
-        <div class="Box-row color-fg-muted">
+        <div class="color-fg-muted p-3">
           No recently updated modules found
         </div>
       {/if}

--- a/app/bcr/format.js
+++ b/app/bcr/format.js
@@ -17,6 +17,30 @@ function formatRelativePast(value) {
 exports.formatRelativePast = formatRelativePast;
 
 /**
+ * Format a duration as a short relative string ("2 days ago", "3 hours ago").
+ * Unlike formatRelativePast, this never includes the full date.
+ *
+ * @param {string|undefined} value The datetime string
+ * @returns {string}
+ */
+function formatRelativeShort(value) {
+	if (!value) {
+		return "";
+	}
+	const diff = Date.now() - new Date(value).getTime();
+	const seconds = Math.floor(diff / 1000);
+	const minutes = Math.floor(seconds / 60);
+	const hours = Math.floor(minutes / 60);
+	const days = Math.floor(hours / 24);
+	if (days > 0) return days === 1 ? "yesterday" : days + " days ago";
+	if (hours > 0) return hours === 1 ? "1 hour ago" : hours + " hours ago";
+	if (minutes > 0)
+		return minutes === 1 ? "1 minute ago" : minutes + " minutes ago";
+	return "just now";
+}
+exports.formatRelativeShort = formatRelativeShort;
+
+/**
  * Format date as YYYY-MM-DD
  * @param {string|number} value
  * @return {string}

--- a/app/bcr/home.js
+++ b/app/bcr/home.js
@@ -15,7 +15,8 @@ const { createMaintainersMap, createModuleMap } = goog.require(
 const { homeOverviewComponent, homeSelect } = goog.require(
 	"soy.bcrfrontend.app",
 );
-const { formatRelativePast } = goog.require("bcrfrontend.format");
+const { formatRelativePast, formatRelativeShort } =
+	goog.require("bcrfrontend.format");
 const { getApplication } = goog.require("bcrfrontend.common");
 const { Component, Route } = goog.require("stack.ui");
 
@@ -124,7 +125,7 @@ class HomeOverviewComponent extends Component {
 		const recentlyUpdated = allVersions.slice(0, 15).map((item) => {
 			return {
 				moduleVersion: item.v,
-				commitDate: formatRelativePast(item.v.getCommit().getDate()),
+				commitDate: formatRelativeShort(item.v.getCommit().getDate()),
 				isNew: item.m.getVersionsList().length === 1,
 			};
 		});

--- a/app/bcr/style.css
+++ b/app/bcr/style.css
@@ -267,3 +267,41 @@ code .line::before {
 	text-align: right;
 	color: rgba(115, 138, 148, 0.4);
 }
+
+/* ========================================
+ * Recently Updated Timeline
+ * ======================================== */
+
+.timeline-avatar-badge {
+	background-color: var(
+		--bgColor-default,
+		var(--color-canvas-default)
+	) !important;
+	border: 3px solid var(--bgColor-default, var(--color-canvas-default)) !important;
+	padding: 0;
+	overflow: hidden;
+	border-radius: 50%;
+	width: 48px !important;
+	height: 48px !important;
+	margin-left: -23px !important;
+}
+
+.timeline-avatar-badge img {
+	width: 42px;
+	height: 42px;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+.timeline-avatar-badge + .TimelineItem-body {
+	margin-top: 0;
+	align-self: center;
+}
+
+.timeline-first:before {
+	top: 50% !important;
+}
+
+.timeline-last:before {
+	bottom: 50% !important;
+}

--- a/data/generated.MODULE.bazel
+++ b/data/generated.MODULE.bazel
@@ -24,7 +24,7 @@ use_repo(
     "bzl.abseil-py---2.1.0",
     "bzl.abseil-py---2.4.0",
     "bzl.aexml---4.7.0.1",
-    "bzl.antlr4-cpp-runtime---4.12.0",
+    "bzl.antlr4-cpp-runtime---4.13.0",
     "bzl.ape---1.0.1",
     "bzl.apple_rules_lint---0.3.2",
     "bzl.apple_rules_lint---0.4.0",
@@ -48,7 +48,7 @@ use_repo(
     "bzl.apple_support---2.5.4",
     "bzl.argparse---3.2.0",
     "bzl.asc_swift---1.6.0",
-    "bzl.asio---1.28.2",
+    "bzl.asio---1.31.0",
     "bzl.asio---1.32.0",
     "bzl.aspect_bazel_lib---1.28.0",
     "bzl.aspect_bazel_lib---1.38.1",
@@ -117,7 +117,7 @@ use_repo(
     "bzl.aspect_tools_telemetry---0.3.2",
     "bzl.aspect_tools_telemetry---0.3.3",
     "bzl.assimp---5.4.3.bcr.6",
-    "bzl.assimp---6.0.2",
+    "bzl.assimp---6.0.3",
     "bzl.awk.bzl---0.2.3",
     "bzl.aws-in-a-box---0.0.69",
     "bzl.babylon---1.4.4",
@@ -149,6 +149,7 @@ use_repo(
     "bzl.bazel_features---1.43.0",
     "bzl.bazel_features---1.44.0",
     "bzl.bazel_features---1.45.0",
+    "bzl.bazel_features---1.46.0",
     "bzl.bazel_features---1.9.0",
     "bzl.bazel_features---1.9.1",
     "bzl.bazel_gomock---0.2.0",
@@ -160,6 +161,7 @@ use_repo(
     "bzl.bazel_lib---3.1.0",
     "bzl.bazel_lib---3.2.0",
     "bzl.bazel_lib---3.2.2",
+    "bzl.bazel_lib---3.3.1",
     "bzl.bazel_linux_packages---0.3.1",
     "bzl.bazel_paq---1.4.1",
     "bzl.bazel_skylib---1.0.3",
@@ -195,7 +197,6 @@ use_repo(
     "bzl.boost.algorithm---1.89.0.bcr.2",
     "bzl.boost.algorithm---1.90.0.bcr.1",
     "bzl.boost.align---1.87.0",
-    "bzl.boost.align---1.88.0.bcr.3",
     "bzl.boost.align---1.89.0.bcr.2",
     "bzl.boost.align---1.90.0.bcr.1",
     "bzl.boost.any---1.89.0.bcr.2",
@@ -204,8 +205,10 @@ use_repo(
     "bzl.boost.array---1.89.0.bcr.2",
     "bzl.boost.array---1.90.0.bcr.1",
     "bzl.boost.asio---1.87.0.bcr.1",
+    "bzl.boost.asio---1.88.0.bcr.3",
     "bzl.boost.asio---1.89.0.bcr.2",
     "bzl.boost.asio---1.90.0.bcr.1",
+    "bzl.boost.assert---1.83.0.bcr.4",
     "bzl.boost.assert---1.87.0",
     "bzl.boost.assert---1.89.0.bcr.2",
     "bzl.boost.assert---1.90.0.bcr.1",
@@ -238,6 +241,7 @@ use_repo(
     "bzl.boost.concept_check---1.89.0.bcr.2",
     "bzl.boost.concept_check---1.90.0.bcr.1",
     "bzl.boost.config---1.87.0",
+    "bzl.boost.config---1.88.0.bcr.3",
     "bzl.boost.config---1.89.0.bcr.2",
     "bzl.boost.config---1.90.0.bcr.1",
     "bzl.boost.container---1.83.0.bcr.4",
@@ -247,14 +251,12 @@ use_repo(
     "bzl.boost.container_hash---1.88.0.bcr.3",
     "bzl.boost.container_hash---1.89.0.bcr.2",
     "bzl.boost.container_hash---1.90.0.bcr.1",
-    "bzl.boost.context---1.88.0.bcr.3",
     "bzl.boost.context---1.89.0.bcr.2",
     "bzl.boost.context---1.90.0.bcr.1",
-    "bzl.boost.conversion---1.83.0.bcr.4",
     "bzl.boost.conversion---1.87.0",
+    "bzl.boost.conversion---1.88.0.bcr.3",
     "bzl.boost.conversion---1.89.0.bcr.2",
     "bzl.boost.conversion---1.90.0.bcr.1",
-    "bzl.boost.core---1.83.0.bcr.4",
     "bzl.boost.core---1.87.0",
     "bzl.boost.core---1.89.0.bcr.2",
     "bzl.boost.core---1.90.0.bcr.1",
@@ -266,13 +268,13 @@ use_repo(
     "bzl.boost.crc---1.89.0.bcr.2",
     "bzl.boost.crc---1.90.0.bcr.1",
     "bzl.boost.date_time---1.87.0",
-    "bzl.boost.date_time---1.88.0.bcr.3",
     "bzl.boost.date_time---1.89.0.bcr.2",
     "bzl.boost.date_time---1.90.0.bcr.1",
     "bzl.boost.describe---1.87.0",
     "bzl.boost.describe---1.89.0.bcr.2",
     "bzl.boost.describe---1.90.0.bcr.1",
     "bzl.boost.detail---1.87.0",
+    "bzl.boost.detail---1.88.0.bcr.3",
     "bzl.boost.detail---1.89.0.bcr.2",
     "bzl.boost.detail---1.90.0.bcr.1",
     "bzl.boost.dll---1.89.0.bcr.2",
@@ -281,6 +283,7 @@ use_repo(
     "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
     "bzl.boost.endian---1.87.0",
+    "bzl.boost.endian---1.88.0.bcr.3",
     "bzl.boost.endian---1.89.0.bcr.2",
     "bzl.boost.endian---1.90.0.bcr.1",
     "bzl.boost.exception---1.87.0",
@@ -292,6 +295,7 @@ use_repo(
     "bzl.boost.foreach---1.90.0.bcr.1",
     "bzl.boost.format---1.89.0.bcr.2",
     "bzl.boost.format---1.90.0.bcr.1",
+    "bzl.boost.function---1.83.0.bcr.4",
     "bzl.boost.function---1.87.0",
     "bzl.boost.function---1.89.0.bcr.2",
     "bzl.boost.function---1.90.0.bcr.1",
@@ -299,10 +303,10 @@ use_repo(
     "bzl.boost.function_types---1.89.0.bcr.2",
     "bzl.boost.function_types---1.90.0.bcr.1",
     "bzl.boost.functional---1.87.0",
-    "bzl.boost.functional---1.88.0.bcr.3",
     "bzl.boost.functional---1.89.0.bcr.2",
     "bzl.boost.functional---1.90.0.bcr.1",
     "bzl.boost.fusion---1.87.0",
+    "bzl.boost.fusion---1.88.0.bcr.3",
     "bzl.boost.fusion---1.89.0.bcr.2",
     "bzl.boost.fusion---1.90.0.bcr.1",
     "bzl.boost.geometry---1.89.0.bcr.2",
@@ -319,20 +323,17 @@ use_repo(
     "bzl.boost.icl---1.89.0.bcr.2",
     "bzl.boost.icl---1.90.0.bcr.1",
     "bzl.boost.integer---1.87.0",
-    "bzl.boost.integer---1.88.0.bcr.3",
     "bzl.boost.integer---1.89.0.bcr.2",
     "bzl.boost.integer---1.90.0.bcr.1",
     "bzl.boost.interprocess---1.89.0.bcr.2",
     "bzl.boost.interprocess---1.90.0.bcr.1",
     "bzl.boost.intrusive---1.87.0",
-    "bzl.boost.intrusive---1.88.0.bcr.3",
     "bzl.boost.intrusive---1.89.0.bcr.2",
     "bzl.boost.intrusive---1.90.0.bcr.1",
     "bzl.boost.io---1.89.0.bcr.2",
     "bzl.boost.io---1.90.0.bcr.1",
-    "bzl.boost.iostreams---1.90.0.bcr.2",
+    "bzl.boost.iostreams---1.88.0.bcr.4",
     "bzl.boost.iterator---1.87.0",
-    "bzl.boost.iterator---1.88.0.bcr.3",
     "bzl.boost.iterator---1.89.0.bcr.2",
     "bzl.boost.iterator---1.90.0.bcr.1",
     "bzl.boost.json---1.89.0.bcr.2",
@@ -343,7 +344,6 @@ use_repo(
     "bzl.boost.lambda2---1.90.0.bcr.1",
     "bzl.boost.leaf---1.89.0.bcr.2",
     "bzl.boost.leaf---1.90.0.bcr.1",
-    "bzl.boost.lexical_cast---1.83.0.bcr.4",
     "bzl.boost.lexical_cast---1.87.0",
     "bzl.boost.lexical_cast---1.89.0.bcr.2",
     "bzl.boost.lexical_cast---1.90.0.bcr.1",
@@ -357,7 +357,7 @@ use_repo(
     "bzl.boost.math---1.87.0",
     "bzl.boost.math---1.89.0.bcr.2",
     "bzl.boost.math---1.90.0.bcr.1",
-    "bzl.boost.move---1.88.0.bcr.1",
+    "bzl.boost.move---1.83.0.bcr.4",
     "bzl.boost.move---1.89.0.bcr.2",
     "bzl.boost.move---1.90.0.bcr.1",
     "bzl.boost.mp11---1.87.0",
@@ -390,7 +390,6 @@ use_repo(
     "bzl.boost.pfr---1.89.0.bcr.2",
     "bzl.boost.pfr---1.90.0.bcr.1",
     "bzl.boost.phoenix---1.87.0",
-    "bzl.boost.phoenix---1.88.0.bcr.3",
     "bzl.boost.phoenix---1.89.0.bcr.2",
     "bzl.boost.phoenix---1.90.0.bcr.1",
     "bzl.boost.polygon---1.89.0.bcr.2",
@@ -403,7 +402,6 @@ use_repo(
     "bzl.boost.predef---1.89.0.bcr.2",
     "bzl.boost.predef---1.90.0.bcr.1",
     "bzl.boost.preprocessor---1.87.0",
-    "bzl.boost.preprocessor---1.90.0",
     "bzl.boost.preprocessor---1.90.0.bcr.1",
     "bzl.boost.process---1.89.0.bcr.2",
     "bzl.boost.process---1.90.0.bcr.1",
@@ -426,13 +424,13 @@ use_repo(
     "bzl.boost.random---1.89.0.bcr.2",
     "bzl.boost.random---1.90.0.bcr.1",
     "bzl.boost.range---1.87.0",
-    "bzl.boost.range---1.88.0.bcr.3",
     "bzl.boost.range---1.89.0.bcr.2",
     "bzl.boost.range---1.90.0.bcr.1",
+    "bzl.boost.ratio---1.83.0.bcr.4",
     "bzl.boost.ratio---1.87.0",
-    "bzl.boost.ratio---1.88.0.bcr.3",
     "bzl.boost.ratio---1.89.0.bcr.2",
     "bzl.boost.ratio---1.90.0.bcr.1",
+    "bzl.boost.rational---1.83.0.bcr.4",
     "bzl.boost.rational---1.87.0",
     "bzl.boost.rational---1.89.0.bcr.2",
     "bzl.boost.rational---1.90.0.bcr.1",
@@ -443,33 +441,32 @@ use_repo(
     "bzl.boost.scope---1.90.0.bcr.1",
     "bzl.boost.scope_exit---1.89.0.bcr.2",
     "bzl.boost.scope_exit---1.90.0.bcr.1",
-    "bzl.boost.serialization---1.83.0.bcr.4",
     "bzl.boost.serialization---1.89.0.bcr.2",
     "bzl.boost.serialization---1.90.0.bcr.1",
     "bzl.boost.signals2---1.89.0.bcr.2",
     "bzl.boost.signals2---1.90.0.bcr.1",
-    "bzl.boost.smart_ptr---1.83.0.bcr.4",
     "bzl.boost.smart_ptr---1.87.0",
     "bzl.boost.smart_ptr---1.89.0.bcr.2",
     "bzl.boost.smart_ptr---1.90.0.bcr.1",
     "bzl.boost.sort---1.89.0.bcr.2",
     "bzl.boost.sort---1.90.0.bcr.1",
-    "bzl.boost.spirit---1.89.0.bcr.3",
+    "bzl.boost.spirit---1.88.0.bcr.3",
     "bzl.boost.spirit---1.90.0.bcr.1",
     "bzl.boost.stacktrace---1.89.0.bcr.2",
     "bzl.boost.stacktrace---1.90.0.bcr.1",
+    "bzl.boost.static_assert---1.83.0.bcr.4",
     "bzl.boost.static_assert---1.87.0",
     "bzl.boost.static_assert---1.89.0.bcr.2",
     "bzl.boost.static_assert---1.90.0.bcr.1",
     "bzl.boost.static_string---1.89.0.bcr.2",
     "bzl.boost.static_string---1.90.0.bcr.1",
+    "bzl.boost.system---1.83.0.bcr.4",
     "bzl.boost.system---1.87.0",
-    "bzl.boost.system---1.88.0.bcr.3",
     "bzl.boost.system---1.89.0.bcr.2",
     "bzl.boost.system---1.90.0.bcr.1",
     "bzl.boost.test---1.89.0.bcr.2",
     "bzl.boost.test---1.90.0.bcr.1",
-    "bzl.boost.thread---1.87.0.bcr.1",
+    "bzl.boost.thread---1.88.0.bcr.3",
     "bzl.boost.thread---1.89.0.bcr.2",
     "bzl.boost.thread---1.90.0.bcr.1",
     "bzl.boost.throw_exception---1.87.0",
@@ -477,8 +474,8 @@ use_repo(
     "bzl.boost.throw_exception---1.90.0.bcr.1",
     "bzl.boost.timer---1.89.0.bcr.2",
     "bzl.boost.timer---1.90.0.bcr.1",
+    "bzl.boost.tokenizer---1.83.0.bcr.4",
     "bzl.boost.tokenizer---1.87.0",
-    "bzl.boost.tokenizer---1.88.0.bcr.3",
     "bzl.boost.tokenizer---1.89.0.bcr.2",
     "bzl.boost.tokenizer---1.90.0.bcr.1",
     "bzl.boost.tti---1.89.0.bcr.2",
@@ -487,14 +484,15 @@ use_repo(
     "bzl.boost.tuple---1.88.0.bcr.3",
     "bzl.boost.tuple---1.89.0.bcr.2",
     "bzl.boost.tuple---1.90.0.bcr.1",
+    "bzl.boost.type_index---1.83.0.bcr.4",
     "bzl.boost.type_index---1.87.0",
     "bzl.boost.type_index---1.89.0.bcr.2",
     "bzl.boost.type_index---1.90.0.bcr.1",
-    "bzl.boost.type_traits---1.83.0.bcr.4",
     "bzl.boost.type_traits---1.87.0",
     "bzl.boost.type_traits---1.89.0.bcr.2",
     "bzl.boost.type_traits---1.90.0.bcr.1",
     "bzl.boost.typeof---1.87.0",
+    "bzl.boost.typeof---1.88.0.bcr.3",
     "bzl.boost.typeof---1.89.0.bcr.2",
     "bzl.boost.typeof---1.90.0.bcr.1",
     "bzl.boost.units---1.89.0.bcr.2",
@@ -504,7 +502,6 @@ use_repo(
     "bzl.boost.unordered---1.90.0.bcr.1",
     "bzl.boost.url---1.89.0.bcr.2",
     "bzl.boost.url---1.90.0.bcr.1",
-    "bzl.boost.utility---1.83.0.bcr.4",
     "bzl.boost.utility---1.87.0",
     "bzl.boost.utility---1.89.0.bcr.2",
     "bzl.boost.utility---1.90.0.bcr.1",
@@ -524,7 +521,7 @@ use_repo(
     "bzl.boost.winapi---1.90.0.bcr.1",
     "bzl.boost.xpressive---1.89.0.bcr.2",
     "bzl.boost.xpressive---1.90.0.bcr.1",
-    "bzl.boost---1.83.0.bcr.4",
+    "bzl.boost---1.89.0.bcr.4",
     "bzl.boost---1.90.0.bcr.1",
     "bzl.boringssl---0.0.0-20211025-d4f1ab9",
     "bzl.boringssl---0.0.0-20230215-5c22014",
@@ -556,13 +553,14 @@ use_repo(
     "bzl.buildifier_prebuilt---8.5.1.2",
     "bzl.buildozer---8.5.1",
     "bzl.bullet---3.26.0-rc0.bcr.2",
-    "bzl.bzip2---1.0.8.bcr.1",
+    "bzl.bzip2---1.0.8.bcr.4",
     "bzl.bzlparty_rules_quickjs---0.1.0",
     "bzl.bzlparty_tools---0.4.0",
     "bzl.bzlws---0.2.0",
     "bzl.c-ares---1.15.0",
     "bzl.c-ares---1.16.1",
     "bzl.c-ares---1.19.1.bcr.1",
+    "bzl.c-ares---1.34.6",
     "bzl.c-blosc2---2.22.0",
     "bzl.c4core---0.2.6",
     "bzl.capnp-cpp---1.1.0",
@@ -616,7 +614,7 @@ use_repo(
     "bzl.cucumber-cpp---0.8.0.bcr.1",
     "bzl.cuda_toolchain_types---0.0.1",
     "bzl.cuda_toolkit---0.0.2",
-    "bzl.curl---8.4.0.bcr.1",
+    "bzl.curl---8.12.0.bcr.1",
     "bzl.curl---8.7.1",
     "bzl.cxx.rs---1.0.194",
     "bzl.cxxopts---3.3.1",
@@ -635,14 +633,14 @@ use_repo(
     "bzl.download_utils---1.0.1",
     "bzl.effcee---0.0.0-20250222",
     "bzl.egl-registry---0.0.0-20250527",
-    "bzl.eigen---3.4.0.bcr.2",
     "bzl.eigen---3.4.0.bcr.3",
     "bzl.eigen---3.4.1.bcr.1",
+    "bzl.eigen---4.0.0-20241125.bcr.3",
     "bzl.elemental2---1.3.2",
     "bzl.emboss---2026.0212.185041",
     "bzl.emsdk---4.0.13",
     "bzl.emsdk---5.0.5",
-    "bzl.engflowapis---2024.11.13-06.15.38",
+    "bzl.engflowapis---2024.11.04-11.10.20",
     "bzl.engflowapis-java---2025.07.24-06.20.24",
     "bzl.envoy_api---0.0.0-20241214-918efc9",
     "bzl.envoy_api---0.0.0-20250128-4de3c74",
@@ -663,20 +661,21 @@ use_repo(
     "bzl.flex---2.6.4.bcr.5",
     "bzl.flip---1.6",
     "bzl.fmt---10.1.1",
-    "bzl.fmt---11.0.2.bcr.1",
     "bzl.fmt---11.1.3",
+    "bzl.fmt---11.1.4",
     "bzl.fmt---12.1.0",
     "bzl.fmt---8.1.1",
     "bzl.folly---2025.01.13.00.bcr.6",
     "bzl.fp16---0.0.0-20210320-0a92994",
     "bzl.freeimage---3.19.10.bcr.5",
-    "bzl.freetype---2.14.1",
+    "bzl.freetype---2.9",
     "bzl.fremtind_rules_vitest---0.2.1",
     "bzl.fshlib---0.2.0",
     "bzl.ftxui---6.1.9",
     "bzl.fuzztest---20260219.0",
     "bzl.fxdiv---0.0.0-20201209-63058ef",
     "bzl.gawk---5.3.2.bcr.1",
+    "bzl.gawk---5.3.2.bcr.4",
     "bzl.gazelle---0.29.0",
     "bzl.gazelle---0.30.0",
     "bzl.gazelle---0.33.0",
@@ -696,10 +695,13 @@ use_repo(
     "bzl.gazelle---0.47.0",
     "bzl.gazelle---0.50.0",
     "bzl.gazelle_cc---0.5.0",
+    "bzl.gazelle_py---0.5.0",
+    "bzl.gazelle_ts---0.4.0",
     "bzl.gcc_toolchain---0.9.0",
     "bzl.generate_export_header---0.1.0",
     "bzl.gflags---2.2.2.bcr.1",
     "bzl.glib---2.82.2.bcr.8",
+    "bzl.glog---0.5.0",
     "bzl.glog---0.6.0",
     "bzl.glog---0.7.0",
     "bzl.glog---0.7.1.bcr.1",
@@ -718,6 +720,7 @@ use_repo(
     "bzl.googleapis---0.0.0-20240326-1c8d509c5",
     "bzl.googleapis---0.0.0-20240819-fe8ba054a",
     "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
+    "bzl.googleapis---0.0.0-20250604-de157ca3",
     "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
     "bzl.googleapis---0.0.0-20251003-2193a2bf",
     "bzl.googleapis---0.0.0-20260130-c0fcb356",
@@ -743,6 +746,7 @@ use_repo(
     "bzl.grpc---1.73.1",
     "bzl.grpc---1.74.1",
     "bzl.grpc---1.76.0.bcr.1",
+    "bzl.grpc---1.78.0",
     "bzl.grpc---1.80.0",
     "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
     "bzl.grpc-java---1.62.2",
@@ -755,11 +759,11 @@ use_repo(
     "bzl.grpc_ecosystem_grpc_gateway---2.26.3",
     "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
     "bzl.grpc_kotlin---1.5.0",
-    "bzl.gutil---20250409.0",
+    "bzl.gutil---20260226.0",
     "bzl.gutil---20260309.0.bcr.1",
     "bzl.gz-common---7.0.0",
     "bzl.gz-common---7.1.0",
-    "bzl.gz-common---7.1.1",
+    "bzl.gz-common---7.2.0-pre1",
     "bzl.gz-fuel-tools---11.0.0",
     "bzl.gz-math---9.0.0",
     "bzl.gz-math---9.1.0",
@@ -825,7 +829,6 @@ use_repo(
     "bzl.libdwarf---2.2.0",
     "bzl.libevent---2.1.12-stable.bcr.0",
     "bzl.libpfm---4.11.0",
-    "bzl.libpfm---4.11.0.bcr.2",
     "bzl.libpng---1.6.41",
     "bzl.libprotobuf-mutator---1.3",
     "bzl.librdkafka---2.3.0.bcr.1",
@@ -836,14 +839,14 @@ use_repo(
     "bzl.liburing---2.5",
     "bzl.libuuid---2.39.3.bcr.1",
     "bzl.libwebp---1.5.0",
-    "bzl.libx11---1.8.12.bcr.5",
+    "bzl.libx11---1.8.12",
     "bzl.libxau---1.0.12.bcr.2",
     "bzl.libxcb---1.17.0.bcr.2",
     "bzl.libxtrans---1.5.2.bcr.2",
     "bzl.libyaml---0.2.5",
     "bzl.libzip---1.10.1.bcr.1",
     "bzl.libzmq---4.3.5.bcr.4",
-    "bzl.lit2md---0.2.3",
+    "bzl.lit2md---1.0.1",
     "bzl.llvm-project---17.0.3.bcr.4",
     "bzl.lz4---1.10.0.bcr.1",
     "bzl.lz4---1.9.4.bcr.2",
@@ -866,12 +869,12 @@ use_repo(
     "bzl.nasm---2.14.02.bcr.2",
     "bzl.ncurses---6.4.20221231.bcr.9",
     "bzl.ng-log---0.8.0-rc1",
-    "bzl.nlohmann_json---3.11.2",
     "bzl.nlohmann_json---3.11.3.bcr.1",
     "bzl.nlohmann_json---3.12.0.bcr.1",
     "bzl.nlohmann_json---3.6.1",
     "bzl.nogo_analyzer_bzlmod---0.1.0",
     "bzl.nsync---1.29.2",
+    "bzl.octomap---1.10.0",
     "bzl.octomap---1.9.7.bcr.1",
     "bzl.ode---0.16.6.bcr.1",
     "bzl.ofiuco---0.3.7",
@@ -907,7 +910,7 @@ use_repo(
     "bzl.opentelemetry-proto---1.8.0",
     "bzl.opentracing-cpp---1.6.0",
     "bzl.or-tools---9.15",
-    "bzl.osqp---0.6.3.bcr.3",
+    "bzl.osqp---1.0.0.bcr.2",
     "bzl.osqp-eigen---0.10.3",
     "bzl.p4_constraints---20260311.0",
     "bzl.p4c---1.2.5.11.bcr.1",
@@ -941,7 +944,6 @@ use_repo(
     "bzl.prometheus-cpp---1.3.0.bcr.2",
     "bzl.proto-converter---0.0.0-20230607-d77ff30",
     "bzl.protobuf---24.4",
-    "bzl.protobuf---26.0.bcr.2",
     "bzl.protobuf---27.2",
     "bzl.protobuf---27.5",
     "bzl.protobuf---3.19.0",
@@ -954,6 +956,7 @@ use_repo(
     "bzl.protobuf---32.0",
     "bzl.protobuf---32.1",
     "bzl.protobuf---33.0",
+    "bzl.protobuf---33.0-rc1",
     "bzl.protobuf---33.1",
     "bzl.protobuf---33.2",
     "bzl.protobuf---33.4",
@@ -983,7 +986,7 @@ use_repo(
     "bzl.pybind11_bazel---3.0.1",
     "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
-    "bzl.qdldl---0.1.8.bcr.1",
+    "bzl.qdldl---0.1.7.bcr.1",
     "bzl.quill---11.1.0",
     "bzl.range-v3---0.12.0",
     "bzl.rapidjson---1.1.0",
@@ -992,7 +995,7 @@ use_repo(
     "bzl.re.bzl---0.2.0",
     "bzl.re2---2021-09-01",
     "bzl.re2---2023-09-01",
-    "bzl.re2---2024-02-01",
+    "bzl.re2---2024-04-01",
     "bzl.re2---2024-07-02.bcr.1",
     "bzl.re2---2025-08-12.bcr.1",
     "bzl.re2---2025-11-05.bcr.1",
@@ -1012,7 +1015,7 @@ use_repo(
     "bzl.rules_android---0.7.2",
     "bzl.rules_android_ndk---0.1.5",
     "bzl.rules_angular---0.1.0",
-    "bzl.rules_apko---1.5.44",
+    "bzl.rules_apko---1.5.45",
     "bzl.rules_appimage---1.20.0",
     "bzl.rules_apple---3.13.0",
     "bzl.rules_apple---3.16.0",
@@ -1137,9 +1140,9 @@ use_repo(
     "bzl.rules_haskell---1.0",
     "bzl.rules_helm---0.24.0",
     "bzl.rules_img---0.3.3",
-    "bzl.rules_img---0.3.8",
-    "bzl.rules_img_pull_tool---0.3.8",
-    "bzl.rules_img_tool---0.3.8",
+    "bzl.rules_img---0.3.9",
+    "bzl.rules_img_pull_tool---0.3.9",
+    "bzl.rules_img_tool---0.3.9",
     "bzl.rules_ios---5.0.0",
     "bzl.rules_ios---6.0.1",
     "bzl.rules_ispc---0.0.6",
@@ -1287,19 +1290,22 @@ use_repo(
     "bzl.rules_pycross---0.8.1",
     "bzl.rules_pydeps---0.5.0",
     "bzl.rules_python---0.10.2",
-    "bzl.rules_python---0.22.1",
+    "bzl.rules_python---0.17.3",
     "bzl.rules_python---0.4.0",
     "bzl.rules_python---1.7.0",
-    "bzl.rules_python_gazelle_plugin---0.31.0",
+    "bzl.rules_python_gazelle_plugin---1.4.0",
+    "bzl.rules_qemu---0.1.0",
     "bzl.rules_qt---0.0.6",
     "bzl.rules_req_compile---1.1.0",
     "bzl.rules_robolectric---4.14.1.2",
     "bzl.rules_robolectric---4.16.1",
-    "bzl.rules_rs---0.0.64",
+    "bzl.rules_rs---0.0.61",
+    "bzl.rules_rs---0.0.68",
     "bzl.rules_ruby---0.19.0",
     "bzl.rules_ruby---0.25.0",
+    "bzl.rules_runfiles_group---0.0.1-rc.2",
     "bzl.rules_rust---0.45.1",
-    "bzl.rules_rust---0.49.3",
+    "bzl.rules_rust---0.50.1",
     "bzl.rules_rust---0.51.0",
     "bzl.rules_rust_mutants---0.69.1",
     "bzl.rules_rust_mutation---0.69.0",
@@ -1310,9 +1316,9 @@ use_repo(
     "bzl.rules_s5---0.0.13",
     "bzl.rules_scala---7.0.0",
     "bzl.rules_scala---7.1.3",
-    "bzl.rules_scala---7.1.4",
     "bzl.rules_scala---7.1.5",
     "bzl.rules_scala---7.2.2",
+    "bzl.rules_scala---7.2.3",
     "bzl.rules_scala---7.2.4",
     "bzl.rules_scala_native---0.1.0",
     "bzl.rules_sh---0.4.0",
@@ -1377,7 +1383,7 @@ use_repo(
     "bzl.rules_webtesting---0.4.1",
     "bzl.rules_xcodeproj---4.0.1",
     "bzl.rules_ytt---0.4.0",
-    "bzl.rules_zig---0.13.0",
+    "bzl.rules_zig---0.14.0",
     "bzl.ruy---0.0.0-20200416-9f53ba4",
     "bzl.ryandraves_nlb---0.1.0",
     "bzl.s2geometry---0.14.0",
@@ -1389,10 +1395,9 @@ use_repo(
     "bzl.simplehttp---0.2.0",
     "bzl.skcms---20250916.0.bcr.1",
     "bzl.skywalking-data-collect-protocol---10.3.0",
-    "bzl.snappy---1.1.8",
     "bzl.snappy---1.2.0",
     "bzl.snappy---1.2.2.bcr.3",
-    "bzl.soplex---7.1.3",
+    "bzl.soplex---7.1.2.bcr.1",
     "bzl.sourcekit_bazel_bsp---0.8.3",
     "bzl.sourcekitten---0.37.2",
     "bzl.sourcekitten---0.37.3",
@@ -1404,8 +1409,8 @@ use_repo(
     "bzl.sphinxdocs---2.0.0",
     "bzl.spirv_headers---1.4.341.0",
     "bzl.sqids_bazel---0.1.0",
-    "bzl.sqlite3---3.50.1",
     "bzl.sqlite3---3.50.3",
+    "bzl.sqlite3---3.51.0",
     "bzl.squashfs-tools---4.7.4",
     "bzl.stardoc---0.5.0",
     "bzl.stardoc---0.5.1",
@@ -1419,8 +1424,8 @@ use_repo(
     "bzl.stardoc---0.8.0",
     "bzl.stardoc---0.8.1",
     "bzl.subspace---2.5.0",
+    "bzl.supply-chain-go---0.0.10",
     "bzl.supply-chain-go---0.0.6",
-    "bzl.supply-chain-go---0.0.7",
     "bzl.supply_chain_tools---0.0.1",
     "bzl.swift-filename-matcher---2.0.1",
     "bzl.swift-index-store---1.10.0",
@@ -1430,12 +1435,11 @@ use_repo(
     "bzl.swift-system---1.6.4.bcr.1",
     "bzl.swift-tomldecoder---0.4.4",
     "bzl.swift_argument_parser---1.3.1.2",
-    "bzl.swift_argument_parser---1.6.2",
     "bzl.swift_argument_parser---1.7.0",
     "bzl.swift_bep_parser---0.0.6",
     "bzl.swift_gazelle_plugin---0.2.2",
     "bzl.swiftlint---0.63.2",
-    "bzl.swig---4.1.0",
+    "bzl.swig---4.3.0.bcr.2",
     "bzl.swxmlhash---7.0.2.2",
     "bzl.systemc---3.0.2.bcr.1",
     "bzl.tar.bzl---0.10.1",
@@ -1460,9 +1464,10 @@ use_repo(
     "bzl.toml.bzl---0.3.0",
     "bzl.toolchain_utils---1.0.2",
     "bzl.toolchains_arm_gnu---1.1.0",
+    "bzl.toolchains_avr---0.1.2",
     "bzl.toolchains_buildbuddy---0.0.4",
     "bzl.toolchains_llvm---1.7.0",
-    "bzl.toolchains_llvm_bootstrapped---0.5.6",
+    "bzl.toolchains_llvm_bootstrapped---0.5.3",
     "bzl.toolchains_musl---0.1.27",
     "bzl.toolchains_protoc---0.2.1",
     "bzl.toolchains_protoc---0.3.1",
@@ -1473,14 +1478,15 @@ use_repo(
     "bzl.tree-sitter-bazel---0.24.4",
     "bzl.tree-sitter-bazel---0.26.5",
     "bzl.tree-sitter-c-bazel---0.23.4",
+    "bzl.trlc---2.0.4",
     "bzl.tweag-credential-helper---0.0.9",
     "bzl.ultrajson---5.10.0",
     "bzl.upb---0.0.0-20220923-a547704",
     "bzl.upb---0.0.0-20230516-61a97ef",
     "bzl.upb---0.0.0-20230907-e7430e6",
     "bzl.verible---0.0.3933",
+    "bzl.verilator---5.034.bcr.2",
     "bzl.verilator---5.036.bcr.3",
-    "bzl.verilator---5.046.bcr.3",
     "bzl.version_utils---0.1.0",
     "bzl.vhdl_ls_gen---0.3.0",
     "bzl.wangle---2025.02.10.00.bcr.2",
@@ -1511,9 +1517,9 @@ use_repo(
     "bzl.zipkin-api---1.0.0.bcr.1",
     "bzl.zlib---1.2.11",
     "bzl.zlib---1.2.12",
+    "bzl.zlib---1.3",
     "bzl.zlib---1.3.1.bcr.8",
     "bzl.zlib-ng---2.0.7",
-    "bzl.zstd---1.5.5.bcr.2",
     "bzl.zstd---1.5.6",
     "bzl.zstd---1.5.7.bcr.1",
     "bzl.zstd-jni---1.5.6-9",
@@ -1960,6 +1966,12 @@ http_archive(
 )
 
 http_archive(
+    name = "github.com_bazel-contrib_bazel-lib_releases_download_v3.3.1_bazel-lib-v3.3.1.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.docs.tar.gz",
+)
+
+http_archive(
     name = "github.com_bazel-contrib_bazel_features_releases_download_v1.41.0_bazel_features-v1.41.0.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.41.0/bazel_features-v1.41.0.docs.tar.gz",
@@ -1993,6 +2005,12 @@ http_archive(
     name = "github.com_bazel-contrib_bazel_features_releases_download_v1.45.0_bazel_features-v1.45.0.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.45.0/bazel_features-v1.45.0.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_bazel-contrib_bazel_features_releases_download_v1.46.0_bazel_features-v1.46.0.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.docs.tar.gz",
 )
 
 http_archive(
@@ -2275,6 +2293,12 @@ http_archive(
     name = "github.com_bazel-contrib_rules_img_releases_download_v0.3.8_rules_img-v0.3.8.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/bazel-contrib/rules_img/releases/download/v0.3.8/rules_img-v0.3.8.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_bazel-contrib_rules_img_releases_download_v0.3.9_rules_img-v0.3.9.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/bazel-contrib/rules_img/releases/download/v0.3.9/rules_img-v0.3.9.docs.tar.gz",
 )
 
 http_archive(
@@ -2878,6 +2902,30 @@ http_archive(
 )
 
 http_archive(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.65_rules_rs-v0.0.65.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.65/rules_rs-v0.0.65.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.66_rules_rs-v0.0.66.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.66/rules_rs-v0.0.66.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.68_rules_rs-v0.0.68.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_hermeticbuild_rules_runfiles_group_releases_download_v0.0.1-rc.2_rules_runfiles_group-v0.0.1-rc.2.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.2/rules_runfiles_group-v0.0.1-rc.2.docs.tar.gz",
+)
+
+http_archive(
     name = "github.com_hermeticbuild_sha256.star_releases_download_v0.0.1_sha256.bzl-v0.0.1.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.docs.tar.gz",
@@ -3046,31 +3094,13 @@ http_archive(
 )
 
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.0",
+    name = "bzl.abseil-cpp---20250127.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.0",
+    strip_prefix = "abseil-cpp-20250127.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250127.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250127.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20260107.0",
@@ -3082,13 +3112,13 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250512.1",
+    name = "bzl.abseil-cpp---20211102.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250512.1",
+    strip_prefix = "abseil-cpp-20211102.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20210324.2",
@@ -3100,40 +3130,22 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.1",
+    name = "bzl.abseil-cpp---20240116.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.1",
+    strip_prefix = "abseil-cpp-20240116.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    name = "bzl.abseil-cpp---20250814.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240722.0",
+    strip_prefix = "abseil-cpp-20250814.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20260107.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20260107.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250512.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250512.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.0/abseil-cpp-20250512.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250814.1",
@@ -3154,31 +3166,13 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.0",
+    name = "bzl.abseil-cpp---20230802.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.0",
+    strip_prefix = "abseil-cpp-20230802.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.2",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20211102.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20211102.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20230802.0.bcr.1",
@@ -3190,6 +3184,33 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240722.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250127.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250127.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.2",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.abseil-cpp---20230125.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3199,13 +3220,40 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250127.1",
+    name = "bzl.abseil-cpp---20260107.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250127.1",
+    strip_prefix = "abseil-cpp-20260107.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250512.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250512.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250512.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250512.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.0/abseil-cpp-20250512.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-py---2.1.0",
@@ -3235,13 +3283,13 @@ starlark_repository.archive(
     urls = ["https://github.com/tadija/AEXML/archive/refs/tags/4.7.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.antlr4-cpp-runtime---4.12.0",
+    name = "bzl.antlr4-cpp-runtime---4.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "antlr4-4.12.0/runtime/Cpp",
+    strip_prefix = "antlr4-4.13.0/runtime/Cpp",
     type = "tar.gz",
-    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.12.0.tar.gz"],
+    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ape---1.0.1",
@@ -3253,15 +3301,6 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_rules_lint---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "apple_rules_lint-0.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.apple_rules_lint---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3271,36 +3310,45 @@ starlark_repository.archive(
     urls = ["https://github.com/apple/apple_rules_lint/releases/download/0.4.0/apple_rules_lint-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.16.0",
+    name = "bzl.apple_rules_lint---0.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "apple_rules_lint-0.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
+    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.8.1",
+    name = "bzl.apple_support---1.17.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---2.1.0",
+    name = "bzl.apple_support---1.21.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.24.5",
+    name = "bzl.apple_support---1.23.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.0/apple_support.1.23.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---2.4.0",
@@ -3311,12 +3359,44 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.4.0/apple_support.2.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.24.2",
+    name = "bzl.apple_support---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.23.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---1.13.0",
@@ -3327,12 +3407,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---2.3.0",
+    name = "bzl.apple_support---1.24.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---2.2.0",
@@ -3341,6 +3421,22 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.22.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---1.15.1",
@@ -3359,60 +3455,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.24.1",
+    name = "bzl.apple_support---1.24.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.22.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.23.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.23.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.0/apple_support.1.23.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.21.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.17.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.argparse---3.2.0",
@@ -3442,13 +3490,94 @@ starlark_repository.archive(
     urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-32-0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.asio---1.28.2",
+    name = "bzl.asio---1.31.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "asio-asio-1-28-2/asio/include",
-    type = "zip",
-    urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-2.zip"],
+    strip_prefix = "asio-asio-1-31-0",
+    type = "tar.gz",
+    urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-31-0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.13.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.8.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.7",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.38.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.38.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---1.42.3",
@@ -3460,13 +3589,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.7",
+    name = "bzl.aspect_bazel_lib---2.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.7",
+    strip_prefix = "bazel-lib-2.6.1",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.9.3",
@@ -3487,49 +3625,31 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.2",
+    name = "bzl.aspect_bazel_lib---2.9.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.2",
+    strip_prefix = "bazel-lib-2.9.4",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.8.1",
+    name = "bzl.aspect_bazel_lib---2.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.8.1",
+    strip_prefix = "bazel-lib-2.11.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.38.1",
+    name = "bzl.aspect_bazel_lib---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.38.1",
+    strip_prefix = "bazel-lib-2.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.16.0",
@@ -3548,78 +3668,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.14.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.11.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.11.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.9.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.9.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.13.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_gazelle_prebuilt---0.0.8",
@@ -3649,15 +3697,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_cypress/releases/download/v0.7.2/rules_cypress-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_esbuild---0.21.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_esbuild-0.21.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_esbuild---0.25.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3665,6 +3704,15 @@ starlark_repository.archive(
     strip_prefix = "rules_esbuild-0.25.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.25.1/rules_esbuild-v0.25.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_esbuild---0.21.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_esbuild-0.21.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_jasmine---2.0.4",
@@ -3712,6 +3760,24 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.3.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.3.5",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---3.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-3.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3719,6 +3785,42 @@ starlark_repository.archive(
     strip_prefix = "rules_js-2.0.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.34.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.6.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.6.0",
@@ -3739,24 +3841,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.3/rules_js-v3.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js---1.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3764,15 +3848,6 @@ starlark_repository.archive(
     strip_prefix = "rules_js-1.40.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.9.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.9.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.9.2/rules_js-v2.9.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.3.8",
@@ -3784,13 +3859,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.42.0",
+    name = "bzl.aspect_rules_js---1.39.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.42.0",
+    strip_prefix = "rules_js-1.39.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.5.0",
@@ -3802,13 +3877,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---3.0.1",
+    name = "bzl.aspect_rules_js---1.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-3.0.1",
+    strip_prefix = "rules_js-1.42.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.9.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.9.2/rules_js-v2.9.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---1.34.1",
@@ -3820,33 +3904,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.3.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.3.5",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3856,30 +3913,12 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js_rust_wasm_bindgen---0.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/UebelAndre/aspect_rules_js_rust_wasm_bindgen/releases/download/0.0.2/aspect_rules_js_rust_wasm_bindgen-0.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_lint---0.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_lint-0.12.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_lint---1.0.0-rc4",
@@ -3900,6 +3939,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_lint/releases/download/v2.5.0/rules_lint-v2.5.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_lint---0.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_lint-0.12.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3909,15 +3957,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.0.0/rules_py-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_py---1.11.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_py-1.11.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.11.2/rules_py-v1.11.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.8.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3925,6 +3964,15 @@ starlark_repository.archive(
     strip_prefix = "rules_py-1.8.4",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.8.4/rules_py-v1.8.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_py---1.11.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_py-1.11.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.11.2/rules_py-v1.11.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_rollup---2.0.1",
@@ -3954,15 +4002,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_terser/releases/download/v2.1.0/rules_terser-v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.1.0/rules_ts-v3.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3972,13 +4011,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.8.8",
+    name = "bzl.aspect_rules_ts---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.8.8",
+    strip_prefix = "rules_ts-3.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.8.8/rules_ts-v3.8.8.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.1.0/rules_ts-v3.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.7.0",
@@ -3999,6 +4038,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.6.0/rules_ts-v3.6.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_ts---3.8.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ts-3.8.8",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.8.8/rules_ts-v3.8.8.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_webpack---0.17.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4006,6 +4054,15 @@ starlark_repository.archive(
     strip_prefix = "rules_webpack-0.17.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_webpack/releases/download/v0.17.1/rules_webpack-v0.17.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_tools_telemetry---0.2.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tools_telemetry-0.2.6",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.6/tools_telemetry-v0.2.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_tools_telemetry---0.3.2",
@@ -4026,15 +4083,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_tools_telemetry---0.2.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tools_telemetry-0.2.6",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.6/tools_telemetry-v0.2.6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_tools_telemetry---0.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4053,13 +4101,13 @@ starlark_repository.archive(
     urls = ["https://github.com/assimp/assimp/archive/refs/tags/v5.4.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.assimp---6.0.2",
+    name = "bzl.assimp---6.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "assimp-6.0.2",
+    strip_prefix = "assimp-6.0.3",
     type = "tar.gz",
-    urls = ["https://github.com/assimp/assimp/archive/refs/tags/v6.0.2.tar.gz"],
+    urls = ["https://github.com/assimp/assimp/archive/refs/tags/v6.0.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.awk.bzl---0.2.3",
@@ -4106,20 +4154,20 @@ starlark_repository.archive(
     urls = ["https://github.com/Tinder/bazel-diff/releases/download/v19.0.3/release.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_bats---0.35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.35.0/bazel-bats-v0.35.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_bats---0.38.23",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.38.23/bazel-bats-v0.38.23.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_bats---0.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.35.0/bazel-bats-v0.35.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_cc_meta---0.2.0",
@@ -4149,24 +4197,6 @@ starlark_repository.archive(
     urls = ["https://github.com/buildbuddy-io/bazel_env.bzl/releases/download/v0.7.2/bazel_env.bzl-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_features---1.44.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4176,13 +4206,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.30.0",
+    name = "bzl.bazel_features---1.32.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.30.0",
+    strip_prefix = "bazel_features-1.32.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.9.1",
@@ -4194,13 +4242,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.18.0",
+    name = "bzl.bazel_features---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.18.0",
+    strip_prefix = "bazel_features-0.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.19.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.0.0",
@@ -4212,40 +4269,40 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.28.0",
+    name = "bzl.bazel_features---1.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.28.0",
+    strip_prefix = "bazel_features-1.43.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---0.1.0",
+    name = "bzl.bazel_features---1.15.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-0.1.0",
+    strip_prefix = "bazel_features-1.15.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.24.0",
+    name = "bzl.bazel_features---1.45.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.24.0",
+    strip_prefix = "bazel_features-1.45.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.45.0/bazel_features-v1.45.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.35.0",
+    name = "bzl.bazel_features---1.20.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.35.0",
+    strip_prefix = "bazel_features-1.20.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.9.0",
@@ -4266,40 +4323,49 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.32.0",
+    name = "bzl.bazel_features---1.35.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.32.0",
+    strip_prefix = "bazel_features-1.35.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.43.0",
+    name = "bzl.bazel_features---1.28.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.43.0",
+    strip_prefix = "bazel_features-1.28.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.19.0",
+    name = "bzl.bazel_features---1.30.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.19.0",
+    strip_prefix = "bazel_features-1.30.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.45.0",
+    name = "bzl.bazel_features---1.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.45.0",
+    strip_prefix = "bazel_features-1.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.45.0/bazel_features-v1.45.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.18.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.38.0",
@@ -4311,15 +4377,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.38.0/bazel_features-v1.38.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_features---1.4.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4329,24 +4386,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.20.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.20.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_features---1.39.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4354,6 +4393,24 @@ starlark_repository.archive(
     strip_prefix = "bazel_features-1.39.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.46.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.24.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.24.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_gomock---0.2.0",
@@ -4382,15 +4439,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazeltools/bazel_jar_jar/releases/download/v0.1.15/bazel_jar_jar-v0.1.15.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.1.0/bazel-lib-v3.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_lib---3.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4398,6 +4446,15 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-3.0.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.1.0/bazel-lib-v3.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_lib---3.2.2",
@@ -4409,13 +4466,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.0",
+    name = "bzl.bazel_lib---3.3.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.0",
+    strip_prefix = "bazel-lib-3.3.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0-beta.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0-beta.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_lib---3.0.0-rc.0",
@@ -4427,13 +4493,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0-beta.1",
+    name = "bzl.bazel_lib---3.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0-beta.1",
+    strip_prefix = "bazel-lib-3.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_linux_packages---0.3.1",
@@ -4454,20 +4520,12 @@ starlark_repository.archive(
     urls = ["https://github.com/gregl83/bazel-paq/releases/download/v1.4.1/bazel-paq-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.1",
+    name = "bzl.bazel_skylib---1.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.0/bazel-skylib-1.8.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.2.0",
@@ -4478,28 +4536,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.7.1",
+    name = "bzl.bazel_skylib---1.4.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.9.0",
+    name = "bzl.bazel_skylib---1.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.7.0",
@@ -4510,52 +4560,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.0/bazel-skylib-1.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_skylib---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.8.2",
@@ -4566,12 +4576,68 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.2/bazel-skylib-1.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.3.0",
+    name = "bzl.bazel_skylib---1.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib_gazelle_plugin---1.9.0",
@@ -4599,24 +4665,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel/archive/refs/tags/8.7.0rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.10/java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.10/bazel-worker-api-v0.0.10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.4/java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_worker_java---0.0.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4633,6 +4681,24 @@ starlark_repository.archive(
     strip_prefix = "bazel-worker-api-0.0.8/java",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.4/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.10/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.10/bazel-worker-api-v0.0.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazeldnf---v0.99.2-rc1",
@@ -4707,22 +4773,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost---1.83.0.bcr.4",
+    name = "bzl.boost---1.89.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "boost-boost-1.83.0",
+    strip_prefix = "boost-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.algorithm---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "algorithm-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.algorithm---1.89.0.bcr.2",
@@ -4734,6 +4791,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.algorithm---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "algorithm-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.algorithm---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4741,6 +4807,15 @@ starlark_repository.archive(
     strip_prefix = "algorithm-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.align---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "align-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.align---1.87.0",
@@ -4761,24 +4836,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.align---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.align---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.any---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4797,15 +4854,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.array---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.array---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4815,6 +4863,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.array---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "array-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.array---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4822,6 +4879,15 @@ starlark_repository.archive(
     strip_prefix = "array-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.asio---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "asio-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.asio---1.87.0.bcr.1",
@@ -4842,13 +4908,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.asio---1.90.0.bcr.1",
+    name = "bzl.boost.asio---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "asio-boost-1.90.0",
+    strip_prefix = "asio-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.88.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.assert---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "assert-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.assert---1.90.0.bcr.1",
@@ -4869,22 +4944,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.assert---1.89.0.bcr.2",
+    name = "bzl.boost.assert---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "assert-boost-1.89.0",
+    strip_prefix = "assert-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.assign---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "assign-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.assign---1.89.0.bcr.2",
@@ -4896,6 +4962,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.assign---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "assign-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.atomic---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4903,15 +4978,6 @@ starlark_repository.archive(
     strip_prefix = "atomic-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.atomic---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "atomic-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.atomic---1.89.0.bcr.2",
@@ -4923,13 +4989,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.beast---1.90.0.bcr.1",
+    name = "bzl.boost.atomic---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "beast-boost-1.90.0",
+    strip_prefix = "atomic-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.beast---1.89.0.bcr.2",
@@ -4939,6 +5005,15 @@ starlark_repository.archive(
     strip_prefix = "beast-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.beast---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "beast-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.bimap---1.89.0.bcr.2",
@@ -4968,15 +5043,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.bind---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.bind---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4984,6 +5050,15 @@ starlark_repository.archive(
     strip_prefix = "bind-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.bind---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bind-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.bind---1.83.0.bcr.4",
@@ -4995,6 +5070,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.callable_traits---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "callable_traits-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.callable_traits---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5004,13 +5088,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.callable_traits---1.89.0.bcr.2",
+    name = "bzl.boost.charconv---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "callable_traits-boost-1.89.0",
+    strip_prefix = "charconv-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.charconv---1.90.0.bcr.1",
@@ -5022,13 +5106,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.charconv---1.89.0.bcr.2",
+    name = "bzl.boost.chrono---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "charconv-boost-1.89.0",
+    strip_prefix = "chrono-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.chrono---1.89.0.bcr.2",
@@ -5047,15 +5131,6 @@ starlark_repository.archive(
     strip_prefix = "chrono-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.chrono---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "chrono-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.circular_buffer---1.89.0.bcr.2",
@@ -5103,13 +5178,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/compute/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.concept_check---1.90.0.bcr.1",
+    name = "bzl.boost.concept_check---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.90.0",
+    strip_prefix = "concept_check-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.concept_check---1.87.0",
@@ -5121,13 +5196,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.concept_check---1.89.0.bcr.2",
+    name = "bzl.boost.concept_check---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.89.0",
+    strip_prefix = "concept_check-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.config---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "config-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.config---1.89.0.bcr.2",
@@ -5148,22 +5232,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.config---1.90.0.bcr.1",
+    name = "bzl.boost.config---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "config-boost-1.90.0",
+    strip_prefix = "config-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.container---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "container-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container---1.89.0.bcr.2",
@@ -5175,6 +5250,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.container---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "container-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.container---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5182,15 +5266,6 @@ starlark_repository.archive(
     strip_prefix = "container-boost-1.83.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.container_hash---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container_hash---1.89.0.bcr.2",
@@ -5209,6 +5284,15 @@ starlark_repository.archive(
     strip_prefix = "container_hash-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.container_hash---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "container_hash-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container_hash---1.88.0.bcr.3",
@@ -5238,15 +5322,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.context---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "context-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5254,15 +5329,6 @@ starlark_repository.archive(
     strip_prefix = "conversion-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.conversion---1.89.0.bcr.2",
@@ -5274,22 +5340,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.conversion---1.83.0.bcr.4",
+    name = "bzl.boost.conversion---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.83.0",
+    strip_prefix = "conversion-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.core---1.89.0.bcr.2",
+    name = "bzl.boost.conversion---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.89.0",
+    strip_prefix = "conversion-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.core---1.87.0",
@@ -5310,22 +5376,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.core---1.83.0.bcr.4",
+    name = "bzl.boost.core---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.83.0",
+    strip_prefix = "core-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.87.0",
+    name = "bzl.boost.coroutine---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.87.0",
+    strip_prefix = "coroutine-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.coroutine---1.89.0.bcr.2",
@@ -5337,13 +5403,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.90.0.bcr.1",
+    name = "bzl.boost.coroutine---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.90.0",
+    strip_prefix = "coroutine-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.coroutine2---1.90.0.bcr.1",
@@ -5382,6 +5448,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/crc/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.date_time---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "date_time-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.date_time---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5400,24 +5475,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.date_time---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "date_time-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.date_time---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "date_time-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.describe---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5425,15 +5482,6 @@ starlark_repository.archive(
     strip_prefix = "describe-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.describe---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.describe---1.89.0.bcr.2",
@@ -5445,13 +5493,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.detail---1.90.0.bcr.1",
+    name = "bzl.boost.describe---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "detail-boost-1.90.0",
+    strip_prefix = "describe-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.detail---1.87.0",
@@ -5463,6 +5511,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.detail---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "detail-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.detail---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5470,6 +5527,15 @@ starlark_repository.archive(
     strip_prefix = "detail-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.detail---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "detail-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.dll---1.90.0.bcr.1",
@@ -5499,15 +5565,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5517,13 +5574,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.endian---1.89.0.bcr.2",
+    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.89.0",
+    strip_prefix = "dynamic_bitset-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.endian---1.87.0",
@@ -5544,13 +5601,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.exception---1.87.0",
+    name = "bzl.boost.endian---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "exception-boost-1.87.0",
+    strip_prefix = "endian-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.endian---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "endian-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.exception---1.89.0.bcr.2",
@@ -5562,6 +5628,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.exception---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.exception---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5571,15 +5646,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.filesystem---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "filesystem-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.filesystem---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5587,6 +5653,15 @@ starlark_repository.archive(
     strip_prefix = "filesystem-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.filesystem---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "filesystem-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.foreach---1.89.0.bcr.2",
@@ -5625,6 +5700,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.function---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "function-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.function---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5643,22 +5727,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.function---1.89.0.bcr.2",
+    name = "bzl.boost.function---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "function-boost-1.89.0",
+    strip_prefix = "function-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.function_types---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.function_types---1.90.0.bcr.1",
@@ -5677,6 +5752,15 @@ starlark_repository.archive(
     strip_prefix = "function_types-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.function_types---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "function_types-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.functional---1.87.0",
@@ -5706,24 +5790,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.functional---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.fusion---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.fusion---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5742,13 +5808,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.geometry---1.89.0.bcr.2",
+    name = "bzl.boost.fusion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "geometry-boost-1.89.0",
+    strip_prefix = "fusion-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.fusion---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fusion-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.geometry---1.90.0.bcr.1",
@@ -5758,6 +5833,15 @@ starlark_repository.archive(
     strip_prefix = "geometry-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.geometry---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "geometry-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.graph---1.90.0.bcr.1",
@@ -5823,15 +5907,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/histogram/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.hof---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "hof-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/hof/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.hof---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5841,13 +5916,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/hof/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.icl---1.89.0.bcr.2",
+    name = "bzl.boost.hof---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "icl-boost-1.89.0",
+    strip_prefix = "hof-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/hof/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.icl---1.90.0.bcr.1",
@@ -5857,6 +5932,15 @@ starlark_repository.archive(
     strip_prefix = "icl-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.icl---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "icl-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.integer---1.87.0",
@@ -5886,13 +5970,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.integer---1.88.0.bcr.3",
+    name = "bzl.boost.interprocess---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "integer-boost-1.88.0",
+    strip_prefix = "interprocess-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.interprocess---1.90.0.bcr.1",
@@ -5902,15 +5986,6 @@ starlark_repository.archive(
     strip_prefix = "interprocess-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.interprocess---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "interprocess-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.intrusive---1.89.0.bcr.2",
@@ -5940,15 +6015,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.intrusive---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "intrusive-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.io---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5967,22 +6033,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.iostreams---1.90.0.bcr.2",
+    name = "bzl.boost.iostreams---1.88.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "iostreams-boost-1.90.0",
+    strip_prefix = "iostreams-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/iostreams/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.iterator---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/iostreams/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.iterator---1.90.0.bcr.1",
@@ -6003,13 +6060,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.iterator---1.88.0.bcr.3",
+    name = "bzl.boost.iterator---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.88.0",
+    strip_prefix = "iterator-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.json---1.90.0.bcr.1",
@@ -6030,15 +6087,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.lambda---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lambda-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.lambda---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6046,6 +6094,15 @@ starlark_repository.archive(
     strip_prefix = "lambda-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.lambda---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "lambda-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.lambda2---1.90.0.bcr.1",
@@ -6066,15 +6123,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.leaf---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "leaf-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.leaf---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6082,6 +6130,15 @@ starlark_repository.archive(
     strip_prefix = "leaf-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.leaf---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "leaf-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.lexical_cast---1.89.0.bcr.2",
@@ -6109,15 +6166,6 @@ starlark_repository.archive(
     strip_prefix = "lexical_cast-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.lexical_cast---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lexical_cast-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.locale---1.90.0.bcr.1",
@@ -6183,15 +6231,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.math---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "math-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.math---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6199,6 +6238,15 @@ starlark_repository.archive(
     strip_prefix = "math-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.math---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "math-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.math---1.90.0.bcr.1",
@@ -6210,15 +6258,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.move---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "move-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.move---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6228,22 +6267,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.move---1.88.0.bcr.1",
+    name = "bzl.boost.move---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "move-boost-1.87.0",
+    strip_prefix = "move-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.mp11---1.87.0",
+    name = "bzl.boost.move---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.87.0",
+    strip_prefix = "move-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mp11---1.89.0.bcr.2",
@@ -6255,6 +6294,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.mp11---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "mp11-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.mp11---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6262,15 +6310,6 @@ starlark_repository.archive(
     strip_prefix = "mp11-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.mpl---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "mpl-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mpl---1.87.0",
@@ -6291,6 +6330,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.mpl---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "mpl-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.mqtt5---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6300,15 +6348,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mqtt5/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.multi_array---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "multi_array-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.multi_array---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6316,6 +6355,15 @@ starlark_repository.archive(
     strip_prefix = "multi_array-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.multi_array---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "multi_array-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.multi_index---1.90.0.bcr.1",
@@ -6336,13 +6384,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.multiprecision---1.90.0.bcr.1",
+    name = "bzl.boost.multiprecision---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "multiprecision-boost-1.90.0",
+    strip_prefix = "multiprecision-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.multiprecision---1.89.0.bcr.2",
@@ -6354,22 +6402,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.multiprecision---1.87.0",
+    name = "bzl.boost.multiprecision---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "multiprecision-boost-1.87.0",
+    strip_prefix = "multiprecision-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.mysql---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "mysql-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mysql---1.90.0.bcr.1",
@@ -6381,13 +6420,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.numeric_conversion---1.89.0.bcr.2",
+    name = "bzl.boost.mysql---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.89.0",
+    strip_prefix = "mysql-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.numeric_conversion---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "numeric_conversion-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.numeric_conversion---1.90.0.bcr.1",
@@ -6399,13 +6447,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.numeric_conversion---1.87.0",
+    name = "bzl.boost.numeric_conversion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.87.0",
+    strip_prefix = "numeric_conversion-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.numeric_interval---1.90.0.bcr.1",
@@ -6426,15 +6474,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ublas/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.optional---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "optional-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.optional---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6451,6 +6490,15 @@ starlark_repository.archive(
     strip_prefix = "optional-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.optional---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "optional-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.outcome---1.90.0.bcr.1",
@@ -6480,15 +6528,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/parameter/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.pfr---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pfr-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.pfr---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6498,13 +6537,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.phoenix---1.87.0",
+    name = "bzl.boost.pfr---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "phoenix-boost-1.87.0",
+    strip_prefix = "pfr-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.phoenix---1.90.0.bcr.1",
@@ -6525,13 +6564,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.phoenix---1.88.0.bcr.3",
+    name = "bzl.boost.phoenix---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "phoenix-boost-1.88.0",
+    strip_prefix = "phoenix-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.polygon---1.90.0.bcr.1",
@@ -6552,15 +6591,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.pool---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.pool---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6570,6 +6600,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.pool---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pool-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.pool---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6577,6 +6616,15 @@ starlark_repository.archive(
     strip_prefix = "pool-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.predef---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "predef-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.predef---1.89.0.bcr.2",
@@ -6597,15 +6645,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.predef---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.predef---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6613,15 +6652,6 @@ starlark_repository.archive(
     strip_prefix = "predef-boost-1.83.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.preprocessor---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "preprocessor-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.preprocessor---1.87.0",
@@ -6633,22 +6663,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.preprocessor---1.90.0",
+    name = "bzl.boost.preprocessor---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "preprocessor-boost-1.89.0",
+    strip_prefix = "preprocessor-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.process---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "process-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.process---1.89.0.bcr.2",
@@ -6658,6 +6679,15 @@ starlark_repository.archive(
     strip_prefix = "process-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.process---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "process-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.program_options---1.89.0.bcr.2",
@@ -6696,6 +6726,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.property_tree---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "property_tree-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.property_tree---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6705,13 +6744,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.property_tree---1.89.0.bcr.2",
+    name = "bzl.boost.proto---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "property_tree-boost-1.89.0",
+    strip_prefix = "proto-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.proto---1.87.0",
@@ -6730,15 +6769,6 @@ starlark_repository.archive(
     strip_prefix = "proto-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.proto---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.proto---1.88.0.bcr.3",
@@ -6795,15 +6825,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.random---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "random-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.random---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6822,22 +6843,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.range---1.87.0",
+    name = "bzl.boost.random---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.87.0",
+    strip_prefix = "random-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.range---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.range---1.90.0.bcr.1",
@@ -6849,13 +6861,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.range---1.88.0.bcr.3",
+    name = "bzl.boost.range---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.88.0",
+    strip_prefix = "range-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.range---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "range-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.ratio---1.87.0",
@@ -6867,15 +6888,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.ratio---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.ratio---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6885,13 +6897,31 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.ratio---1.88.0.bcr.3",
+    name = "bzl.boost.ratio---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.88.0",
+    strip_prefix = "ratio-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.ratio---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ratio-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.rational---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rational-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.rational---1.89.0.bcr.2",
@@ -6912,22 +6942,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.rational---1.90.0.bcr.1",
+    name = "bzl.boost.rational---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.90.0",
+    strip_prefix = "rational-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.regex---1.90.0.bcr.1",
+    name = "bzl.boost.regex---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.90.0",
+    strip_prefix = "regex-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.regex---1.89.0.bcr.2",
@@ -6939,13 +6969,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.regex---1.87.0",
+    name = "bzl.boost.regex---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.87.0",
+    strip_prefix = "regex-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.scope---1.90.0.bcr.1",
@@ -6966,15 +6996,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/scope/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.scope_exit---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "scope_exit-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.scope_exit---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6984,13 +7005,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.serialization---1.89.0.bcr.2",
+    name = "bzl.boost.scope_exit---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "serialization-boost-1.89.0",
+    strip_prefix = "scope_exit-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.serialization---1.90.0.bcr.1",
@@ -7002,13 +7023,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.serialization---1.83.0.bcr.4",
+    name = "bzl.boost.serialization---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "serialization-boost-1.83.0",
+    strip_prefix = "serialization-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.signals2---1.89.0.bcr.2",
@@ -7029,15 +7050,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/signals2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.smart_ptr---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7056,13 +7068,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.smart_ptr---1.83.0.bcr.4",
+    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.83.0",
+    strip_prefix = "smart_ptr-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.sort---1.90.0.bcr.1",
@@ -7092,22 +7104,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/spirit/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.spirit---1.89.0.bcr.3",
+    name = "bzl.boost.spirit---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "spirit-boost-1.89.0",
+    strip_prefix = "spirit-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/spirit/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.stacktrace---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "stacktrace-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/spirit/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.stacktrace---1.90.0.bcr.1",
@@ -7119,13 +7122,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.static_assert---1.87.0",
+    name = "bzl.boost.stacktrace---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.87.0",
+    strip_prefix = "stacktrace-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.static_assert---1.89.0.bcr.2",
@@ -7137,6 +7140,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.static_assert---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "static_assert-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.static_assert---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7146,13 +7158,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.static_string---1.90.0.bcr.1",
+    name = "bzl.boost.static_assert---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_string-boost-1.90.0",
+    strip_prefix = "static_assert-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.static_string---1.89.0.bcr.2",
@@ -7164,22 +7176,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.system---1.87.0",
+    name = "bzl.boost.static_string---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.87.0",
+    strip_prefix = "static_string-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.system---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.system---1.89.0.bcr.2",
@@ -7191,22 +7194,31 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.system---1.88.0.bcr.3",
+    name = "bzl.boost.system---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.88.0",
+    strip_prefix = "system-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.test---1.90.0.bcr.1",
+    name = "bzl.boost.system---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "test-boost-1.90.0",
+    strip_prefix = "system-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.system---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "system-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.test---1.89.0.bcr.2",
@@ -7218,13 +7230,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.thread---1.89.0.bcr.2",
+    name = "bzl.boost.test---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "thread-boost-1.89.0",
+    strip_prefix = "test-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.thread---1.90.0.bcr.1",
@@ -7236,22 +7248,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.thread---1.87.0.bcr.1",
+    name = "bzl.boost.thread---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "thread-boost-1.87.0",
+    strip_prefix = "thread-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.throw_exception---1.90.0.bcr.1",
+    name = "bzl.boost.thread---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.90.0",
+    strip_prefix = "thread-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.throw_exception---1.89.0.bcr.2",
@@ -7270,6 +7282,15 @@ starlark_repository.archive(
     strip_prefix = "throw_exception-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.throw_exception---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "throw_exception-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.timer---1.89.0.bcr.2",
@@ -7317,13 +7338,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tokenizer---1.88.0.bcr.3",
+    name = "bzl.boost.tokenizer---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tokenizer-boost-1.88.0",
+    strip_prefix = "tokenizer-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.tti---1.90.0.bcr.1",
@@ -7344,6 +7365,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.tuple---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tuple-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.tuple---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7362,15 +7392,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tuple---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.tuple---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7378,15 +7399,6 @@ starlark_repository.archive(
     strip_prefix = "tuple-boost-1.88.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.type_index---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.type_index---1.90.0.bcr.1",
@@ -7398,6 +7410,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.type_index---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "type_index-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.type_index---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7407,22 +7428,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.87.0",
+    name = "bzl.boost.type_index---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.87.0",
+    strip_prefix = "type_index-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.type_traits---1.90.0.bcr.1",
@@ -7434,13 +7446,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.83.0.bcr.4",
+    name = "bzl.boost.type_traits---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.83.0",
+    strip_prefix = "type_traits-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.type_traits---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "type_traits-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.typeof---1.89.0.bcr.2",
@@ -7470,13 +7491,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.units---1.89.0.bcr.2",
+    name = "bzl.boost.typeof---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "units-boost-1.89.0",
+    strip_prefix = "typeof-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.units---1.90.0.bcr.1",
@@ -7488,22 +7509,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.unordered---1.89.0.bcr.2",
+    name = "bzl.boost.units---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.89.0",
+    strip_prefix = "units-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.unordered---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.unordered---1.90.0.bcr.1",
@@ -7515,13 +7527,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.url---1.90.0.bcr.1",
+    name = "bzl.boost.unordered---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "url-boost-1.90.0",
+    strip_prefix = "unordered-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.unordered---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "unordered-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.url---1.89.0.bcr.2",
@@ -7533,22 +7554,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.utility---1.87.0",
+    name = "bzl.boost.url---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.87.0",
+    strip_prefix = "url-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.utility---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.utility---1.90.0.bcr.1",
@@ -7560,22 +7572,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.utility---1.83.0.bcr.4",
+    name = "bzl.boost.utility---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.83.0",
+    strip_prefix = "utility-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.uuid---1.90.0.bcr.1",
+    name = "bzl.boost.utility---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "uuid-boost-1.90.0",
+    strip_prefix = "utility-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.uuid---1.89.0.bcr.2",
@@ -7587,22 +7599,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.variant---1.89.0.bcr.2",
+    name = "bzl.boost.uuid---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.89.0",
+    strip_prefix = "uuid-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.variant---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.variant---1.87.0",
@@ -7614,6 +7617,24 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.variant---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.variant---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.variant---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7621,24 +7642,6 @@ starlark_repository.archive(
     strip_prefix = "variant-boost-1.88.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.variant2---1.89.0.bcr.2",
@@ -7650,6 +7653,24 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.variant2---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant2-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.variant2---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant2-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.variant2---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7657,15 +7678,6 @@ starlark_repository.archive(
     strip_prefix = "variant2-boost-1.88.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.vmd---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "vmd-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/vmd/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.vmd---1.90.0.bcr.1",
@@ -7677,13 +7689,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/vmd/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.winapi---1.90.0.bcr.1",
+    name = "bzl.boost.vmd---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.90.0",
+    strip_prefix = "vmd-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/vmd/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.winapi---1.87.0",
@@ -7693,6 +7705,15 @@ starlark_repository.archive(
     strip_prefix = "winapi-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.winapi---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "winapi-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.xpressive---1.90.0.bcr.1",
@@ -7722,24 +7743,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20250514.0/boringssl-0.20250514.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20241024.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241024.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260413.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260413.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boringssl---0.20240913.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7749,58 +7752,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
+    name = "bzl.boringssl---0.20260413.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
+    strip_prefix = "boringssl-0.20260413.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20250212.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250212.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250212.0/boringssl-0.20250212.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20240930.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20240930.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260327.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260327.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20240530-2db0eb3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-2db0eb3f96a5756298dcd7f9319e56a98585bd10",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20241209.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241209.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20251124.0",
@@ -7821,6 +7779,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20251002.0/boringssl-0.20251002.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20240530-2db0eb3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-2db0eb3f96a5756298dcd7f9319e56a98585bd10",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boringssl---0.20250415.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7837,6 +7804,60 @@ starlark_repository.archive(
     strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
     type = "zip",
     urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20240930.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20240930.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241024.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241024.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20250212.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20250212.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250212.0/boringssl-0.20250212.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20260327.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20260327.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241209.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241209.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.brotli---1.1.0",
@@ -7857,15 +7878,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/brotli/archive/refs/tags/v1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.build_stack_rules_proto---4.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-v4.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/stackb/rules_proto/releases/download/v4.1.1/rules_proto-v4.1.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.build_stack_rules_proto---4.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7873,6 +7885,15 @@ starlark_repository.archive(
     strip_prefix = "rules_proto-v4.2.0",
     type = "tar.gz",
     urls = ["https://github.com/stackb/rules_proto/releases/download/v4.2.0/rules_proto-v4.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.build_stack_rules_proto---4.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-v4.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/stackb/rules_proto/releases/download/v4.1.1/rules_proto-v4.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.build_stack_scala_gazelle---0.1.1",
@@ -7884,67 +7905,12 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/scala-gazelle/releases/download/v0.1.1/scala-gazelle-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---6.4.0",
+    name = "bzl.buildifier_prebuilt---8.5.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---6.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-6.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---7.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-7.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---7.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-7.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.3.1.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.1.1",
@@ -7956,12 +7922,67 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.5.1.2",
+    name = "bzl.buildifier_prebuilt---6.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-6.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---7.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-7.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-6.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---7.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-7.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildozer---8.5.1",
@@ -7982,13 +8003,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bulletphysics/bullet3/archive/d1a4256b3a019117f2bb6cb8c63d6367aaf512e2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bzip2---1.0.8.bcr.1",
+    name = "bzl.bzip2---1.0.8.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     strip_prefix = "bzip2-1.0.8",
     type = "tar.gz",
-    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
+    urls = ["https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bzlparty_rules_quickjs---0.1.0",
@@ -8026,6 +8047,15 @@ starlark_repository.archive(
     urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_16_1/c-ares-1.16.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.c-ares---1.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "c-ares-1.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.c-ares---1.19.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8035,13 +8065,13 @@ starlark_repository.archive(
     urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.c-ares---1.15.0",
+    name = "bzl.c-ares---1.34.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "c-ares-1.15.0",
+    strip_prefix = "c-ares-1.34.5",
     type = "tar.gz",
-    urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz"],
+    urls = ["https://github.com/c-ares/c-ares/releases/download/v1.34.5/c-ares-1.34.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.c-blosc2---2.22.0",
@@ -8089,15 +8119,6 @@ starlark_repository.archive(
     urls = ["https://github.com/caseyduquettesc/rules_python_pytest/releases/download/v1.1.1/rules_python_pytest-v1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.catch2---3.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Catch2-3.13.0",
-    type = "tar.gz",
-    urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.13.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.catch2---3.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8105,6 +8126,15 @@ starlark_repository.archive(
     strip_prefix = "Catch2-3.8.0",
     type = "tar.gz",
     urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.catch2---3.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Catch2-3.13.0",
+    type = "tar.gz",
+    urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ccd---2.1.0.bcr.1",
@@ -8161,13 +8191,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-spec---0.23.0",
+    name = "bzl.cel-spec---0.25.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.23.0",
+    strip_prefix = "cel-spec-0.25.1",
     type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cel-spec---0.24.0",
@@ -8179,13 +8209,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-spec---0.25.1",
+    name = "bzl.cel-spec---0.23.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.25.1",
+    strip_prefix = "cel-spec-0.23.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz"],
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ceres-solver---2.2.0",
@@ -8197,12 +8227,12 @@ starlark_repository.archive(
     urls = ["https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cgrindel_bazel_starlib---0.28.0",
+    name = "bzl.cgrindel_bazel_starlib---0.27.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.28.0/bazel-starlib.v0.28.0.tar.gz"],
+    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.27.0/bazel-starlib.v0.27.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cgrindel_bazel_starlib---0.30.0",
@@ -8213,12 +8243,12 @@ starlark_repository.archive(
     urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.30.0/bazel-starlib.v0.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cgrindel_bazel_starlib---0.27.0",
+    name = "bzl.cgrindel_bazel_starlib---0.28.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.27.0/bazel-starlib.v0.27.0.tar.gz"],
+    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.28.0/bazel-starlib.v0.28.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.civetweb---1.16.bcr.4",
@@ -8256,13 +8286,13 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/closure-templates/releases/download/v1.0.1/closure-templates-v1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.2",
+    name = "bzl.cmake_configure_file---0.1.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.2",
+    strip_prefix = "cmake_configure_file-0.1.4",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.2/cmake_configure_file-0.1.2.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.4/cmake_configure_file-v0.1.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.3",
@@ -8274,15 +8304,6 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.3/cmake_configure_file-v0.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.4",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.4/cmake_configure_file-v0.1.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8290,6 +8311,15 @@ starlark_repository.archive(
     strip_prefix = "cmake_configure_file-0.1.7",
     type = "tar.gz",
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cmake_configure_file---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cmake_configure_file-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.2/cmake_configure_file-0.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.codspeed_google_benchmark_compat---2.1.0",
@@ -8346,15 +8376,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.33.0/rules_jvm-v0.33.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.contrib_rules_jvm---0.24.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm-0.24.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.24.0/rules_jvm-v0.24.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.contrib_rules_jvm---0.28.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8362,6 +8383,15 @@ starlark_repository.archive(
     strip_prefix = "rules_jvm-0.28.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.28.0/rules_jvm-v0.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.contrib_rules_jvm---0.24.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm-0.24.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.24.0/rules_jvm-v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.copybara---0.0.0-20250728-6672ce2",
@@ -8409,15 +8439,6 @@ starlark_repository.archive(
     urls = ["https://github.com/dallison/cpp_toolbelt/releases/download/2.0.2/cpp_toolbelt-2.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cppitertools---2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cppitertools-2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cppitertools---2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8425,6 +8446,15 @@ starlark_repository.archive(
     strip_prefix = "cppitertools-2.1",
     type = "tar.gz",
     urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cppitertools---2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cppitertools-2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cpptoml---0.1.1",
@@ -8454,15 +8484,6 @@ starlark_repository.archive(
     urls = ["https://github.com/zeromq/cppzmq/archive/refs/tags/v4.10.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cpuinfo---0.0.0-20250925-877328f",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cpuinfo-877328f188a3c7d1fa855871a278eb48d530c4c0",
-    type = "tar.gz",
-    urls = ["https://github.com/pytorch/cpuinfo/archive/877328f188a3c7d1fa855871a278eb48d530c4c0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cpuinfo---0.0.0-20260312-7607ca5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8470,6 +8491,15 @@ starlark_repository.archive(
     strip_prefix = "cpuinfo-7607ca500436b37ad23fb8d18614bec7796b68a7",
     type = "tar.gz",
     urls = ["https://github.com/pytorch/cpuinfo/archive/7607ca500436b37ad23fb8d18614bec7796b68a7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cpuinfo---0.0.0-20250925-877328f",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cpuinfo-877328f188a3c7d1fa855871a278eb48d530c4c0",
+    type = "tar.gz",
+    urls = ["https://github.com/pytorch/cpuinfo/archive/877328f188a3c7d1fa855871a278eb48d530c4c0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.crc32c---1.1.0",
@@ -8526,13 +8556,13 @@ starlark_repository.archive(
     urls = ["https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.curl---8.4.0.bcr.1",
+    name = "bzl.curl---8.12.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "curl-8.4.0",
+    strip_prefix = "curl-8.12.0",
     type = "tar.gz",
-    urls = ["https://github.com/curl/curl/releases/download/curl-8_4_0/curl-8.4.0.tar.gz"],
+    urls = ["https://github.com/curl/curl/releases/download/curl-8_12_0/curl-8.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cxx.rs---1.0.194",
@@ -8553,15 +8583,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.3.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cython---3.0.11-1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cython-3.0.11-1",
-    type = "tar.gz",
-    urls = ["https://github.com/cython/cython/archive/refs/tags/3.0.11-1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cython---3.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8569,6 +8590,15 @@ starlark_repository.archive(
     strip_prefix = "cython-3.2.4",
     type = "tar.gz",
     urls = ["https://github.com/cython/cython/archive/refs/tags/3.2.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cython---3.0.11-1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cython-3.0.11-1",
+    type = "tar.gz",
+    urls = ["https://github.com/cython/cython/archive/refs/tags/3.0.11-1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.darts-clone---0.32",
@@ -8706,13 +8736,13 @@ starlark_repository.archive(
     urls = ["https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.eigen---3.4.0.bcr.2",
+    name = "bzl.eigen---4.0.0-20241125.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "eigen-3.4.0",
+    strip_prefix = "eigen-8ad4344ca79f2f248bc5ed70eec72e4b9c4d5e88",
     type = "zip",
-    urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip"],
+    urls = ["https://github.com/eigen-mirror/eigen/archive/8ad4344ca79f2f248bc5ed70eec72e4b9c4d5e88.zip"],
 )
 starlark_repository.archive(
     name = "bzl.elemental2---1.3.2",
@@ -8750,12 +8780,12 @@ starlark_repository.archive(
     urls = ["https://github.com/emscripten-core/emsdk/archive/refs/tags/4.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.engflowapis---2024.11.13-06.15.38",
+    name = "bzl.engflowapis---2024.11.04-11.10.20",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.11.13-06.15.38/engflowapis-2024.11.13-06.15.38.tar.gz"],
+    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.11.04-11.10.20/engflowapis-2024.11.04-11.10.20.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.engflowapis-java---2025.07.24-06.20.24",
@@ -8767,22 +8797,13 @@ starlark_repository.archive(
     urls = ["https://github.com/EngFlow/engflowapis/releases/download/2025.07.24-06.20.24/engflowapis-2025.07.24-06.20.24.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20250128-4de3c74",
+    name = "bzl.envoy_api---0.0.0-20251216-6ef568c",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-4de3c74cf21a9958c1cf26d8993c55c6e0d28b49",
+    strip_prefix = "data-plane-api-6ef568cf4a67362849911d1d2a546fd9f35db2ff",
     type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4de3c74cf21a9958c1cf26d8993c55c6e0d28b49.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20241214-918efc9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-918efc9df33d27b5a3850332d408a3684a4de8ca",
-    type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/918efc9df33d27b5a3850332d408a3684a4de8ca.tar.gz"],
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20251105-4a2b9a3",
@@ -8794,13 +8815,22 @@ starlark_repository.archive(
     urls = ["https://github.com/envoyproxy/data-plane-api/archive/4a2b9a30628e95e0cfe985c45c10adc8a6b1643b.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20251216-6ef568c",
+    name = "bzl.envoy_api---0.0.0-20241214-918efc9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-6ef568cf4a67362849911d1d2a546fd9f35db2ff",
+    strip_prefix = "data-plane-api-918efc9df33d27b5a3850332d408a3684a4de8ca",
     type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz"],
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/918efc9df33d27b5a3850332d408a3684a4de8ca.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.envoy_api---0.0.0-20250128-4de3c74",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "data-plane-api-4de3c74cf21a9958c1cf26d8993c55c6e0d28b49",
+    type = "tar.gz",
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4de3c74cf21a9958c1cf26d8993c55c6e0d28b49.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.envoy_toolshed---0.3.25",
@@ -8891,15 +8921,6 @@ starlark_repository.archive(
     urls = ["https://github.com/facebookincubator/fizz/releases/download/v2025.02.10.00/fizz-v2025.02.10.00.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.flatbuffers---25.2.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "flatbuffers-25.2.10",
-    type = "tar.gz",
-    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.flatbuffers---25.12.19",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8907,6 +8928,15 @@ starlark_repository.archive(
     strip_prefix = "flatbuffers-25.12.19",
     type = "tar.gz",
     urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.12.19.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.flatbuffers---25.2.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "flatbuffers-25.2.10",
+    type = "tar.gz",
+    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.flex---2.6.4.bcr.5",
@@ -8927,24 +8957,6 @@ starlark_repository.archive(
     urls = ["https://github.com/NVlabs/flip/archive/79675788aa642fbb4732effe2b45b082ff4c4d52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.fmt---8.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-8.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.fmt---10.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-10.1.1",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
-)
-starlark_repository.archive(
     name = "bzl.fmt---11.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8963,13 +8975,31 @@ starlark_repository.archive(
     urls = ["https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.fmt---11.0.2.bcr.1",
+    name = "bzl.fmt---8.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-11.0.2",
+    strip_prefix = "fmt-8.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.fmt---10.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-10.1.1",
     type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/11.0.2/fmt-11.0.2.zip"],
+    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.fmt---11.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-11.1.4",
+    type = "zip",
+    urls = ["https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip"],
 )
 starlark_repository.archive(
     name = "bzl.folly---2025.01.13.00.bcr.6",
@@ -8998,13 +9028,13 @@ starlark_repository.archive(
     urls = ["https://github.com/danoli3/FreeImage/archive/refs/tags/3.19.10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.freetype---2.14.1",
+    name = "bzl.freetype---2.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "freetype-2.14.1",
+    strip_prefix = "freetype-2.9",
     type = "tar.gz",
-    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.gz"],
+    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.fremtind_rules_vitest---0.2.1",
@@ -9059,6 +9089,23 @@ starlark_repository.archive(
     urls = ["https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
 )
 starlark_repository.archive(
+    name = "bzl.gawk---5.3.2.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gawk-5.3.2",
+    type = "tar.xz",
+    urls = ["https://mirrors.kernel.org/gnu/gawk/gawk-5.3.2.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gazelle---0.47.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9075,44 +9122,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gazelle---0.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.36.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.41.0",
@@ -9131,23 +9146,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.29.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-gazelle-0.29.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.45.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gazelle---0.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9156,44 +9154,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.39.1",
+    name = "bzl.gazelle---0.36.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.42.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.38.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.50.0",
@@ -9204,6 +9170,79 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gazelle---0.30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.42.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.45.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.29.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-gazelle-0.29.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.38.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gazelle_cc---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9211,6 +9250,24 @@ starlark_repository.archive(
     strip_prefix = "gazelle_cc-0.5.0",
     type = "tar.gz",
     urls = ["https://github.com/EngFlow/gazelle_cc/releases/download/v0.5.0/gazelle_cc-v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle_py---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gazelle_py-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/perplexityai/gazelle_py/releases/download/v0.5.0/gazelle_py-v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle_ts---0.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gazelle_ts-0.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/gazelle_ts/releases/download/v0.4.0/gazelle_ts-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gcc_toolchain---0.9.0",
@@ -9276,6 +9333,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/glog/archive/refs/tags/v0.7.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.glog---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "glog-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.glpk---5.0.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9303,22 +9369,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/bazel-common/releases/download/0.0.1/bazel-common-0.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.4",
+    name = "bzl.google_benchmark---1.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.4",
+    strip_prefix = "benchmark-1.8.3",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.5",
@@ -9330,6 +9387,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.google_benchmark---1.8.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.8.2",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.google_benchmark---1.9.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9339,13 +9405,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.3",
+    name = "bzl.google_benchmark---1.8.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.3",
+    strip_prefix = "benchmark-1.8.4",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.9.2",
@@ -9384,13 +9450,22 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.0.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20251003-2193a2bf",
+    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-2193a2bfcecb92b92aad7a4d81baa428cafd7dfd",
+    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
     type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/2193a2bfcecb92b92aad7a4d81baa428cafd7dfd.zip"],
+    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
@@ -9400,6 +9475,33 @@ starlark_repository.archive(
     strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
     type = "tar.gz",
     urls = ["https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260422-20ac242a",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-20ac242a6b3a723cb10c1a0201209261addaf7d8",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/20ac242a6b3a723cb10c1a0201209261addaf7d8.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260223-edfe7983",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-edfe7983b9d99d6244b4d7636d25fa6e752a2041",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/edfe7983b9d99d6244b4d7636d25fa6e752a2041.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20251003-2193a2bf",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-2193a2bfcecb92b92aad7a4d81baa428cafd7dfd",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/2193a2bfcecb92b92aad7a4d81baa428cafd7dfd.zip"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20240819-fe8ba054a",
@@ -9429,40 +9531,13 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    name = "bzl.googleapis---0.0.0-20250604-de157ca3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
+    strip_prefix = "googleapis-de157ca34fa487ce248eb9130293d630b501e4ad",
     type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260422-20ac242a",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-20ac242a6b3a723cb10c1a0201209261addaf7d8",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/20ac242a6b3a723cb10c1a0201209261addaf7d8.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260223-edfe7983",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-edfe7983b9d99d6244b4d7636d25fa6e752a2041",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/edfe7983b9d99d6244b4d7636d25fa6e752a2041.zip"],
+    urls = ["https://github.com/googleapis/googleapis/archive/de157ca34fa487ce248eb9130293d630b501e4ad.zip"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis-rules-registry---1.0.0",
@@ -9483,13 +9558,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.11.0",
+    name = "bzl.googletest---1.14.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-release-1.11.0",
+    strip_prefix = "googletest-1.14.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.15.2",
@@ -9501,6 +9576,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.googletest---1.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googletest-release-1.11.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.googletest---1.17.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9508,15 +9592,6 @@ starlark_repository.archive(
     strip_prefix = "googletest-1.17.0",
     type = "tar.gz",
     urls = ["https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.googletest---1.14.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.14.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.13.0",
@@ -9545,22 +9620,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gperftools/gperftools/releases/download/gperftools-2.18.1/gperftools-2.18.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.76.0.bcr.1",
+    name = "bzl.grpc---1.73.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.76.0",
+    strip_prefix = "grpc-1.73.1",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.71.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.71.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.71.0.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.80.0",
@@ -9572,15 +9638,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.80.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.69.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.grpc---1.41.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9588,42 +9645,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-1.41.0",
     type = "zip",
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.70.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.73.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.73.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.74.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.74.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.68.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.68.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.72.0",
@@ -9635,6 +9656,24 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.72.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc---1.71.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.71.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.71.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.68.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.68.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc---1.56.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9644,6 +9683,51 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc---1.70.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.76.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.76.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.74.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.74.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.69.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.69.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.78.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.78.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.78.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9651,15 +9735,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-httpjson-transcoding-ff41eb3fc9209e6197595b54f7addfa244c0bdb6",
     type = "tar.gz",
     urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/ff41eb3fc9209e6197595b54f7addfa244c0bdb6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.66.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.66.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-java---1.71.0",
@@ -9680,15 +9755,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.67.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc-java---1.78.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.78.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.78.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.grpc-java---1.62.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9696,6 +9762,15 @@ starlark_repository.archive(
     strip_prefix = "grpc-java-1.62.2",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.62.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.66.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.66.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-java---1.69.0",
@@ -9707,6 +9782,15 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc-java---1.78.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.78.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.78.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc-proto---0.0.0-20240627-ec30f58.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9716,14 +9800,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-proto/archive/ec30f589e2519d595688b9a42f88a91bdd6b733f.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.29.0/grpc-gateway-v2.29.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.grpc_ecosystem_grpc_gateway---2.26.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9731,6 +9807,14 @@ starlark_repository.archive(
     strip_prefix = "grpc-gateway-2.26.3",
     type = "tar.gz",
     urls = ["https://github.com/grpc-ecosystem/grpc-gateway/archive/refs/tags/v2.26.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.29.0/grpc-gateway-v2.29.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc_kotlin---1.5.0",
@@ -9751,22 +9835,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/gutil/releases/download/20260309.0/gutil-release-20260309.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.gutil---20250409.0",
+    name = "bzl.gutil---20260226.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gutil-20250409.0",
+    strip_prefix = "gutil-release-20260226",
     type = "zip",
-    urls = ["https://github.com/google/gutil/releases/download/20250409.0/gutil-20250409.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.gz-common---7.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-common-gz-common7_7.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.1.1.tar.gz"],
+    urls = ["https://github.com/google/gutil/releases/download/20260226.0/gutil-release-20260226.zip"],
 )
 starlark_repository.archive(
     name = "bzl.gz-common---7.1.0",
@@ -9776,6 +9851,15 @@ starlark_repository.archive(
     strip_prefix = "gz-common-gz-common7_7.1.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-common---7.2.0-pre1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-common-gz-common7_7.2.0-pre1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.2.0-pre1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-common---7.0.0",
@@ -9814,15 +9898,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-msgs---12.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-msgs-gz-msgs12_12.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-msgs---12.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9832,13 +9907,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-physics---9.0.0",
+    name = "bzl.gz-msgs---12.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-physics-gz-physics9_9.0.0",
+    strip_prefix = "gz-msgs-gz-msgs12_12.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.0.0.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-physics---9.2.0",
@@ -9850,6 +9925,15 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.2.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gz-physics---9.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-physics-gz-physics9_9.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.0.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gz-plugin---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9857,15 +9941,6 @@ starlark_repository.archive(
     strip_prefix = "gz-plugin-gz-plugin4_4.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/tags/gz-plugin4_4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gz-rendering---10.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-rendering-gz-rendering10_10.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-rendering---10.0.0",
@@ -9877,13 +9952,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-sensors---10.0.0",
+    name = "bzl.gz-rendering---10.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-sensors-gz-sensors10_10.0.0",
+    strip_prefix = "gz-rendering-gz-rendering10_10.0.1",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.0.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-sensors---10.0.1",
@@ -9895,6 +9970,15 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gz-sensors---10.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-sensors-gz-sensors10_10.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gz-sim---10.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9904,15 +9988,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-sim/archive/refs/tags/gz-sim10_10.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-transport---15.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-transport-gz-transport15_15.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-transport---15.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9920,6 +9995,15 @@ starlark_repository.archive(
     strip_prefix = "gz-transport-gz-transport15_15.0.2",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-transport---15.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-transport-gz-transport15_15.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-utils---4.0.0",
@@ -9940,15 +10024,6 @@ starlark_repository.archive(
     urls = ["https://github.com/GZGavinZhao/gzgz_rules_sass/releases/download/v1.0.4/gzgz_rules_sass-v1.0.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.helly25_bashtest---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bashtest-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.helly25_bashtest---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9956,6 +10031,15 @@ starlark_repository.archive(
     strip_prefix = "bashtest-0.1.0",
     type = "tar.gz",
     urls = ["https://github.com/helly25/bashtest/releases/download/0.1.0/bashtest-0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.helly25_bashtest---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bashtest-0.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.helly25_bzl---0.3.1",
@@ -10002,14 +10086,6 @@ starlark_repository.archive(
     urls = ["https://github.com/FBorowiec/hermetic_clang_toolchain/releases/download/v1.0.1/hermetic_clang_toolchain-1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.hermetic_launcher---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.5/hermetic_launcher-v0.0.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.hermetic_launcher---0.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10018,13 +10094,12 @@ starlark_repository.archive(
     urls = ["https://github.com/malt3/hermetic-launcher/releases/download/v0.0.3/hermetic_launcher-v0.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.highs---1.11.0",
+    name = "bzl.hermetic_launcher---0.0.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "HiGHS",
     type = "tar.gz",
-    urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.11.0/source-archive.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.5/hermetic_launcher-v0.0.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highs---1.13.0",
@@ -10036,13 +10111,13 @@ starlark_repository.archive(
     urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.13.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.highway---1.3.0.bcr.1",
+    name = "bzl.highs---1.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "highway-1.3.0",
+    strip_prefix = "HiGHS",
     type = "tar.gz",
-    urls = ["https://github.com/google/highway/releases/download/1.3.0/highway-1.3.0.tar.gz"],
+    urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.11.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highway---1.2.0",
@@ -10052,6 +10127,15 @@ starlark_repository.archive(
     strip_prefix = "highway-1.2.0",
     type = "tar.gz",
     urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.highway---1.3.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "highway-1.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/highway/releases/download/1.3.0/highway-1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highwayhash---0.0.0-20240305-5ad3bf8.bcr.1",
@@ -10090,15 +10174,6 @@ starlark_repository.archive(
     urls = ["https://github.com/eclipse-iceoryx/iceoryx2/archive/refs/tags/v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.imath---3.1.12.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Imath-3.1.12",
-    type = "tar.gz",
-    urls = ["https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.1.12/Imath-3.1.12.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.imath---3.2.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10106,6 +10181,15 @@ starlark_repository.archive(
     strip_prefix = "Imath-3.2.2",
     type = "tar.gz",
     urls = ["https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.2.2/Imath-3.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.imath---3.1.12.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Imath-3.1.12",
+    type = "tar.gz",
+    urls = ["https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.1.12/Imath-3.1.12.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.isl---0.27",
@@ -10162,15 +10246,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"],
 )
 starlark_repository.archive(
-    name = "bzl.jq.bzl---0.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.1.0/jq.bzl-v0.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.jq.bzl---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10189,6 +10264,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.jq.bzl---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jq.bzl-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.1.0/jq.bzl-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jq.bzl---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10198,15 +10282,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.0/jq.bzl-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.jsinterop_base---1.2.0-RC1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jsinterop-base-1.2.0-RC1",
-    type = "tar.gz",
-    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.jsinterop_base---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10214,6 +10289,15 @@ starlark_repository.archive(
     strip_prefix = "jsinterop-base-1.1.1",
     type = "tar.gz",
     urls = ["https://github.com/google/jsinterop-base/releases/download/1.1.1/jsinterop-base-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.jsinterop_base---1.2.0-RC1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jsinterop-base-1.2.0-RC1",
+    type = "tar.gz",
+    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsinterop_generator---20250910",
@@ -10315,15 +10399,6 @@ starlark_repository.archive(
     urls = ["https://github.com/yuyawk/libc_replacer/releases/download/0.1.3/libc_replacer-0.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libdeflate---1.25",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "libdeflate-1.25",
-    type = "tar.gz",
-    urls = ["https://github.com/ebiggers/libdeflate/releases/download/v1.25/libdeflate-1.25.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.libdeflate---1.23",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10331,6 +10406,15 @@ starlark_repository.archive(
     strip_prefix = "libdeflate-1.23",
     type = "tar.gz",
     urls = ["https://github.com/ebiggers/libdeflate/releases/download/v1.23/libdeflate-1.23.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.libdeflate---1.25",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "libdeflate-1.25",
+    type = "tar.gz",
+    urls = ["https://github.com/ebiggers/libdeflate/releases/download/v1.25/libdeflate-1.25.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libdwarf---0.12.0.bcr.1",
@@ -10367,15 +10451,6 @@ starlark_repository.archive(
     strip_prefix = "libpfm-4.11.0",
     type = "tar.gz",
     urls = ["https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.libpfm---4.11.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "libpfm-4.11.0",
-    type = "tar.gz",
-    urls = ["https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libpng---1.6.41",
@@ -10468,13 +10543,13 @@ starlark_repository.archive(
     urls = ["https://github.com/webmproject/libwebp/archive/refs/tags/v1.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libx11---1.8.12.bcr.5",
+    name = "bzl.libx11---1.8.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     strip_prefix = "libx11-libX11-1.8.12",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/libx11/archive/refs/tags/libX11-1.8.12.tar.gz"],
+    urls = ["https://gitlab.freedesktop.org/xorg/lib/libx11/-/archive/libX11-1.8.12/libx11-libX11-1.8.12.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libxau---1.0.12.bcr.2",
@@ -10531,12 +10606,12 @@ starlark_repository.archive(
     urls = ["https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.lit2md---0.2.3",
+    name = "bzl.lit2md---1.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/filmil/lit2md/releases/download/v0.2.3/lit2md-v0.2.3.zip"],
+    urls = ["https://github.com/filmil/lit2md/releases/download/v1.0.1/lit2md-v1.0.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.llvm-project---17.0.3.bcr.4",
@@ -10736,12 +10811,12 @@ starlark_repository.archive(
     urls = ["https://github.com/ng-log/ng-log/archive/refs/tags/v0.8.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.6.1",
+    name = "bzl.nlohmann_json---3.11.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
 )
 starlark_repository.archive(
     name = "bzl.nlohmann_json---3.12.0.bcr.1",
@@ -10752,20 +10827,12 @@ starlark_repository.archive(
     urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.11.3.bcr.1",
+    name = "bzl.nlohmann_json---3.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.11.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip"],
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
 )
 starlark_repository.archive(
     name = "bzl.nogo_analyzer_bzlmod---0.1.0",
@@ -10793,6 +10860,15 @@ starlark_repository.archive(
     strip_prefix = "octomap-1.9.7",
     type = "tar.gz",
     urls = ["https://github.com/OctoMap/octomap/archive/refs/tags/v1.9.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.octomap---1.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "octomap-1.10.0",
+    type = "zip",
+    urls = ["https://github.com/OctoMap/octomap/releases/download/v1.10.0/octomap-1.10.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.ode---0.16.6.bcr.1",
@@ -10876,15 +10952,6 @@ starlark_repository.archive(
     urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/refs/tags/v0.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.openconfig_attestz---0.6.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "attestz-0.6.8",
-    type = "tar.gz",
-    urls = ["https://github.com/openconfig/attestz/archive/refs/tags/v0.6.8.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.openconfig_attestz---0.6.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10892,6 +10959,15 @@ starlark_repository.archive(
     strip_prefix = "attestz-0.6.10",
     type = "tar.gz",
     urls = ["https://github.com/openconfig/attestz/archive/refs/tags/v0.6.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.openconfig_attestz---0.6.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "attestz-0.6.8",
+    type = "tar.gz",
+    urls = ["https://github.com/openconfig/attestz/archive/refs/tags/v0.6.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.openconfig_bootz---0.7.0",
@@ -10930,15 +11006,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openconfig/gnoi/archive/refs/tags/v0.6.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.openconfig_gnsi---1.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gnsi-1.9.1",
-    type = "tar.gz",
-    urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.openconfig_gnsi---1.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10946,6 +11013,15 @@ starlark_repository.archive(
     strip_prefix = "gnsi-1.9.0",
     type = "tar.gz",
     urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.openconfig_gnsi---1.9.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gnsi-1.9.1",
+    type = "tar.gz",
+    urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.openexr---3.3.3.bcr.1",
@@ -11011,15 +11087,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openssl/openssl/releases/download/openssl-3.5.4/openssl-3.5.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.24.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.24.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11036,6 +11103,33 @@ starlark_repository.archive(
     strip_prefix = "opentelemetry-cpp-1.19.0",
     type = "tar.gz",
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-cpp---1.24.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-cpp-1.24.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-proto---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-proto-1.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-proto-1.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.1.0",
@@ -11065,24 +11159,6 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.3.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.opentracing-cpp---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11101,12 +11177,12 @@ starlark_repository.archive(
     urls = ["https://github.com/google/or-tools/releases/download/v9.15/or-tools-9.15.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.osqp---0.6.3.bcr.3",
+    name = "bzl.osqp---1.0.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/osqp/osqp/releases/download/v0.6.3/osqp-v0.6.3-src.tar.gz"],
+    urls = ["https://github.com/osqp/osqp/releases/download/v1.0.0/osqp-v1.0.0-src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.osqp-eigen---0.10.3",
@@ -11206,6 +11282,14 @@ starlark_repository.archive(
     urls = ["https://github.com/tzaeschke/phtree-cpp/releases/download/v1.7.0/phtree-cpp-v1.7.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.pico-sdk---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/raspberrypi/pico-sdk/releases/download/2.1.0/pico-sdk-2.1.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.pico-sdk---2.2.2-develop.bcr.20260420-79b38e95",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11215,12 +11299,13 @@ starlark_repository.archive(
     urls = ["https://github.com/raspberrypi/pico-sdk/archive/79b38e9543116e9be524388ae4650393e6453026.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pico-sdk---2.1.0",
+    name = "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "picotool-d1a8d35da3f622cf228c0a17e9b7a4295d5282d0",
     type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/pico-sdk/releases/download/2.1.0/pico-sdk-2.1.0.tar.gz"],
+    urls = ["https://github.com/raspberrypi/picotool/archive/d1a8d35da3f622cf228c0a17e9b7a4295d5282d0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.picotool---2.1.0",
@@ -11240,15 +11325,6 @@ starlark_repository.archive(
     urls = ["https://github.com/raspberrypi/picotool/releases/download/2.2.0/picotool-2.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "picotool-d1a8d35da3f622cf228c0a17e9b7a4295d5282d0",
-    type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/picotool/archive/d1a8d35da3f622cf228c0a17e9b7a4295d5282d0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pixelmatch-cpp17---1.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11264,6 +11340,22 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.5",
@@ -11290,36 +11382,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.platforms---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms_contrib---0.2.3",
@@ -11385,87 +11461,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/proto-converter/archive/d77ff301f48bf2e7a0f8935315e847c1a8e00017.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---30.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.4/protobuf-33.4.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---24.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-24.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---35.0-rc1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-35.0-rc1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0-rc1/protobuf-35.0-rc1.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---34.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-34.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.2",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.protobuf---34.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11473,33 +11468,6 @@ starlark_repository.archive(
     strip_prefix = "protobuf-34.0",
     type = "tar.gz",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protobuf-34.0.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---32.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-32.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---3.19.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-3.19.6",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.5",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---33.2",
@@ -11511,22 +11479,31 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.5",
+    name = "bzl.protobuf---30.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.5",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
+    strip_prefix = "protobuf-30.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---31.1",
+    name = "bzl.protobuf---24.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.1",
+    strip_prefix = "protobuf-24.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.2",
     type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---32.0",
@@ -11538,6 +11515,69 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.protobuf---31.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---34.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-34.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-30.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---31.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---3.19.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-3.19.6",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.4/protobuf-33.4.bazel.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.protobuf---3.19.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11547,13 +11587,13 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---31.0",
+    name = "bzl.protobuf---33.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
+    strip_prefix = "protobuf-33.5",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---30.2",
@@ -11565,13 +11605,49 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---26.0.bcr.2",
+    name = "bzl.protobuf---32.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-26.0",
+    strip_prefix = "protobuf-32.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---35.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-35.0-rc1",
     type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v26.0/protobuf-26.0.tar.gz"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0-rc1/protobuf-35.0-rc1.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.5",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.0-rc1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0-rc1/protobuf-33.0-rc1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf-matchers---0.1.2",
@@ -11599,15 +11675,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protoc-gen-validate---1.2.1.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protoc-gen-validate-1.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.protoc-gen-validate---1.0.4.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11615,6 +11682,15 @@ starlark_repository.archive(
     strip_prefix = "protoc-gen-validate-1.0.4",
     type = "tar.gz",
     urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protoc-gen-validate---1.2.1.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protoc-gen-validate-1.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protothreads---0.1.6",
@@ -11625,15 +11701,6 @@ starlark_repository.archive(
     urls = ["https://github.com/JalonWong/protothreads/releases/download/v0.1.6/protothreads-v0.1.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protovalidate---1.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protovalidate-1.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/protovalidate/releases/download/v1.2.0/protovalidate-1.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.protovalidate---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11641,6 +11708,15 @@ starlark_repository.archive(
     strip_prefix = "protovalidate-1.1.1",
     type = "tar.gz",
     urls = ["https://github.com/bufbuild/protovalidate/releases/download/v1.1.1/protovalidate-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protovalidate---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protovalidate-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/protovalidate/releases/download/v1.2.0/protovalidate-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protovalidate-cc---1.1.0",
@@ -11697,33 +11773,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_abseil/releases/download/v202402.0/pybind11_abseil-202402.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.12.0",
-    type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.pybind11_bazel---3.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-3.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.11.1.bzl.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.11.1.bzl.2",
-    type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_bazel---3.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11733,13 +11782,13 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.1/pybind11_bazel-3.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.13.6",
+    name = "bzl.pybind11_bazel---2.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.13.6",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
+    strip_prefix = "pybind11_bazel-2.12.0",
+    type = "zip",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.11.1",
@@ -11751,13 +11800,31 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
+    name = "bzl.pybind11_bazel---2.13.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_protobuf-f02a2b7653bc50eb5119d125842a3870db95d251",
+    strip_prefix = "pybind11_bazel-2.13.6",
     type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---2.11.1.bzl.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-2.11.1.bzl.2",
+    type = "zip",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---3.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-3.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
@@ -11769,13 +11836,22 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_protobuf/archive/1d7a7296604537db5f6ace2ddafd1d08c967ec63.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.qdldl---0.1.8.bcr.1",
+    name = "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "qdldl-0.1.8",
+    strip_prefix = "pybind11_protobuf-f02a2b7653bc50eb5119d125842a3870db95d251",
     type = "tar.gz",
-    urls = ["https://github.com/osqp/qdldl/archive/refs/tags/v0.1.8.tar.gz"],
+    urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.qdldl---0.1.7.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "qdldl-0.1.7",
+    type = "tar.gz",
+    urls = ["https://github.com/osqp/qdldl/archive/refs/tags/v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.quill---11.1.0",
@@ -11832,13 +11908,13 @@ starlark_repository.archive(
     urls = ["https://github.com/jvolkman/re.bzl/releases/download/v0.2.0/re.bzl-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2023-09-01",
+    name = "bzl.re2---2025-11-05.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "re2-2023-09-01",
+    strip_prefix = "re2-2025-11-05",
     type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.zip"],
+    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
 )
 starlark_repository.archive(
     name = "bzl.re2---2025-08-12.bcr.1",
@@ -11850,24 +11926,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2025-08-12/re2-2025-08-12.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2024-07-02.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-07-02",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.re2---2025-11-05.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2025-11-05",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
-)
-starlark_repository.archive(
     name = "bzl.re2---2021-09-01",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11877,13 +11935,31 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2024-02-01",
+    name = "bzl.re2---2023-09-01",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-02-01",
+    strip_prefix = "re2-2023-09-01",
     type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-02-01/re2-2024-02-01.zip"],
+    urls = ["https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2024-07-02.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2024-07-02",
+    type = "zip",
+    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2024-04-01",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2024-04-01",
+    type = "zip",
+    urls = ["https://github.com/google/re2/releases/download/2024-04-01/re2-2024-04-01.zip"],
 )
 starlark_repository.archive(
     name = "bzl.readerwriterqueue---1.0.6",
@@ -11904,15 +11980,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Celtoys/Remotery/archive/refs/tags/v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.riegeli---0.0.0-20250822-9f2744d",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "riegeli-9f2744dc23e81d84c02f6f51244e9e9bb9802d57",
-    type = "tar.gz",
-    urls = ["https://github.com/google/riegeli/archive/9f2744dc23e81d84c02f6f51244e9e9bb9802d57.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.riegeli---0.0.0-20240927-cdfb25a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11920,6 +11987,15 @@ starlark_repository.archive(
     strip_prefix = "riegeli-cdfb25afbc3a024a57156d7f4f3a98bcf239d278",
     type = "tar.gz",
     urls = ["https://github.com/google/riegeli/archive/cdfb25afbc3a024a57156d7f4f3a98bcf239d278.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.riegeli---0.0.0-20250822-9f2744d",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "riegeli-9f2744dc23e81d84c02f6f51244e9e9bb9802d57",
+    type = "tar.gz",
+    urls = ["https://github.com/google/riegeli/archive/9f2744dc23e81d84c02f6f51244e9e9bb9802d57.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.robin-map---1.4.0",
@@ -11967,6 +12043,15 @@ starlark_repository.archive(
     urls = ["https://github.com/michaeljs1990/rules_abs/releases/download/0.1.0/rules_abs-0.1.0.tar"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_android---0.6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_android---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11976,13 +12061,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.7.1",
+    name = "bzl.rules_android---0.7.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.1",
+    strip_prefix = "rules_android-0.7.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android---0.6.4",
@@ -11994,22 +12079,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.4/rules_android-v0.6.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.6.6",
+    name = "bzl.rules_android---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.6.6",
+    strip_prefix = "rules_android-0.7.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_android---0.7.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android_ndk---0.1.5",
@@ -12030,13 +12106,13 @@ starlark_repository.archive(
     urls = ["https://github.com/devversion/rules_angular/releases/download/v0.1.0/rules_angular-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apko---1.5.44",
+    name = "bzl.rules_apko---1.5.45",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_apko-1.5.44",
+    strip_prefix = "rules_apko-1.5.45",
     type = "tar.gz",
-    urls = ["https://github.com/chainguard-dev/rules_apko/releases/download/v1.5.44/rules_apko-v1.5.44.tar.gz"],
+    urls = ["https://github.com/chainguard-dev/rules_apko/releases/download/v1.5.45/rules_apko-v1.5.45.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_appimage---1.20.0",
@@ -12048,12 +12124,28 @@ starlark_repository.archive(
     urls = ["https://github.com/lalten/rules_appimage/releases/download/v1.20.0/rules_appimage-v1.20.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---3.16.0",
+    name = "bzl.rules_apple---4.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---3.13.0",
@@ -12064,28 +12156,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.3",
+    name = "bzl.rules_apple---3.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.5.2",
@@ -12104,20 +12180,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.1.0/rules_apple.4.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.1",
+    name = "bzl.rules_apple---3.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---3.5.0",
+    name = "bzl.rules_apple---3.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.3.3",
@@ -12128,12 +12204,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.0",
+    name = "bzl.rules_apple---4.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.5.0",
@@ -12195,20 +12271,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.37.1/rules_bazel_integration_test.v0.37.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_bison---0.4.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.4/rules_bison-v0.4.tar.xz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_bison---0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.3/rules_bison-v0.3.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_bison---0.4.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.4/rules_bison-v0.4.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_browsers---0.4.0",
@@ -12228,15 +12304,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bfreis/rules_bsx/releases/download/v1.0.1/rules_bsx-v1.0.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_buf---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_buf-0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.3.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_buf---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12244,6 +12311,15 @@ starlark_repository.archive(
     strip_prefix = "rules_buf-abbbfce7c3fccf1d4b87afa28140d9ce53f80057",
     type = "zip",
     urls = ["https://github.com/bufbuild/rules_buf/archive/abbbfce7c3fccf1d4b87afa28140d9ce53f80057.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_buf---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_buf-0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_buf---0.5.2",
@@ -12272,42 +12348,6 @@ starlark_repository.archive(
     urls = ["https://github.com/JalonWong/rules_c_proto/releases/download/v0.1.0/rules_c_proto-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.15",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.15",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.13",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.13",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cc---0.2.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12326,6 +12366,24 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_cc---0.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12335,39 +12393,57 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.4",
+    name = "bzl.rules_cc---0.2.13",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.4",
+    strip_prefix = "rules_cc-0.2.13",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.12",
+    name = "bzl.rules_cc---0.2.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.12",
+    strip_prefix = "rules_cc-0.2.9",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.2",
+    name = "bzl.rules_cc---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.5",
+    name = "bzl.rules_cc---0.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.5",
+    strip_prefix = "rules_cc-0.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.16",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.17",
@@ -12406,6 +12482,50 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.15",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.15",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.12",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_cc---0.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12415,32 +12535,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.6",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.16",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.16",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cc---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12448,24 +12542,6 @@ starlark_repository.archive(
     strip_prefix = "rules_cc-0.1.1",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.10.0",
@@ -12518,15 +12594,6 @@ starlark_repository.archive(
     urls = ["https://github.com/semolina-solutions/rules_ciq/releases/download/0.2.0/rules_ciq-0.2.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_closure---0.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_closure-0.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_closure/releases/download/0.15.0/rules_closure-0.15.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_closure---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12534,6 +12601,15 @@ starlark_repository.archive(
     strip_prefix = "rules_closure-0.16.0",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_closure/releases/download/0.16.0/rules_closure-0.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_closure---0.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_closure-0.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_closure/releases/download/0.15.0/rules_closure-0.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_codeowners---0.2.1",
@@ -12581,15 +12657,6 @@ starlark_repository.archive(
     urls = ["https://github.com/lalten/rules_cpan/releases/download/v1.1.0/rules_cpan-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cuda---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cuda-v0.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.2.4/rules_cuda-v0.2.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cuda---0.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12597,6 +12664,15 @@ starlark_repository.archive(
     strip_prefix = "rules_cuda-v0.3.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.3.0/rules_cuda-v0.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cuda---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cuda-v0.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.2.4/rules_cuda-v0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cuda---0.2.5",
@@ -12750,15 +12826,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kczulko/rules_elm/releases/download/v1.1.1/rules_elm-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_erlang---3.10.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_erlang-3.10.5",
-    type = "tar.gz",
-    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.10.5/rules_erlang-3.10.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_erlang---3.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12766,6 +12833,15 @@ starlark_repository.archive(
     strip_prefix = "rules_erlang-3.16.0",
     type = "tar.gz",
     urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.16.0/rules_erlang-3.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_erlang---3.10.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_erlang-3.10.5",
+    type = "tar.gz",
+    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.10.5/rules_erlang-3.10.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_flex---0.4.1",
@@ -12792,15 +12868,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.3/rules_flex-v0.3.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_foreign_cc---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_foreign_cc-0.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_foreign_cc---0.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12808,6 +12875,15 @@ starlark_repository.archive(
     strip_prefix = "rules_foreign_cc-0.12.0",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_foreign_cc---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_foreign_cc-0.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_formatjs---0.5.0",
@@ -12819,15 +12895,6 @@ starlark_repository.archive(
     urls = ["https://github.com/formatjs/rules_formatjs/releases/download/v0.5.0/rules_formatjs-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_fuzzing---0.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_fuzzing-0.5.2",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_fuzzing---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12835,6 +12902,15 @@ starlark_repository.archive(
     strip_prefix = "rules_fuzzing-v0.6.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_fuzzing/releases/download/v0.6.0/rules_fuzzing-v0.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_fuzzing---0.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_fuzzing-0.5.2",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_gazebo---0.0.6",
@@ -12891,76 +12967,20 @@ starlark_repository.archive(
     urls = ["https://github.com/iocat/rules_gleam/releases/download/v0.1.14/rules_gleam-v0.1.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.41.0",
+    name = "bzl.rules_go---0.51.0-rc1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.59.0",
+    name = "bzl.rules_go---0.52.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.57.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.54.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.39.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.60.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.54.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.53.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.51.0",
@@ -12979,20 +12999,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.58.3",
+    name = "bzl.rules_go---0.60.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.48.0",
@@ -13003,14 +13015,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_go---0.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13019,28 +13023,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.50.1",
+    name = "bzl.rules_go---0.51.0-rc2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.52.0",
+    name = "bzl.rules_go---0.53.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc1",
+    name = "bzl.rules_go---0.59.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.54.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.41.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.58.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.43.0",
@@ -13051,12 +13079,60 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_go---0.54.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.57.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
+)
+starlark_repository.archive(
     name = "bzl.rules_go---0.49.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.50.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_graalvm---0.11.1",
@@ -13094,12 +13170,12 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_helm/releases/download/0.24.0/rules_helm-v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_img---0.3.8",
+    name = "bzl.rules_img---0.3.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.8/rules_img-v0.3.8.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.9/rules_img-v0.3.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_img---0.3.3",
@@ -13110,20 +13186,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.3/rules_img-v0.3.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_img_pull_tool---0.3.8",
+    name = "bzl.rules_img_pull_tool---0.3.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.8/rules_img_pull_tool-v0.3.8.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.9/rules_img_pull_tool-v0.3.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_img_tool---0.3.8",
+    name = "bzl.rules_img_tool---0.3.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.8/rules_img_tool-v0.3.8.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.9/rules_img_tool-v0.3.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ios---6.0.1",
@@ -13160,172 +13236,12 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_itest/releases/download/v0.0.52/rules_itest-v0.0.52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_java---7.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---5.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.9.0/rules_java-8.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.6.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---5.3.5",
@@ -13336,12 +13252,68 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---4.0.0",
+    name = "bzl.rules_java---6.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.11.0",
@@ -13352,6 +13324,94 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.11.0/rules_java-8.11.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_java---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---5.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.15.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.15.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_java---9.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13360,12 +13420,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.13.0",
+    name = "bzl.rules_java---7.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.9.0/rules_java-8.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jni---0.11.1",
@@ -13419,33 +13495,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.1/rules_jvm_external-6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.6",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13453,15 +13502,6 @@ starlark_repository.archive(
     strip_prefix = "rules_jvm_external-6.5",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---4.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-4.4.2",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.8",
@@ -13482,22 +13522,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.9",
+    name = "bzl.rules_jvm_external---6.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.9",
+    strip_prefix = "rules_jvm_external-6.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.9/rules_jvm_external-6.9.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.1",
+    name = "bzl.rules_jvm_external---7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.1",
+    strip_prefix = "rules_jvm_external-7.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---4.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-4.4.2",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.7",
@@ -13509,6 +13558,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_jvm_external---5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13518,13 +13576,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.3",
+    name = "bzl.rules_jvm_external---5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.3",
+    strip_prefix = "rules_jvm_external-5.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.9/rules_jvm_external-6.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kconfig---0.3.1",
@@ -13535,20 +13611,20 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_kconfig/releases/download/0.3.1/rules_kconfig-0.3.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.3.0",
+    name = "bzl.rules_kotlin---2.3.20",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.1.9",
+    name = "bzl.rules_kotlin---2.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.9/rules_kotlin-v2.1.9.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kotlin---2.2.2",
@@ -13567,28 +13643,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.1.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.9/rules_kotlin-v2.1.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_kotlin---1.9.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.3.20",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.1.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kustomize---0.5.3",
@@ -13624,28 +13700,12 @@ starlark_repository.archive(
     urls = ["https://github.com/pigweed-project/rules_libusb/releases/download/v0.1.0-rc2/rules_libusb-8720113729935528369-7f91dc339a79292ab8aa5ca127572e54b0b586e8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_license---0.0.7",
+    name = "bzl.rules_license---0.0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_license---0.0.3",
@@ -13656,20 +13716,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_license---0.0.4",
+    name = "bzl.rules_license---0.0.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_m4---0.3.1",
+    name = "bzl.rules_license---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_license---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.3.bcr.1",
@@ -13678,6 +13746,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3/rules_m4-v0.3.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_m4---0.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.2.3",
@@ -13740,15 +13816,6 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/rules_multirun/releases/download/0.13.0/rules_multirun.0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-0.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_multitool---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13758,13 +13825,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---0.11.0",
+    name = "bzl.rules_multitool---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-0.11.0",
+    strip_prefix = "rules_multitool-0.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_multitool---1.11.1",
@@ -13783,6 +13850,15 @@ starlark_repository.archive(
     strip_prefix = "rules_multitool-1.9.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_multitool---0.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_multitool-0.11.0",
+    type = "tar.gz",
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mypy---0.40.0",
@@ -13828,57 +13904,21 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.13.0/rules_nixpkgs-0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.2.0",
+    name = "bzl.rules_nodejs---5.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.4",
+    name = "bzl.rules_nodejs---6.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.4",
+    strip_prefix = "rules_nodejs-6.3.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---5.8.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-core-5.8.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.5.0",
@@ -13890,12 +13930,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---5.5.3",
+    name = "bzl.rules_nodejs---6.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.7.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.7.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.5.2",
@@ -13916,22 +13975,21 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.2",
+    name = "bzl.rules_nodejs---5.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-core-5.8.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.3",
+    name = "bzl.rules_nodejs---6.3.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.3",
+    strip_prefix = "rules_nodejs-6.3.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---5.8.2",
@@ -13942,13 +14000,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_oci---2.3.0",
+    name = "bzl.rules_nodejs---6.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-2.3.0",
+    strip_prefix = "rules_nodejs-6.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_oci---1.6.0",
@@ -13978,6 +14045,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.0/rules_oci-v2.2.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_oci---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-2.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_openscad---0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13996,13 +14072,13 @@ starlark_repository.archive(
     urls = ["https://github.com/opicaud/rules_pact/releases/download/v1.1.9/rules_pact-v1.1.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---0.2.4",
+    name = "bzl.rules_perl---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.2.4",
+    strip_prefix = "rules_perl-0.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---1.1.0",
@@ -14013,13 +14089,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---0.5.0",
+    name = "bzl.rules_perl---0.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.5.0",
+    strip_prefix = "rules_perl-0.2.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.5.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pex---0.1.1",
@@ -14039,20 +14115,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bookingcom/rules_pitest/releases/download/v0.0.2/rules_mylang-v0.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.0.1",
+    name = "bzl.rules_pkg---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_pkg---0.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg---0.7.0",
@@ -14063,12 +14131,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.2.0",
+    name = "bzl.rules_pkg---0.9.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg---1.1.0",
@@ -14158,13 +14234,13 @@ starlark_repository.archive(
     urls = ["https://github.com/hexdae/rules_probe_rs/releases/download/v0.0.6/rules_probe_rs-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---6.0.2",
+    name = "bzl.rules_proto---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-6.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
+    strip_prefix = "rules_proto-4.0.0",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---7.1.0",
@@ -14176,6 +14252,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_proto---5.3.0-21.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-5.3.0-21.7",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_proto---7.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14185,6 +14270,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_proto---6.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-6.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_proto---6.0.0-rc1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14192,24 +14286,6 @@ starlark_repository.archive(
     strip_prefix = "rules_proto-6.0.0-rc1",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-4.0.0",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---5.3.0-21.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-5.3.0-21.7",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc---5.0.0",
@@ -14374,12 +14450,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.4.0",
+    name = "bzl.rules_python---0.10.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-0.10.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_python---1.7.0",
@@ -14391,31 +14468,39 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.7.0/rules_python-1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.10.2",
+    name = "bzl.rules_python---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.10.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.22.1",
+    name = "bzl.rules_python---0.17.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.22.1",
+    strip_prefix = "rules_python-0.17.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.22.1/rules_python-0.22.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python_gazelle_plugin---0.31.0",
+    name = "bzl.rules_python_gazelle_plugin---1.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.31.0/gazelle",
+    strip_prefix = "rules_python-1.4.0/gazelle",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.31.0/rules_python-0.31.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.4.0/rules_python-1.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_qemu---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_qemu-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.1.0/rules_qemu-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_qt---0.0.6",
@@ -14453,13 +14538,31 @@ starlark_repository.archive(
     urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/v4.16.1/robolectric-bazel-v4.16.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.64",
+    name = "bzl.rules_rs---0.0.68",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.64",
+    strip_prefix = "rules_rs-0.0.68",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.64/rules_rs-v0.0.64.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rs---0.0.61",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_rs-0.0.61",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.61/rules_rs-v0.0.61.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_ruby---0.25.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ruby-0.25.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_ruby/releases/download/v0.25.0/rules_ruby-v0.25.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ruby---0.19.0",
@@ -14471,13 +14574,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_ruby/releases/download/v0.19.0/rules_ruby-v0.19.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_ruby---0.25.0",
+    name = "bzl.rules_runfiles_group---0.0.1-rc.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_ruby-0.25.0",
+    strip_prefix = "rules_runfiles_group-0.0.1-rc.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_ruby/releases/download/v0.25.0/rules_ruby-v0.25.0.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.2/rules_runfiles_group-v0.0.1-rc.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust---0.51.0",
@@ -14496,12 +14599,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.45.1/rules_rust-v0.45.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.49.3",
+    name = "bzl.rules_rust---0.50.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.49.3/rules_rust-v0.49.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.50.1/rules_rust-v0.50.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_mutants---0.69.1",
@@ -14565,13 +14668,13 @@ starlark_repository.archive(
     urls = ["https://github.com/Ryang20718/rules_s5/releases/download/v0.0.13/rules_s5-0.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.2.4",
+    name = "bzl.rules_scala---7.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.2.4",
+    strip_prefix = "rules_scala-7.2.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.4/rules_scala-v7.2.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.0.0",
@@ -14581,6 +14684,15 @@ starlark_repository.archive(
     strip_prefix = "rules_scala-7.0.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.4/rules_scala-v7.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.1.5",
@@ -14601,22 +14713,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.3/rules_scala-v7.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.2.2",
+    name = "bzl.rules_scala---7.2.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.2.2",
+    strip_prefix = "rules_scala-7.2.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_scala---7.1.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.1.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.4/rules_scala-v7.1.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.3/rules_scala-v7.2.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala_native---0.1.0",
@@ -14628,15 +14731,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Programming-Rivers/rules_scala_native/releases/download/v0.1.0/rules_scala_native-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_sh---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_sh-0.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/tweag/rules_sh/releases/download/v0.5.0/rules_sh-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_sh---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14644,6 +14738,15 @@ starlark_repository.archive(
     strip_prefix = "rules_sh-0.4.0",
     type = "tar.gz",
     urls = ["https://github.com/tweag/rules_sh/releases/download/v0.4.0/rules_sh-0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_sh---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_sh-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/tweag/rules_sh/releases/download/v0.5.0/rules_sh-0.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shar---1.0.0",
@@ -14654,13 +14757,13 @@ starlark_repository.archive(
     urls = ["https://github.com/filmil/rules_shar/releases/download/v1.0.0/rules_shar-v1.0.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.3.0",
+    name = "bzl.rules_shell---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.3.0",
+    strip_prefix = "rules_shell-0.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.0/rules_shell-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.6.1",
@@ -14672,13 +14775,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.5.1",
+    name = "bzl.rules_shell---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.5.1",
+    strip_prefix = "rules_shell-0.7.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.1/rules_shell-v0.5.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.2.0",
@@ -14699,22 +14811,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.8.0/rules_shell-v0.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.5.0",
+    name = "bzl.rules_shell---0.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.5.0",
+    strip_prefix = "rules_shell-0.5.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.0/rules_shell-v0.4.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.1/rules_shell-v0.5.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.4.1",
@@ -14726,21 +14829,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.7.1",
+    name = "bzl.rules_shell---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.7.1",
+    strip_prefix = "rules_shell-0.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shellcheck---0.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.6.2/rules_shellcheck-0.6.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellcheck---0.3.3",
@@ -14749,6 +14844,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.3.3/rules_shellcheck-0.3.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shellcheck---0.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.6.2/rules_shellcheck-0.6.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellspec---0.1.6",
@@ -14786,14 +14889,6 @@ starlark_repository.archive(
     urls = ["https://github.com/tharakadesilva/rules_spring_aot/releases/download/v0.1.0/rules_spring_aot-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_swift---3.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14802,12 +14897,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.3.0/rules_swift.3.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.1.2",
+    name = "bzl.rules_swift---3.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.0.2",
@@ -14818,12 +14921,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.0",
+    name = "bzl.rules_swift---3.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---1.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.2/rules_swift.3.4.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.1/rules_swift.3.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---2.3.0",
@@ -14842,44 +14985,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.1",
+    name = "bzl.rules_swift_package_manager---1.15.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.1/rules_swift.3.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.2/rules_swift.3.4.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
+    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.15.0/rules_swift_package_manager.v1.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_package_manager---1.9.0",
@@ -14888,14 +14999,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.9.0/rules_swift_package_manager.v1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift_package_manager---1.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.15.0/rules_swift_package_manager.v1.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_previews---0.1.1",
@@ -14993,15 +15096,6 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_typst/releases/download/0.2.0/rules_typst-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_uv---0.21.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_uv-0.21.0",
-    type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_uv---0.44.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15009,6 +15103,15 @@ starlark_repository.archive(
     strip_prefix = "rules_uv-0.44.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_uv---0.21.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_uv-0.21.0",
+    type = "tar.gz",
+    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_uv---0.89.2",
@@ -15020,28 +15123,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_venv---0.17.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_venv---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.16.0/rules_venv-0.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_venv---0.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.12.0/rules_venv-0.12.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_venv---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_venv---0.15.0",
@@ -15052,20 +15147,20 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.15.0/rules_venv-0.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_venv---0.17.0",
+    name = "bzl.rules_venv---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_verilator---0.3.2",
+    name = "bzl.rules_venv---0.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.12.0/rules_venv-0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilator---0.1.0",
@@ -15075,6 +15170,14 @@ starlark_repository.archive(
     strip_prefix = "bazel_rules_verilator-0.1.0",
     type = "tar.gz",
     urls = ["https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.1.0/bazel_rules_verilator-0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_verilator---0.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilog---1.1.1",
@@ -15154,13 +15257,13 @@ starlark_repository.archive(
     urls = ["https://github.com/ekhabarov/rules_ytt/releases/download/v0.4.0/rules_ytt-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_zig---0.13.0",
+    name = "bzl.rules_zig---0.14.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_zig-0.13.0",
+    strip_prefix = "rules_zig-0.14.0",
     type = "tar.gz",
-    urls = ["https://github.com/aherrmann/rules_zig/releases/download/v0.13.0/rules_zig-0.13.0.tar.gz"],
+    urls = ["https://github.com/aherrmann/rules_zig/releases/download/v0.14.0/rules_zig-0.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ruy---0.0.0-20200416-9f53ba4",
@@ -15208,15 +15311,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.sdformat---16.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "sdformat-sdformat16_16.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.sdformat---16.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15224,6 +15318,15 @@ starlark_repository.archive(
     strip_prefix = "sdformat-sdformat16_16.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.sdformat---16.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "sdformat-sdformat16_16.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.sha256.bzl---0.0.1",
@@ -15261,15 +15364,6 @@ starlark_repository.archive(
     urls = ["https://github.com/apache/skywalking-data-collect-protocol/archive/refs/tags/v10.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.snappy---1.2.2.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "snappy-1.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.snappy---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15279,22 +15373,22 @@ starlark_repository.archive(
     urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.snappy---1.1.8",
+    name = "bzl.snappy---1.2.2.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "snappy-1.1.8",
+    strip_prefix = "snappy-1.2.2",
     type = "tar.gz",
-    urls = ["https://github.com/google/snappy/archive/refs/tags/1.1.8.tar.gz"],
+    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.soplex---7.1.3",
+    name = "bzl.soplex---7.1.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "soplex-release-713",
+    strip_prefix = "soplex-release-712",
     type = "tar.gz",
-    urls = ["https://github.com/scipopt/soplex/archive/refs/tags/release-713.tar.gz"],
+    urls = ["https://github.com/scipopt/soplex/archive/refs/tags/release-712.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.sourcekit_bazel_bsp---0.8.3",
@@ -15331,15 +15425,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ryanli/sparrowhawk/releases/download/v2.1.0/sparrowhawk-2.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.spdlog---1.10.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "spdlog-1.10.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.spdlog---1.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15365,6 +15450,15 @@ starlark_repository.archive(
     strip_prefix = "spdlog-1.17.0",
     type = "tar.gz",
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.17.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.spdlog---1.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "spdlog-1.10.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.sphinxdocs---2.0.0",
@@ -15403,13 +15497,13 @@ starlark_repository.archive(
     urls = ["https://sqlite.org/2025/sqlite-amalgamation-3500300.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.sqlite3---3.50.1",
+    name = "bzl.sqlite3---3.51.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "sqlite-amalgamation-3500100",
+    strip_prefix = "sqlite-amalgamation-3510000",
     type = "zip",
-    urls = ["https://sqlite.org/2025/sqlite-amalgamation-3500100.zip"],
+    urls = ["https://sqlite.org/2025/sqlite-amalgamation-3510000.zip"],
 )
 starlark_repository.archive(
     name = "bzl.squashfs-tools---4.7.4",
@@ -15421,28 +15515,12 @@ starlark_repository.archive(
     urls = ["https://github.com/plougher/squashfs-tools/releases/download/4.7.4/squashfs-tools-4.7.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.7.2",
+    name = "bzl.stardoc---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.2/stardoc-0.7.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.5.3",
@@ -15453,44 +15531,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.5.0",
+    name = "bzl.stardoc---0.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.8.1",
@@ -15501,12 +15547,60 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.stardoc---0.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.5.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.stardoc---0.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.2/stardoc-0.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.subspace---2.5.0",
@@ -15518,13 +15612,13 @@ starlark_repository.archive(
     urls = ["https://github.com/dallison/subspace/releases/download/2.5.0/subspace-2.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.supply-chain-go---0.0.7",
+    name = "bzl.supply-chain-go---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.7/lib/supplychain-go",
+    strip_prefix = "supply-chain-0.0.10/lib/supplychain-go",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.7/supply-chain-v0.0.7.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.10/supply-chain-v0.0.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.supply-chain-go---0.0.6",
@@ -15572,15 +15666,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kateinoigakukun/swift-indexstore/archive/refs/tags/0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swift-syntax---603.0.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-syntax-603.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.swift-syntax---603.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15588,6 +15673,15 @@ starlark_repository.archive(
     strip_prefix = "swift-syntax-603.0.1",
     type = "tar.gz",
     urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.swift-syntax---603.0.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "swift-syntax-603.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swift-system---1.6.4.bcr.1",
@@ -15608,15 +15702,6 @@ starlark_repository.archive(
     urls = ["https://github.com/dduan/TOMLDecoder/archive/refs/tags/0.4.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swift_argument_parser---1.3.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-argument-parser-1.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.3.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.swift_argument_parser---1.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15626,13 +15711,13 @@ starlark_repository.archive(
     urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swift_argument_parser---1.6.2",
+    name = "bzl.swift_argument_parser---1.3.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "swift-argument-parser-1.6.2",
+    strip_prefix = "swift-argument-parser-1.3.1",
     type = "tar.gz",
-    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.6.2.tar.gz"],
+    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.3.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swift_bep_parser---0.0.6",
@@ -15659,13 +15744,13 @@ starlark_repository.archive(
     urls = ["https://github.com/realm/SwiftLint/releases/download/0.63.2/bazel.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swig---4.1.0",
+    name = "bzl.swig---4.3.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "swig-4.1.0",
+    strip_prefix = "swig-4.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/swig/swig/archive/refs/tags/v4.1.0.tar.gz"],
+    urls = ["https://github.com/swig/swig/archive/refs/tags/v4.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swxmlhash---7.0.2.2",
@@ -15686,22 +15771,13 @@ starlark_repository.archive(
     urls = ["https://github.com/accellera-official/systemc/archive/refs/tags/3.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.5.1",
+    name = "bzl.tar.bzl---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.5.1",
+    strip_prefix = "tar.bzl-0.7.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.10.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.10.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.1/tar.bzl-v0.10.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tar.bzl---0.2.1",
@@ -15711,6 +15787,15 @@ starlark_repository.archive(
     strip_prefix = "tar.bzl-0.2.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tar.bzl---0.5.5",
@@ -15731,22 +15816,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.6.0",
+    name = "bzl.tar.bzl---0.10.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.6.0",
+    strip_prefix = "tar.bzl-0.10.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.1/tar.bzl-v0.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.7.0",
+    name = "bzl.tar.bzl---0.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.7.0",
+    strip_prefix = "tar.bzl-0.5.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tcl_lang---9.0.2.bcr.1",
@@ -15839,15 +15924,6 @@ starlark_repository.archive(
     urls = ["http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml/tinyxml_2.6.2.orig.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tinyxml2---10.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tinyxml2-10.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.tinyxml2---9.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15855,6 +15931,15 @@ starlark_repository.archive(
     strip_prefix = "tinyxml2-9.0.0",
     type = "tar.gz",
     urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/9.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tinyxml2---10.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tinyxml2-10.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toml.bzl---0.3.0",
@@ -15884,6 +15969,15 @@ starlark_repository.archive(
     urls = ["https://github.com/hexdae/toolchains_arm_gnu/releases/download/v1.1.0/toolchains_arm_gnu-v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.toolchains_avr---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_avr-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/stefanbucur/toolchains_avr/releases/download/v0.1.2/toolchains_avr-0.1.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.toolchains_buildbuddy---0.0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15902,13 +15996,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.7.0/toolchains_llvm-v1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_llvm_bootstrapped---0.5.6",
+    name = "bzl.toolchains_llvm_bootstrapped---0.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_llvm_bootstrapped-0.5.6",
+    strip_prefix = "toolchains_llvm_bootstrapped-0.5.3",
     type = "tar.gz",
-    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.5.6/toolchains_llvm_bootstrapped-0.5.6.tar.gz"],
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.5.3/toolchains_llvm_bootstrapped-0.5.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_musl---0.1.27",
@@ -15917,24 +16011,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl_toolchain-v0.1.27.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.toolchains_protoc---0.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_protoc-0.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.3.1/toolchains_protoc-v0.3.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.toolchains_protoc---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_protoc-0.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.5.0/toolchains_protoc-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_protoc---0.6.1",
@@ -15953,6 +16029,24 @@ starlark_repository.archive(
     strip_prefix = "toolchains_protoc-0.2.1",
     type = "tar.gz",
     urls = ["https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.toolchains_protoc---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_protoc-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.5.0/toolchains_protoc-v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.toolchains_protoc---0.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_protoc-0.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.3.1/toolchains_protoc-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_riscv_gnu---1.0.0",
@@ -16000,6 +16094,15 @@ starlark_repository.archive(
     urls = ["https://github.com/zadlg/tree-sitter-c-bazel/releases/download/v0.23.4/tree-sitter-c.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.trlc---2.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "trlc-trlc-2.0.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bmw-software-engineering/trlc/archive/refs/tags/trlc-2.0.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.tweag-credential-helper---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16017,15 +16120,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ultrajson/ultrajson/archive/refs/tags/5.10.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.upb---0.0.0-20220923-a547704",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "upb-a5477045acaa34586420942098f5fecd3570f577",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.upb---0.0.0-20230907-e7430e6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16033,6 +16127,15 @@ starlark_repository.archive(
     strip_prefix = "upb-e7430e66d6e51def2a88f0b66fdab62b0d9492c1",
     type = "tar.gz",
     urls = ["https://github.com/protocolbuffers/upb/archive/e7430e66d6e51def2a88f0b66fdab62b0d9492c1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.upb---0.0.0-20220923-a547704",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "upb-a5477045acaa34586420942098f5fecd3570f577",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.upb---0.0.0-20230516-61a97ef",
@@ -16062,13 +16165,13 @@ starlark_repository.archive(
     urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.036.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.verilator---5.046.bcr.3",
+    name = "bzl.verilator---5.034.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "verilator-5.046",
+    strip_prefix = "verilator-5.034",
     type = "tar.gz",
-    urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.046.tar.gz"],
+    urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.034.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.version_utils---0.1.0",
@@ -16176,15 +16279,6 @@ starlark_repository.archive(
     urls = ["https://github.com/tuist/XcodeProj/archive/refs/tags/9.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.xds---0.0.0-20251210-ee656c7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "xds-ee656c7534f5d7dc23d44dd611689568f72017a6",
-    type = "tar.gz",
-    urls = ["https://github.com/cncf/xds/archive/ee656c7534f5d7dc23d44dd611689568f72017a6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.xds---0.0.0-20240423-555b57e",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16192,6 +16286,15 @@ starlark_repository.archive(
     strip_prefix = "xds-555b57ec207be86f811fb0c04752db6f85e3d7e2",
     type = "tar.gz",
     urls = ["https://github.com/cncf/xds/archive/555b57ec207be86f811fb0c04752db6f85e3d7e2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.xds---0.0.0-20251210-ee656c7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "xds-ee656c7534f5d7dc23d44dd611689568f72017a6",
+    type = "tar.gz",
+    urls = ["https://github.com/cncf/xds/archive/ee656c7534f5d7dc23d44dd611689568f72017a6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.xml.bzl---0.2.3",
@@ -16247,15 +16350,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/yaml.bzl/releases/download/v0.1.2/yaml.bzl-v0.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yams---6.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Yams-6.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/jpsim/Yams/archive/refs/tags/6.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yams---6.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16265,13 +16359,22 @@ starlark_repository.archive(
     urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yq.bzl---0.3.6",
+    name = "bzl.yams---6.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.3.6",
+    strip_prefix = "Yams-6.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.6/yq.bzl-v0.3.6.tar.gz"],
+    urls = ["https://github.com/jpsim/Yams/archive/refs/tags/6.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yq.bzl---0.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.3.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.2/yq.bzl-v0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.1",
@@ -16283,6 +16386,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.1/yq.bzl-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.yq.bzl---0.3.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.3.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.6/yq.bzl-v0.3.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.yq.bzl---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16290,15 +16402,6 @@ starlark_repository.archive(
     strip_prefix = "yq.bzl-0.1.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.yq.bzl---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.2/yq.bzl-v0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.z3---4.15.2",
@@ -16319,15 +16422,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openzipkin/zipkin-api/archive/refs/tags/1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.zlib---1.2.11",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.2.11",
-    type = "zip",
-    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"],
-)
-starlark_repository.archive(
     name = "bzl.zlib---1.2.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16344,6 +16438,24 @@ starlark_repository.archive(
     strip_prefix = "zlib-1.3.1",
     type = "tar.gz",
     urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.zlib---1.2.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zlib-1.2.11",
+    type = "zip",
+    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.zlib---1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zlib-1.3",
+    type = "tar.gz",
+    urls = ["https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.zlib-ng---2.0.7",
@@ -16371,15 +16483,6 @@ starlark_repository.archive(
     strip_prefix = "zstd-1.5.6",
     type = "tar.gz",
     urls = ["https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.zstd---1.5.5.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zstd-1.5.5",
-    type = "tar.gz",
-    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.zstd-jni---1.5.6-9",


### PR DESCRIPTION
Replace the Box-row table on the home page with a GitHub-style vertical timeline using Primer's TimelineItem component. Each entry shows the PR author's avatar centered on the timeline line, with module name, version, PR number, and a short relative timestamp connected by a dotted leader.

Add formatRelativeShort for concise "2 hours ago" timestamps Add timeline avatar badge CSS to position 42px avatars on the line Harmonize vertical spacing between home page sections