### PR TITLE
Display UI build version in the side pane

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,7 @@
 build --workspace_status_command=./tools/workspace_status.sh
+# Run the workspace status command on every build so STABLE_GIT_COMMIT is
+# threaded into stamped artifacts (e.g. //app/bcr:ui_version_src).
+build --stamp
 
 # IMPORTANT:
 # export JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home

--- a/app/bcr/BUILD.bazel
+++ b/app/bcr/BUILD.bazel
@@ -14,6 +14,7 @@ load("//rules:ghpages.bzl", "ghpages_deploy")
 load("//rules:octicons_closure_template_compile.bzl", "octicons_closure_template_compile")
 load("//rules:prerender.bzl", "prerender_home", "prerender_pages")
 load("//rules:release.bzl", "release_archive")
+load("//rules:ui_version.bzl", "ui_version_js")
 
 string_flag(
     name = "release_type",
@@ -223,6 +224,16 @@ closure_js_test(
     ],
 )
 
+ui_version_js(
+    name = "ui_version_src",
+    template = "ui_version.js.tpl",
+)
+
+closure_js_library(
+    name = "ui_version",
+    srcs = [":ui_version_src"],
+)
+
 closure_js_library(
     name = "app",
     srcs = [
@@ -257,6 +268,7 @@ closure_js_library(
         ":registry",
         ":soy",
         ":starlark",
+        ":ui_version",
         "//build/stack/bazel/registry/v1:bzpb_js",
         "//build/stack/bazel/symbol/v1:sympb_js",
         "//build/stack/starlark/v1beta1:v1beta1_js",

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -303,6 +303,7 @@ import {
   {@param totalModuleVersions: int}
   {@param totalMaintainers: int}
   {@param totalSymbols: int}
+  {@param uiCommitSha: string}
 <div class="px-2">
   <h2 class="h2 d-flex flex-items-center mb-2">
     <span>Bazel Central Registry</span>
@@ -361,7 +362,20 @@ import {
        href="{$registry.getRepositoryUrl()}/commit/{$registry.getCommitSha()}"
        target="_blank" rel="noopener noreferrer">
       <span class="mr-2">{octiconGitCommit16()}</span>
-      <span>Commit {$registry.getCommitSha().substring(0, 8)}</span>
+      <span>BCR Version {$registry.getCommitSha().substring(0, 8)}</span>
+    </a>
+    <a class="Link--muted d-flex flex-items-center mb-2"
+       href="https://github.com/bazel-contrib/bcr-frontend/commit/{$uiCommitSha}"
+       target="_blank" rel="noopener noreferrer">
+      <span class="mr-2">{octiconGitCommit16()}</span>
+      <span>      
+        Frontend Version {$uiCommitSha.substring(0, 8)}</span>
+    </a>
+    <a class="Link--muted d-flex flex-items-center mb-2"
+       href="https://github.com/bazel-contrib/bcr-frontend-site"
+       target="_blank" rel="noopener noreferrer">
+      <span class="mr-2">{octiconMarkGithub16()}</span>
+      <span>Deploy Site</span>
     </a>
   </div>
 
@@ -418,6 +432,7 @@ import {
   {@param totalModuleVersions: int}
   {@param totalMaintainers: int}
   {@param totalSymbols: int}
+  {@param uiCommitSha: string}
 <div class="PageLayout PageLayout--panePos-start PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
   <div class="PageLayout-columns">
 
@@ -428,6 +443,7 @@ import {
         {param totalModuleVersions: $totalModuleVersions /}
         {param totalMaintainers: $totalMaintainers /}
         {param totalSymbols: $totalSymbols /}
+        {param uiCommitSha: $uiCommitSha /}
       {/call}
     </div>
 
@@ -584,6 +600,7 @@ import {
   {@param totalModuleVersions: int}
   {@param totalMaintainers: int}
   {@param totalSymbols: int}
+  {@param uiCommitSha: string}
 <div class="PageLayout PageLayout--panePos-start PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
   <div class="PageLayout-columns">
 
@@ -594,6 +611,7 @@ import {
         {param totalModuleVersions: $totalModuleVersions /}
         {param totalMaintainers: $totalMaintainers /}
         {param totalSymbols: $totalSymbols /}
+        {param uiCommitSha: $uiCommitSha /}
       {/call}
     </div>
 
@@ -2280,6 +2298,7 @@ import {
   {@param totalModuleVersions: int}
   {@param totalMaintainers: int}
   {@param totalSymbols: int}
+  {@param uiCommitSha: string}
 <div class="PageLayout PageLayout--panePos-start PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
   <div class="PageLayout-columns">
 
@@ -2290,6 +2309,7 @@ import {
         {param totalModuleVersions: $totalModuleVersions /}
         {param totalMaintainers: $totalMaintainers /}
         {param totalSymbols: $totalSymbols /}
+        {param uiCommitSha: $uiCommitSha /}
       {/call}
     </div>
 

--- a/app/bcr/documentation.js
+++ b/app/bcr/documentation.js
@@ -75,6 +75,7 @@ const {
 	getLatestModuleVersion,
 } = goog.require("bcrfrontend.registry");
 const { highlightAll } = goog.require("bcrfrontend.syntax");
+const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
 const {
 	generateAspectExample,
 	generateFunctionExample,
@@ -284,6 +285,7 @@ class DocsMapSelectNav extends SelectNav {
 				totalModuleVersions: totalModuleVersions,
 				totalMaintainers: maintainers.size,
 				totalSymbols: computeTotalSymbols(this.registry_),
+				uiCommitSha: uiCommitSha,
 			}),
 		);
 	}

--- a/app/bcr/home.js
+++ b/app/bcr/home.js
@@ -19,6 +19,7 @@ const {
 const { homeOverviewSelectNav, homeRecentTimeline, homeSelect } = goog.require(
 	"soy.bcrfrontend.app",
 );
+const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
 const { formatRelativeShort } = goog.require("bcrfrontend.format");
 const { Component, Route } = goog.require("stack.ui");
 
@@ -119,6 +120,7 @@ class HomeOverviewSelectNav extends SelectNav {
 				totalModuleVersions: totalModuleVersions,
 				totalMaintainers: maintainers.size,
 				totalSymbols: computeTotalSymbols(this.registry_),
+				uiCommitSha: uiCommitSha,
 			}),
 		);
 	}

--- a/app/bcr/maintainers.js
+++ b/app/bcr/maintainers.js
@@ -15,6 +15,7 @@ const { ContentSelect } = goog.require("bcrfrontend.ContentSelect");
 const { SelectNav } = goog.require("bcrfrontend.SelectNav");
 const { getApplication } = goog.require("bcrfrontend.common");
 const { formatRelativeShort } = goog.require("bcrfrontend.format");
+const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
 const {
 	computeTotalSymbols,
 	createMaintainersMap,
@@ -145,6 +146,7 @@ class MaintainersMapSelectNav extends SelectNav {
 				totalModuleVersions: totalModuleVersions,
 				totalMaintainers: this.maintainers_.size,
 				totalSymbols: computeTotalSymbols(this.registry_),
+				uiCommitSha: uiCommitSha,
 			}),
 		);
 	}

--- a/app/bcr/maintainers.soy
+++ b/app/bcr/maintainers.soy
@@ -30,6 +30,7 @@ import {
   {@param totalModuleVersions: int}
   {@param totalMaintainers: int}
   {@param totalSymbols: int}
+  {@param uiCommitSha: string}
 <div class="PageLayout PageLayout--panePos-start PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
   <div class="PageLayout-columns">
 
@@ -40,6 +41,7 @@ import {
         {param totalModuleVersions: $totalModuleVersions /}
         {param totalMaintainers: $totalMaintainers /}
         {param totalSymbols: $totalSymbols /}
+        {param uiCommitSha: $uiCommitSha /}
       {/call}
     </div>
 

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -62,6 +62,7 @@ const {
 } = goog.require("bcrfrontend.registry");
 const { formatDate, formatRelativePast } = goog.require("bcrfrontend.format");
 const { highlightAll } = goog.require("bcrfrontend.syntax");
+const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
 
 /**
  * Fetch documentation for a module version from the site assets.
@@ -1255,6 +1256,7 @@ class ModulesMapSelectNav extends SelectNav {
 				totalModuleVersions: totalModuleVersions,
 				totalMaintainers: maintainers.size,
 				totalSymbols: computeTotalSymbols(this.registry_),
+				uiCommitSha: uiCommitSha,
 			}),
 		);
 	}

--- a/app/bcr/ui_version.js.tpl
+++ b/app/bcr/ui_version.js.tpl
@@ -1,0 +1,7 @@
+goog.module("bcrfrontend.uiVersion");
+
+/** @const {string} */
+exports.commitSha = "__BCR_FRONTEND_COMMIT_SHA__";
+
+/** @const {string} */
+exports.repositoryUrl = "https://github.com/bazel-contrib/bcr-frontend";

--- a/cmd/uiversion/BUILD.bazel
+++ b/cmd/uiversion/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "uiversion_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/bazel-contrib/bcr-frontend/cmd/uiversion",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "uiversion",
+    embed = [":uiversion_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/uiversion/main.go
+++ b/cmd/uiversion/main.go
@@ -1,0 +1,84 @@
+// Command uiversion stamps the UI's git commit SHA into a JS template.
+//
+// Reads a Bazel workspace status file (typically `bazel-out/stable-status.txt`),
+// extracts the value for STABLE_GIT_COMMIT, and substitutes occurrences of a
+// placeholder in the template with that value. If the key is missing or empty,
+// the placeholder is replaced with "unknown".
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+const (
+	statusKey   = "STABLE_GIT_COMMIT"
+	placeholder = "__BCR_FRONTEND_COMMIT_SHA__"
+	fallback    = "unknown"
+)
+
+func main() {
+	log.SetPrefix("uiversion: ")
+	log.SetFlags(0)
+
+	var (
+		infoFile     = flag.String("info_file", "", "path to bazel stable status file")
+		templateFile = flag.String("template", "", "path to JS template containing the placeholder")
+		outFile      = flag.String("out", "", "path to write the substituted JS file")
+	)
+	flag.Parse()
+
+	if *infoFile == "" || *templateFile == "" || *outFile == "" {
+		log.Fatalf("--info_file, --template, --out are all required")
+	}
+
+	commit, err := readStatusKey(*infoFile, statusKey)
+	if err != nil {
+		log.Fatalf("reading %s from %s: %v", statusKey, *infoFile, err)
+	}
+	if commit == "" {
+		commit = fallback
+	}
+
+	tpl, err := os.ReadFile(*templateFile)
+	if err != nil {
+		log.Fatalf("reading template %s: %v", *templateFile, err)
+	}
+
+	out := strings.ReplaceAll(string(tpl), placeholder, commit)
+	if err := os.WriteFile(*outFile, []byte(out), 0o644); err != nil {
+		log.Fatalf("writing %s: %v", *outFile, err)
+	}
+}
+
+// readStatusKey scans a Bazel workspace status file (one "KEY VALUE" pair per
+// line, separated by the first space) and returns the value for the named key,
+// or "" if the key is absent or has no value.
+func readStatusKey(path, key string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		idx := strings.IndexByte(line, ' ')
+		if idx <= 0 {
+			continue
+		}
+		if line[:idx] != key {
+			continue
+		}
+		return strings.TrimSpace(line[idx+1:]), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scanning: %w", err)
+	}
+	return "", nil
+}

--- a/rules/ui_version.bzl
+++ b/rules/ui_version.bzl
@@ -1,0 +1,43 @@
+"""Generate a small JS module exposing the UI's git commit SHA.
+
+The action runs `//cmd/uiversion`, which reads STABLE_GIT_COMMIT from the
+workspace status file (populated by `tools/workspace_status.sh` via
+--workspace_status_command) and substitutes it for the placeholder
+__BCR_FRONTEND_COMMIT_SHA__ in the supplied template. Falls back to
+"unknown" when stamping is disabled or the key is missing/empty.
+"""
+
+def _ui_version_js_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".js")
+    ctx.actions.run(
+        inputs = [ctx.info_file, ctx.file.template],
+        outputs = [out],
+        executable = ctx.executable._tool,
+        arguments = [
+            "--info_file",
+            ctx.info_file.path,
+            "--template",
+            ctx.file.template.path,
+            "--out",
+            out.path,
+        ],
+        mnemonic = "UiVersionJs",
+        progress_message = "Stamping UI commit SHA into %s" % out.short_path,
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+ui_version_js = rule(
+    implementation = _ui_version_js_impl,
+    attrs = {
+        "template": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "JS template containing the __BCR_FRONTEND_COMMIT_SHA__ placeholder.",
+        ),
+        "_tool": attr.label(
+            default = "//cmd/uiversion",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)


### PR DESCRIPTION
Stamps the bcr-frontend git commit SHA into the rendered side pane so visitors can see which UI build is deployed. Adds a "UI Build <sha>" row next to the existing "BCR Build <sha>" registry link, plus a static "Deploy Site" link to bazel-contrib/bcr-frontend-site.

Implementation:
- New //cmd/uiversion Go binary reads STABLE_GIT_COMMIT from the Bazel status file and substitutes a placeholder in a JS template. Handles empty / 1-field-line cases that the previous awk pipeline did not.
- New rules/ui_version.bzl declares a `ui_version_js` rule that invokes the binary on app/bcr/ui_version.js.tpl, producing a Closure module `bcrfrontend.uiVersion` with `commitSha` and `repositoryUrl` exports.
- Threads `uiCommitSha` through bcrSidePane and the four SelectNav consumers (home, modules, maintainers, docs).
- Enables `build --stamp` in .bazelrc so the workspace status command actually populates ctx.info_file (without --stamp Bazel synthesizes a dummy file and the SHA falls back to "unknown").