### PR TITLE
Disable Cloudflare deploy in trigger-via-bcr workflow

### DIFF
--- a/.github/workflows/trigger-via-bcr.yml
+++ b/.github/workflows/trigger-via-bcr.yml
@@ -23,7 +23,6 @@ jobs:
       packages: write
     env:
       GITHUB_TOKEN: ${{ secrets.BCR_AUTOMATION_TOKEN }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -69,16 +68,6 @@ jobs:
           run
           //:bcr
 
-      - name: Deploy to production
-        run: >-
-          bazelisk
-          --bazelrc=.github/workflows/ci.bazelrc
-          --bazelrc=.bazelrc
-          run
-          --//app/bcr:release_type=production
-          --//app/bcr:prerender_modules=on
-          //app/bcr:deploy
-
-      - name: Log deployment
+      - name: Log build
         run: |
-          echo "✅ Deployed BCR commit ${{ steps.bcr.outputs.sha }}"
+          echo "✅ Built BCR commit ${{ steps.bcr.outputs.sha }} (Cloudflare deploy disabled)"


### PR DESCRIPTION
Remove the `Deploy to production` step that ran `//app/bcr:deploy` and the `CLOUDFLARE_API_TOKEN` env var. The workflow still does the BCR submodule update, gazelle run, and Bazel build end-to-end, so the BCR-trigger keeps validating that a fresh registry snapshot builds clean — it just no longer pushes the result to Cloudflare Pages.

The underlying logic (//app/bcr:deploy target, rules/deploy.bzl, cmd/cfdeploy) is left in place; restoring deploys later is a one- revert change.