### PR TITLE
Fix dependents matrix rendering and default to matrix view

### DIFF
--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -750,16 +750,16 @@ import {
   <div class="Box-header d-flex flex-items-center flex-justify-between">
     <span class="Box-title">{$title} {counterLabel(count: $deps.length)}</span>
     <div class="BtnGroup">
-      <button class="BtnGroup-item selected btn btn-sm {css('btn-list')}" title="View list of dependents">
+      <button class="BtnGroup-item btn btn-sm {css('btn-list')}" title="View list of dependents">
         {octiconListUnordered16()}
       </button>
-      <button class="BtnGroup-item btn btn-sm {css('btn-table')}" title="View matrix of dependents by version">
+      <button class="BtnGroup-item selected btn btn-sm {css('btn-table')}" title="View matrix of dependents by version">
         {octiconTable16()}
       </button>
     </div>
   </div>
   <div class="Box-body">
-    <div class="{css('list-content')}">
+    <div class="{css('list-content')}" style="display: none;">
       {for $dep in $deps}
         <div class="mx-1 my-2" style="display: flex; align-items: center;">
           <span style="padding-right: 0.5em;">

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -877,6 +877,8 @@ class ModuleVersionDependentsComponent extends ContentComponent {
 
 		this.enterListButton();
 		this.enterTableButton();
+
+		this.enterTableContent(this.getTableContentElement());
 	}
 
 	enterListButton() {
@@ -1057,7 +1059,7 @@ class ModuleVersionDependentsComponent extends ContentComponent {
 	renderDependentsMatrix(container, data) {
 		// Wrapper for horizontal scroll with grab cursor
 		const wrapper = dom.createDom("div", {
-			class: "m-1",
+			class: "m-1 dependents-matrix",
 			style: "overflow-x: scroll; cursor: grab;",
 			onmousedown: /** @this {!HTMLElement} */ function () {
 				this.style.cursor = "grabbing";

--- a/app/bcr/style.css
+++ b/app/bcr/style.css
@@ -71,6 +71,13 @@ pre code {
 	-webkit-overflow-scrolling: touch;
 }
 
+/* Restore table semantics for the dependents matrix.
+ * The matrix has its own overflow wrapper and needs display: table
+ * for sticky columns and cell-grid layout to work. */
+.Box .Box-body .dependents-matrix table {
+	display: table;
+}
+
 /* width-full on mobile should respect container bounds */
 @media (max-width: 767.98px) {
 	.width-full {


### PR DESCRIPTION
The "Used By" dependents matrix lost its grid layout (no cell borders, no color-bg-success/subtle backgrounds, left-aligned module labels) due to two compounding bugs:

1. The mobile-responsive rule `.Box .Box-body table { display: block }` added in c6f8b94 destroyed the matrix's tabular layout. Add a `dependents-matrix` marker class on the wrapper and a more-specific override that restores `display: table` for the matrix only, leaving the mobile rule in place for other Box-body tables.

2. The matrix's class attribute was silently dropped from the rendered DOM because the `dom.createDom` calls in `renderDependentsMatrix` used unquoted property keys (`class:`, `style:`, `href:`), which Closure ADVANCED_OPTIMIZATIONS renames. Quote all attribute keys so they survive compilation. (See d5c9093 — same issue, fixed before and reintroduced during the app.js -> modules.js migration.)

Also make the matrix view the default since it's the more useful visualization for popular modules: swap the `selected` class to the table button, hide list-content on initial render to avoid a flash, and render the matrix in `enterDocument` instead of waiting for a button click.