### PR TITLE
Convert Testing tab to 2-panel layout; surface global matrix facets

### DIFF
--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -2477,100 +2477,102 @@ import {
 {template presubmitComponent}
   {@param moduleVersion: ModuleVersion}
   {@param? presubmit: Presubmit}
-<div class="{css('Box')} {css('p-3')}">
+  {@param platforms: list<[value: string, active: bool]>}
+  {@param bazelVersions: list<[value: string, active: bool]>}
+<div>
   {if !$presubmit}
     <div class="{css('blankslate')}">
       <p class="{css('text-muted')}">No presubmit configuration available for this module.</p>
     </div>
   {else}
-    <div class="{css('mb-3')}">
-      <h3 class="{css('h3')} {css('mb-2')}">Presubmit Configuration</h3>
-      <p class="{css('text-muted')}">This module's continuous integration testing configuration.</p>
-    </div>
+    {let $bcr: $presubmit.getBcrTestModule() /}
+    {let $matrix: $bcr ? $bcr.getMatrix() : $presubmit.getMatrix() /}
+    {let $tasksMap: $bcr ? $bcr.getTasksMap() : $presubmit.getTasksMap() /}
 
-    {if $presubmit.getBcrTestModule()}
-      {let $bcr: $presubmit.getBcrTestModule() /}
-      <div class="{css('mb-4')}">
-        <h4 class="{css('h4')} {css('mb-2')}">BCR Test Module</h4>
+    <div class="PageLayout PageLayout--panePos-end PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
+      <div class="PageLayout-columns">
+        <div class="PageLayout-content">
+          {if $tasksMap && $tasksMap.keys()}
+            {sectionHeader(title: 'Tasks', count: length($tasksMap.keys()))}
+            {for $taskName in $tasksMap.keys()}
+              {let $task: $tasksMap.get($taskName) /}
+              {if $task}
+                {call presubmitTask_}
+                  {param taskName: $taskName /}
+                  {param task: $task /}
+                {/call}
+              {/if}
+            {/for}
+          {/if}
+        </div>
 
-        {if $bcr.getModulePath()}
-          <div class="{css('mb-2')}">
-            <span class="{css('text-semibold')}">Module Path:</span> <code>{$bcr.getModulePath()}</code>
-          </div>
-        {/if}
+        <div class="PageLayout-pane">
+          <div>
+            {sectionHeader(title: 'Presubmit Configuration')}
+            <p class="f4 mb-3 color-fg-muted">
+              This module's continuous integration testing configuration.
+            </p>
 
-        {if $bcr.getMatrix()}
-          {call presubmitMatrix_}
-            {param matrix: $bcr.getMatrix() /}
-          {/call}
-        {/if}
+            {if $bcr && $bcr.getModulePath()}
+              {sectionDivider()}
+              <div>
+                {sectionHeader(title: 'BCR Test Module')}
+                <div class="d-flex flex-items-center mb-2">
+                  <span class="color-fg-muted">Module Path</span>
+                  <span class="dotted-leader"></span>
+                  <code class="text-bold">{$bcr.getModulePath()}</code>
+                </div>
+              </div>
+            {/if}
 
-        {if $bcr.getTasksMap() && $bcr.getTasksMap().keys()}
-          <h5 class="{css('h5')} {css('mt-3')} {css('mb-2')}">Tasks</h5>
-          {for $taskName in $bcr.getTasksMap().keys()}
-            {let $task: $bcr.getTasksMap().get($taskName) /}
-            {if $task}
-              {call presubmitTask_}
-                {param taskName: $taskName /}
-                {param task: $task /}
+            {if $matrix}
+              {sectionDivider()}
+              {call presubmitMatrix_}
+                {param platforms: $platforms /}
+                {param bazelVersions: $bazelVersions /}
               {/call}
             {/if}
-          {/for}
-        {/if}
+          </div>
+        </div>
       </div>
-    {/if}
-
-    {if $presubmit.getMatrix() && ! $presubmit.getBcrTestModule()}
-      {call presubmitMatrix_}
-        {param matrix: $presubmit.getMatrix() /}
-      {/call}
-    {/if}
-
-    {if $presubmit.getTasksMap() && $presubmit.getTasksMap().keys() && ! $presubmit.getBcrTestModule()}
-      <h4 class="{css('h4')} {css('mb-2')}">Tasks</h4>
-      {for $taskName in $presubmit.getTasksMap().keys()}
-        {let $task: $presubmit.getTasksMap().get($taskName) /}
-        {if $task}
-          {call presubmitTask_}
-            {param taskName: $taskName /}
-            {param task: $task /}
-          {/call}
-        {/if}
-      {/for}
-    {/if}
+    </div>
   {/if}
 </div>
 {/template}
 
 {template presubmitMatrix_ visibility="private"}
-  {@param matrix: Presubmit.PresubmitMatrix}
-<div class="{css('Box')} {css('Box--condensed')} {css('mb-3')}">
-  <div class="{css('Box-header')}">
-    <h5 class="{css('Box-title')}">Test Matrix</h5>
-  </div>
-  <div class="{css('Box-body')}">
-    {if $matrix.getPlatformList() && length($matrix.getPlatformList()) > 0}
-      <div class="{css('mb-2')}">
-        <span class="{css('text-semibold')}">Platforms:</span>
-        <div class="{css('mt-1')}">
-          {for $platform in $matrix.getPlatformList()}
-            <span class="{css('Label')} {css('Label--secondary')} {css('mr-1')}">{$platform}</span>
-          {/for}
-        </div>
-      </div>
-    {/if}
+  {@param platforms: list<[value: string, active: bool]>}
+  {@param bazelVersions: list<[value: string, active: bool]>}
+<div>
+  {sectionHeader(title: 'Test Matrix')}
 
-    {if $matrix.getBazelList() && length($matrix.getBazelList()) > 0}
-      <div>
-        <span class="{css('text-semibold')}">Bazel Versions:</span>
-        <div class="{css('mt-1')}">
-          {for $version in $matrix.getBazelList()}
-            <span class="{css('Label')} {css('Label--accent')} {css('mr-1')}">{$version}</span>
-          {/for}
-        </div>
+  {if length($platforms) > 0}
+    <div class="mb-3">
+      <span class="text-semibold">Platforms:</span>
+      <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+        {for $p in $platforms}
+          <span class="Label {if $p.active}Label--secondary{else}Label--secondary color-fg-subtle{/if}"
+                {if !$p.active}style="opacity: 0.4"{/if}>
+            {$p.value}
+          </span>
+        {/for}
       </div>
-    {/if}
-  </div>
+    </div>
+  {/if}
+
+  {if length($bazelVersions) > 0}
+    <div>
+      <span class="text-semibold">Bazel Versions:</span>
+      <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+        {for $v in $bazelVersions}
+          <span class="Label {if $v.active}Label--accent{else}Label--secondary color-fg-subtle{/if}"
+                {if !$v.active}style="opacity: 0.4"{/if}>
+            {$v.value}
+          </span>
+        {/for}
+      </div>
+    </div>
+  {/if}
 </div>
 {/template}
 
@@ -2591,19 +2593,19 @@ import {
       <tbody>
         {if $task.getPlatform()}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}" style="width: 140px">Platform:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}" style="width: 140px">Platform:</td>
             <td class="{css('py-1')}"><code>{$task.getPlatform()}</code></td>
           </tr>
         {/if}
         {if $task.getBazel()}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}">Bazel:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}">Bazel:</td>
             <td class="{css('py-1')}"><code>{$task.getBazel()}</code></td>
           </tr>
         {/if}
         {if $task.getBuildFlagsList() && length($task.getBuildFlagsList()) > 0}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}">Build Flags:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}">Build Flags:</td>
             <td class="{css('py-1')}">
               {for $flag in $task.getBuildFlagsList()}
                 <code class="{css('mr-1')}">{$flag}</code>
@@ -2613,7 +2615,7 @@ import {
         {/if}
         {if $task.getTestFlagsList() && length($task.getTestFlagsList()) > 0}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}">Test Flags:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}">Test Flags:</td>
             <td class="{css('py-1')}">
               {for $flag in $task.getTestFlagsList()}
                 <code class="{css('mr-1')}">{$flag}</code>
@@ -2623,7 +2625,7 @@ import {
         {/if}
         {if $task.getBuildTargetsList() && length($task.getBuildTargetsList()) > 0}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}">Build Targets:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}">Build Targets:</td>
             <td class="{css('py-1')}">
               {for $target in $task.getBuildTargetsList()}
                 <code class="{css('mr-1')}">{$target}</code>
@@ -2633,7 +2635,7 @@ import {
         {/if}
         {if $task.getTestTargetsList() && length($task.getTestTargetsList()) > 0}
           <tr>
-            <td class="{css('text-semibold')} {css('pr-2')} {css('py-1')}">Test Targets:</td>
+            <td class="{css('text-semibold')} {css('text-small')} {css('pr-2')} {css('py-1')}">Test Targets:</td>
             <td class="{css('py-1')}">
               {for $target in $task.getTestTargetsList()}
                 <code class="{css('mr-1')}">{$target}</code>

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -431,6 +431,7 @@ class ModuleVersionSelectNav extends SelectNav {
 			`${this.getPathUrl()}/${TabName.TESTING}`,
 			() =>
 				new PresubmitSelect(
+					this.registry_,
 					this.module_,
 					this.moduleVersion_,
 					presubmit || null,

--- a/app/bcr/presubmit.js
+++ b/app/bcr/presubmit.js
@@ -5,6 +5,7 @@ const Module = goog.require("proto.build.stack.bazel.registry.v1.Module");
 const ModuleVersion = goog.require(
 	"proto.build.stack.bazel.registry.v1.ModuleVersion",
 );
+const Registry = goog.require("proto.build.stack.bazel.registry.v1.Registry");
 const dom = goog.require("goog.dom");
 const soy = goog.require("goog.soy");
 const { MarkdownComponent } = goog.require("bcrfrontend.markdown");
@@ -13,6 +14,7 @@ const { ContentSelect } = goog.require("bcrfrontend.ContentSelect");
 const { presubmitComponent, presubmitSelect } = goog.require(
 	"soy.bcrfrontend.app",
 );
+const { computeAllPresubmitFacets } = goog.require("bcrfrontend.registry");
 const { highlightAll } = goog.require("bcrfrontend.syntax");
 
 /**
@@ -24,13 +26,17 @@ const TabName = {
 
 class PresubmitSelect extends ContentSelect {
 	/**
+	 * @param {!Registry} registry
 	 * @param {!Module} module
 	 * @param {!ModuleVersion} moduleVersion
 	 * @param {?Presubmit} presubmit
 	 * @param {?dom.DomHelper=} opt_domHelper
 	 */
-	constructor(module, moduleVersion, presubmit, opt_domHelper) {
+	constructor(registry, module, moduleVersion, presubmit, opt_domHelper) {
 		super(opt_domHelper);
+
+		/** @private @const @type {!Registry} */
+		this.registry_ = registry;
 
 		/** @private @const @type {!Module} */
 		this.module_ = module;
@@ -68,6 +74,7 @@ class PresubmitSelect extends ContentSelect {
 				this.addTab(
 					name,
 					new PresubmitOverviewComponent(
+						this.registry_,
 						this.moduleVersion_,
 						this.presubmit_,
 						this.dom_,
@@ -84,12 +91,16 @@ exports.PresubmitSelect = PresubmitSelect;
 
 class PresubmitOverviewComponent extends MarkdownComponent {
 	/**
+	 * @param {!Registry} registry
 	 * @param {!ModuleVersion} moduleVersion
 	 * @param {!Presubmit} presubmit
 	 * @param {?dom.DomHelper=} opt_domHelper
 	 */
-	constructor(moduleVersion, presubmit, opt_domHelper) {
+	constructor(registry, moduleVersion, presubmit, opt_domHelper) {
 		super(opt_domHelper);
+
+		/** @protected @const */
+		this.registry_ = registry;
 
 		/** @protected @const */
 		this.moduleVersion_ = moduleVersion;
@@ -102,10 +113,27 @@ class PresubmitOverviewComponent extends MarkdownComponent {
 	 * @override
 	 */
 	createDom() {
+		const facets = computeAllPresubmitFacets(this.registry_);
+		const matrix =
+			this.presubmit_.getBcrTestModule()?.getMatrix() ||
+			this.presubmit_.getMatrix();
+		const activePlatforms = new Set(matrix ? matrix.getPlatformList() : []);
+		const activeBazelVersions = new Set(matrix ? matrix.getBazelList() : []);
+		const platforms = facets.platforms.map((value) => ({
+			value,
+			active: activePlatforms.has(value),
+		}));
+		const bazelVersions = facets.bazelVersions.map((value) => ({
+			value,
+			active: activeBazelVersions.has(value),
+		}));
+
 		this.setElementInternal(
 			soy.renderAsElement(presubmitComponent, {
 				moduleVersion: this.moduleVersion_,
 				presubmit: this.presubmit_,
+				platforms,
+				bazelVersions,
 			}),
 		);
 	}

--- a/app/bcr/registry.js
+++ b/app/bcr/registry.js
@@ -13,6 +13,7 @@ const ModuleMetadata = goog.require(
 const ModuleVersion = goog.require(
 	"proto.build.stack.bazel.registry.v1.ModuleVersion",
 );
+const Presubmit = goog.require("proto.build.stack.bazel.registry.v1.Presubmit");
 const Registry = goog.require("proto.build.stack.bazel.registry.v1.Registry");
 const strings = goog.require("goog.string");
 
@@ -114,6 +115,85 @@ function createDocumentationMap(registry) {
 	return result;
 }
 exports.createDocumentationMap = createDocumentationMap;
+
+// Cache the presubmit-facet sets per registry commit so we only walk all
+// modules once per session.
+/** @type {?{platforms: !Array<string>, bazelVersions: !Array<string>}} */
+let cachedPresubmitFacets = null;
+/** @type {?string} */
+let cachedPresubmitFacetsCommit = null;
+
+/**
+ * Walks every module version's Presubmit (top-level matrix, BCR test-module
+ * matrix, and per-task overrides) and returns the union of all platforms and
+ * Bazel versions seen across the registry. Used by the Testing tab to display
+ * the universe of possible values, with values absent from the current
+ * module's matrix grayed out.
+ *
+ * @param {!Registry} registry
+ * @returns {!{platforms: !Array<string>, bazelVersions: !Array<string>}}
+ */
+function computeAllPresubmitFacets(registry) {
+	const commit = registry.getCommitSha();
+	if (cachedPresubmitFacetsCommit === commit && cachedPresubmitFacets) {
+		return cachedPresubmitFacets;
+	}
+
+	/** @type {!Set<string>} */
+	const platforms = new Set();
+	/** @type {!Set<string>} */
+	const bazelVersions = new Set();
+
+	// Skip Bazel CI's templated placeholders like "${{ all_platforms }}",
+	// "${{ bazel }}", etc. They're substitution variables, not concrete values.
+	/** @type {function(string): boolean} */
+	const isConcrete = (s) => !!s && !s.includes("${{");
+
+	/**
+	 * @param {?Presubmit.PresubmitMatrix|undefined} matrix
+	 */
+	const collectFromMatrix = (matrix) => {
+		if (!matrix) return;
+		for (const p of matrix.getPlatformList()) {
+			if (isConcrete(p)) platforms.add(p);
+		}
+		for (const v of matrix.getBazelList()) {
+			if (isConcrete(v)) bazelVersions.add(v);
+		}
+	};
+
+	for (const module of registry.getModulesList()) {
+		for (const version of module.getVersionsList()) {
+			const presubmit = version.getPresubmit();
+			if (!presubmit) continue;
+			collectFromMatrix(presubmit.getMatrix());
+			const bcr = presubmit.getBcrTestModule();
+			if (bcr) collectFromMatrix(bcr.getMatrix());
+			// Per-task overrides
+			const tasksMap = bcr ? bcr.getTasksMap() : presubmit.getTasksMap();
+			if (tasksMap) {
+				for (const taskName of tasksMap.keys()) {
+					const task = tasksMap.get(taskName);
+					if (!task) continue;
+					const p = task.getPlatform();
+					if (isConcrete(p)) platforms.add(p);
+					const v = task.getBazel();
+					if (isConcrete(v)) bazelVersions.add(v);
+				}
+			}
+		}
+	}
+
+	cachedPresubmitFacets = {
+		platforms: Array.from(platforms).sort(),
+		// Sort newest-first (descending) so e.g. ["9.x", "8.x"] is the natural
+		// reading order for Bazel major versions.
+		bazelVersions: Array.from(bazelVersions).sort().reverse(),
+	};
+	cachedPresubmitFacetsCommit = commit;
+	return cachedPresubmitFacets;
+}
+exports.computeAllPresubmitFacets = computeAllPresubmitFacets;
 
 /**
  * Counts the total documented symbols across every version of every module


### PR DESCRIPTION
The Testing tab on /modules/<name>/<version>/testing now uses the same 2-panel PageLayout as the Overview tab — Tasks fill the main content column, the Presubmit metadata (title, description, BCR Test Module, Test Matrix) sits in a right side pane.

Test Matrix renders the union of platforms and Bazel versions seen across the entire registry, with the values used by the current module highlighted and the rest grayed out (opacity: 0.4). The union set is computed in registry.js by walking every module version's presubmit (top-level matrix, BCR test-module matrix, and per-task platform/bazel overrides) and is memoized on the registry commit SHA.

Notable details:
- Drops the Box / Box--condensed wrapper around the matrix in favor of a sectionHeader('Test Matrix'), matching the rest of the side pane styling.
- Skips Bazel CI's substitution placeholders (`${{ all_platforms }}`, `${{ bazel }}`, etc.) so only literal values populate the chips.
- Bazel versions sort newest-first; platforms sort alphabetically.
- Tasks-list label cells (Platform / Bazel / Build Flags / Test Flags / Build Targets / Test Targets) gain `text-small` for visual consistency.
- Collapses the previous BCR-test-module-vs-direct-presubmit duplication in presubmitComponent into a single render path using let-bindings on $matrix and $tasksMap.

Wiring: PresubmitSelect / PresubmitOverviewComponent now take a Registry; ModuleVersionSelectNav passes this.registry_ through the addNavTabLazy factory.