### PR TITLE
Fix registrycompiler crash on unmatched documentation entries

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,7 +68,7 @@ gazelle(
         "--bazel-release-set-file=$BUILD_WORKING_DIRECTORY/bazel-releases.json",
         "--pr-author-set-file=$BUILD_WORKING_DIRECTORY/pr-authors.json",
         "--registry-root=data/bazel-central-registry",
-        "--registry-url=https://bcr.stack.build",
+        "--registry-url=https://registry-preview.bazel.build",
         "--blacklisted_url=https://netcologne.dl.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.11.0.tar.gz",
         "--blacklisted_url=https://netcologne.dl.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz",
         "--blacklisted_url=https://github.com/mathematic-inc/rules_mjml/releases/download/v0.1.0/rules_mjml-v0.1.0.tar.gz",

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -310,8 +310,7 @@ import {
   </h2>
 
   <p class="f4 mb-4 color-fg-muted">
-    The official registry for Bazel modules. Publish to the BCR to make modules
-    discoverable and consumable via Bzlmod, Bazel's external dependency system.
+    The central registry of Bazel modules for the Bzlmod external dependency system.  
   </p>
 
   <a class="Link--primary d-flex flex-items-center mb-2" href="/#/modules">

--- a/cmd/registrycompiler/registrycompiler.go
+++ b/cmd/registrycompiler/registrycompiler.go
@@ -88,7 +88,11 @@ func run(args []string) error {
 					mv.Source.Documentation = d
 				}
 			} else {
-				log.Panicf("module version not found!", mv)
+				// The doc registry may carry entries for module versions that
+				// are no longer in the main registry (e.g. yanked, or the doc
+				// snapshot is newer than the registry snapshot). Skip them
+				// rather than failing the build.
+				log.Printf("warning: skipping documentation for unknown module version %s", id)
 			}
 		}
 	}


### PR DESCRIPTION
When the documentation registry contained an entry for a module version not present in the main registry (e.g. yanked, or generated from a newer snapshot), registrycompiler would panic with `module version not found!%!(EXTRA *bzpb.ModuleVersion=<nil>)` and take down the "Generate all docs" CI action. The format string also lacked a verb and printed the wrong (nil) variable.