### PR TITLE
Bot author avatars + Bazel docs link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Conventions and gotchas for this repo
+
+## Soy templates (`*.soy`)
+
+This project uses Closure Templates (Soy) v3. A few common pitfalls:
+
+- **No `and` / `or` / `not` keywords.** Use the symbol operators: `&&`, `||`, `!`. Soy is closer to JS expression syntax than Python.
+
+  ```soy
+  {if $a && $b}…{/if}            // correct
+  {if $a and $b}…{/if}           // parse error
+
+  {let $x: !$cond /}             // correct
+  {let $x: not $cond /}          // parse error
+  ```
+
+- **Templates can't be called inside `{if}` conditions.** A template invocation may only sit at the top level of a `{print}`, the RHS of `{let}`, or the value of a `{param}`. To use a computed boolean from another template, hoist the call into a `{let}` first.
+
+- **`strContains` doesn't exist as a function call.** Use the string method form: `$str.indexOf($substr) >= 0`. Methods like `.startsWith(...)`, `.endsWith(...)`, `.indexOf(...)` are available; the standalone `strContains(...)` function is not.
+
+- **Optional `string` params need a non-null guard before method calls.** A `{@param? name: string}` has type `string|null`; calling `.startsWith()` on it without coalescing will fail type checking. Bind a normalized local first:
+
+  ```soy
+  {let $safeName: $name ?? '' /}
+  {if $safeName.startsWith('bot/')}…{/if}
+  ```
+
+- **Quote attribute keys in `dom.createDom()`** when calling from JS. The Closure Compiler renames unquoted `class:` / `style:` keys at ADVANCED, silently dropping them from the DOM. Always write `{ "class": "..." }`, not `{ class: "..." }`.
+
+- **`isLast`, `isFirst`, `index` are not soy builtins.** Use `{for $item, $idx in $list}…{/for}` and compare `$idx` to `length($list) - 1` if you need first/last detection.
+
+## Closure JS
+
+- `goog.module` files; not ES modules. The IDE may suggest converting — ignore the hint.
+- Strict typing: array access (`arr[i]`) is typed `T`, not `T|undefined`. But `Array.prototype.find` / `.filter` lambdas often need explicit `@type` JSDoc casts to please the type checker. When the compiler complains "could not determine the type", restructure to a plain `for` loop or annotate the lambda's params.
+- `?HTMLInputElement` (not `?Element`) is required for `.value` access on text inputs. Cast at the `querySelector` boundary.
+- When passing data into `soy.renderAsElement(template, data)`, prefer **inline object literals** at the call site. Returning the data object from a helper function defeats Closure's bidirectional type inference and produces `JSC_TYPE_MISMATCH` against the soy template's strict record type.
+
+## Build and proto regeneration
+
+- The user runs `bazel` themselves. Don't invoke `bazel build` / `bazel run` from agents; it triggers rebuild thrash for them and we don't have to.
+- After editing `*.proto`: regenerate via `bazel run //:proto_assets` (handled by the user).
+- After editing Go sources or `go.mod`: the user runs `go mod tidy` / gazelle as needed.
+
+## Bazel rules
+
+- `ctx.actions.run` does not capture stdout. To redirect, either have the tool itself write to a `--output <path>` flag, or use `ctx.actions.run_shell` (less hermetic). The `cmd/bazelisk` wrapper takes the former approach.
+- Sandboxed actions don't inherit `$HOME`. Tools that derive a cache directory from `os.UserCacheDir()` must fall back explicitly (see `cmd/bazelisk/bazelisk.go`).
+- Parallel `bazel` invocations against the same `$OUTPUT_BASE` serialize on the output-base lock. Pass `--output_user_root=<unique>` per invocation when you need true parallelism, or use `--batch` to skip the server entirely.

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -10,6 +10,8 @@ import {
     octiconChevronRight16,
     octiconChevronUp24,
     octiconCode16,
+    octiconDependabot16,
+    octiconDependabot24,
     octiconDotFill16,
     octiconDotFill24,
     octiconFile16,
@@ -359,6 +361,12 @@ import {
       <span>Bazel on GitHub</span>
     </a>
     <a class="Link--muted d-flex flex-items-center mb-2"
+       href="https://preview.bazel.build"
+       target="_blank" rel="noopener noreferrer">
+      <span class="mr-2">{octiconBook16()}</span>
+      <span>Bazel Documentation</span>
+    </a>
+    <a class="Link--muted d-flex flex-items-center mb-2"
        href="https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md"
        target="_blank" rel="noopener noreferrer">
       <span class="mr-2">{octiconPencil16()}</span>
@@ -480,6 +488,58 @@ import {
 {/template}
 
 
+{template commitAuthorAvatarLink}
+  {@param? name: string}
+  {@param? title: string}
+  {@param size: int}
+  {let $safeName: $name ?? '' /}
+  {let $isBot: $safeName.endsWith('-bot') || $safeName.indexOf('[bot]') >= 0 || $safeName.startsWith('bot/') /}
+{if $safeName && $isBot}
+  <div class="TimelineItem-badge timeline-avatar-badge"
+       title="{$title ?? '@' + $safeName}"
+       style="display: inline-flex; align-items: center; justify-content: center;">
+    {if $size >= 24}
+      {octiconDependabot24(class: 'color-fg-muted')}
+    {else}
+      {octiconDependabot16(class: 'color-fg-muted')}
+    {/if}
+  </div>
+{elseif $safeName}
+  <a href="{githubUserUrl(name: $safeName)}"
+     title="{$title ?? '@' + $safeName}"
+     class="TimelineItem-badge timeline-avatar-badge">
+    <img class="avatar circle" width="{$size}" height="{$size}"
+         src="{githubAvatarUrl(name: $safeName)}"
+         alt="@{$safeName}">
+  </a>
+{else}
+  <div class="TimelineItem-badge timeline-avatar-badge">
+    <img class="avatar circle" width="{$size}" height="{$size}"
+         src="{githubAvatarUrl(name: '')}"
+         alt="bazelbuild">
+  </div>
+{/if}
+{/template}
+
+
+{template commitAuthorNameLink}
+  {@param? name: string}
+  {@param? displayName: string}
+  {@param class: string}
+  {let $safeName: $name ?? '' /}
+  {let $isBot: $safeName.endsWith('-bot') || $safeName.indexOf('[bot]') >= 0 || $safeName.startsWith('bot/') /}
+  {if $safeName}
+    {if $isBot}
+      <span class="{$class}">{$displayName ?? $safeName}</span>
+    {else}
+      <a class="{$class}" href="{githubUserUrl(name: $safeName)}">
+        {$displayName ?? $safeName}
+      </a>
+    {/if}
+  {/if}
+{/template}
+
+
 {template homeRecentTimeline}
   {@param recentlyUpdated: list<[moduleVersion: ModuleVersion, commitDate: string, isNew: bool, linkUrl: string, pullRequestUrl: string, displayName: string]>}
 <div>
@@ -489,21 +549,11 @@ import {
         {let $commit: $item.moduleVersion.getCommit() /}
         {let $hasUser: $commit?.getGithubUser() /}
         <div class="TimelineItem{if $idx == 0} timeline-first{/if}{if $idx == length($recentlyUpdated) - 1} timeline-last{/if}">
-          {if $hasUser}
-            <a href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}"
-               title="{$commit?.getGithubName() ? $commit?.getGithubName() : '@' + $commit?.getGithubUser()}"
-               class="TimelineItem-badge timeline-avatar-badge">
-              <img class="avatar circle" width="42" height="42"
-                   src="{githubAvatarUrl(name: $commit?.getGithubUser() ?? '')}"
-                   alt="@{$commit?.getGithubUser()}">
-            </a>
-          {else}
-            <div class="TimelineItem-badge timeline-avatar-badge">
-              <img class="avatar circle" width="42" height="42"
-                   src="{githubAvatarUrl(name: '')}"
-                   alt="bazelbuild">
-            </div>
-          {/if}
+          {call commitAuthorAvatarLink}
+            {param name: $commit?.getGithubUser() /}
+            {param title: $commit?.getGithubName() ? $commit?.getGithubName() : ('@' + ($commit?.getGithubUser() ?? '')) /}
+            {param size: 42 /}
+          {/call}
           <div class="TimelineItem-body">
             <div class="d-flex flex-items-center">
               <div style="flex-shrink: 0">
@@ -527,9 +577,11 @@ import {
                 </a>
                 {if $hasUser}
                   {sp}by{sp}
-                  <a class="Link--muted text-bold" href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}">
-                    {$commit?.getGithubName() ? $commit?.getGithubName() : $commit?.getGithubUser()}
-                  </a>
+                  {call commitAuthorNameLink}
+                    {param name: $commit?.getGithubUser() /}
+                    {param displayName: $commit?.getGithubName() ? $commit?.getGithubName() : $commit?.getGithubUser() /}
+                    {param class: 'Link--muted text-bold' /}
+                  {/call}
                 {/if}
               </div>
             {/if}
@@ -636,13 +688,13 @@ import {
       <div class="Box mb-3">
         <div class="Box-row d-flex flex-items-center">
           {if $hasUser}
-            <a href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}"
-               class="d-flex flex-items-center mr-3"
-               title="{$commit?.getGithubName() ? $commit?.getGithubName() : '@' + $commit?.getGithubUser()}">
-              <img class="avatar circle" width="32" height="32"
-                   src="{githubAvatarUrl(name: $commit?.getGithubUser() ?? '')}"
-                   alt="@{$commit?.getGithubUser()}">
-            </a>
+            <div class="mr-3">
+              {call commitAuthorAvatarLink}
+                {param name: $commit?.getGithubUser() /}
+                {param title: $commit?.getGithubName() ? $commit?.getGithubName() : ('@' + ($commit?.getGithubUser() ?? '')) /}
+                {param size: 32 /}
+              {/call}
+            </div>
           {/if}
           <div>
             <div>
@@ -662,9 +714,11 @@ import {
                 {/if}
                 {if $hasUser}
                   {if $commit?.getPullRequest()}{sp}by{sp}{/if}
-                  <a class="Link--muted text-bold" href="{githubUserUrl(name: $commit?.getGithubUser() ?? '')}">
-                    {$commit?.getGithubName() ? $commit?.getGithubName() : $commit?.getGithubUser()}
-                  </a>
+                  {call commitAuthorNameLink}
+                    {param name: $commit?.getGithubUser() /}
+                    {param displayName: $commit?.getGithubName() ? $commit?.getGithubName() : $commit?.getGithubUser() /}
+                    {param class: 'Link--muted text-bold' /}
+                  {/call}
                 {/if}
               </div>
             {/if}

--- a/data/generated.MODULE.bazel
+++ b/data/generated.MODULE.bazel
@@ -24,7 +24,7 @@ use_repo(
     "bzl.abseil-py---2.1.0",
     "bzl.abseil-py---2.4.0",
     "bzl.aexml---4.7.0.1",
-    "bzl.antlr4-cpp-runtime---4.12.0",
+    "bzl.antlr4-cpp-runtime---4.13.2.bcr.1",
     "bzl.ape---1.0.1",
     "bzl.apple_rules_lint---0.3.2",
     "bzl.apple_rules_lint---0.4.0",
@@ -48,7 +48,6 @@ use_repo(
     "bzl.apple_support---2.5.4",
     "bzl.argparse---3.2.0",
     "bzl.asc_swift---1.6.0",
-    "bzl.asio---1.24.0",
     "bzl.asio---1.32.0",
     "bzl.aspect_bazel_lib---1.28.0",
     "bzl.aspect_bazel_lib---1.38.1",
@@ -116,7 +115,6 @@ use_repo(
     "bzl.aspect_tools_telemetry---0.2.8",
     "bzl.aspect_tools_telemetry---0.3.3",
     "bzl.assimp---5.4.3.bcr.6",
-    "bzl.assimp---6.0.2",
     "bzl.awk.bzl---0.2.3",
     "bzl.aws-in-a-box---0.0.69",
     "bzl.babylon---1.4.4",
@@ -180,8 +178,8 @@ use_repo(
     "bzl.bazel_skylib---1.8.2",
     "bzl.bazel_skylib---1.9.0",
     "bzl.bazel_skylib_gazelle_plugin---1.9.0",
-    "bzl.bazel_sonarqube---1.0.5",
-    "bzl.bazel_tools---8.7.0rc2",
+    "bzl.bazel_sonarqube---1.0.6",
+    "bzl.bazel_tools---8.7.0",
     "bzl.bazel_worker_java---0.0.10",
     "bzl.bazel_worker_java---0.0.4",
     "bzl.bazel_worker_java---0.0.5",
@@ -202,13 +200,11 @@ use_repo(
     "bzl.boost.any---1.89.0.bcr.2",
     "bzl.boost.any---1.90.0.bcr.1",
     "bzl.boost.array---1.87.0",
-    "bzl.boost.array---1.88.0.bcr.3",
     "bzl.boost.array---1.89.0.bcr.2",
     "bzl.boost.array---1.90.0.bcr.1",
     "bzl.boost.asio---1.87.0.bcr.1",
     "bzl.boost.asio---1.89.0.bcr.2",
     "bzl.boost.asio---1.90.0.bcr.1",
-    "bzl.boost.assert---1.83.0.bcr.4",
     "bzl.boost.assert---1.87.0",
     "bzl.boost.assert---1.89.0.bcr.2",
     "bzl.boost.assert---1.90.0.bcr.1",
@@ -230,6 +226,7 @@ use_repo(
     "bzl.boost.charconv---1.89.0.bcr.2",
     "bzl.boost.charconv---1.90.0.bcr.1",
     "bzl.boost.chrono---1.87.0",
+    "bzl.boost.chrono---1.88.0.bcr.3",
     "bzl.boost.chrono---1.89.0.bcr.2",
     "bzl.boost.chrono---1.90.0.bcr.1",
     "bzl.boost.circular_buffer---1.89.0.bcr.2",
@@ -243,14 +240,12 @@ use_repo(
     "bzl.boost.config---1.87.0",
     "bzl.boost.config---1.89.0.bcr.2",
     "bzl.boost.config---1.90.0.bcr.1",
-    "bzl.boost.container---1.88.0.bcr.3",
+    "bzl.boost.container---1.87.0.bcr.2",
     "bzl.boost.container---1.89.0.bcr.2",
     "bzl.boost.container---1.90.0.bcr.1",
     "bzl.boost.container_hash---1.87.0",
-    "bzl.boost.container_hash---1.88.0.bcr.3",
     "bzl.boost.container_hash---1.89.0.bcr.2",
     "bzl.boost.container_hash---1.90.0.bcr.1",
-    "bzl.boost.context---1.88.0.bcr.3",
     "bzl.boost.context---1.89.0.bcr.2",
     "bzl.boost.context---1.90.0.bcr.1",
     "bzl.boost.conversion---1.87.0",
@@ -272,6 +267,7 @@ use_repo(
     "bzl.boost.describe---1.87.0",
     "bzl.boost.describe---1.89.0.bcr.2",
     "bzl.boost.describe---1.90.0.bcr.1",
+    "bzl.boost.detail---1.83.0.bcr.4",
     "bzl.boost.detail---1.87.0",
     "bzl.boost.detail---1.89.0.bcr.2",
     "bzl.boost.detail---1.90.0.bcr.1",
@@ -280,6 +276,7 @@ use_repo(
     "bzl.boost.dynamic_bitset---1.87.0",
     "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
+    "bzl.boost.endian---1.83.0.bcr.4",
     "bzl.boost.endian---1.87.0",
     "bzl.boost.endian---1.89.0.bcr.2",
     "bzl.boost.endian---1.90.0.bcr.1",
@@ -293,18 +290,16 @@ use_repo(
     "bzl.boost.foreach---1.90.0.bcr.1",
     "bzl.boost.format---1.89.0.bcr.2",
     "bzl.boost.format---1.90.0.bcr.1",
-    "bzl.boost.function---1.83.0.bcr.4",
     "bzl.boost.function---1.87.0",
+    "bzl.boost.function---1.88.0.bcr.3",
     "bzl.boost.function---1.89.0.bcr.2",
     "bzl.boost.function---1.90.0.bcr.1",
     "bzl.boost.function_types---1.87.0",
-    "bzl.boost.function_types---1.88.0.bcr.3",
     "bzl.boost.function_types---1.89.0.bcr.2",
     "bzl.boost.function_types---1.90.0.bcr.1",
     "bzl.boost.functional---1.87.0",
     "bzl.boost.functional---1.89.0.bcr.2",
     "bzl.boost.functional---1.90.0.bcr.1",
-    "bzl.boost.fusion---1.83.0.bcr.4",
     "bzl.boost.fusion---1.87.0",
     "bzl.boost.fusion---1.89.0.bcr.2",
     "bzl.boost.fusion---1.90.0.bcr.1",
@@ -322,15 +317,14 @@ use_repo(
     "bzl.boost.icl---1.89.0.bcr.2",
     "bzl.boost.icl---1.90.0.bcr.1",
     "bzl.boost.integer---1.87.0",
-    "bzl.boost.integer---1.88.0.bcr.3",
     "bzl.boost.integer---1.89.0.bcr.2",
     "bzl.boost.integer---1.90.0.bcr.1",
     "bzl.boost.interprocess---1.89.0.bcr.2",
     "bzl.boost.interprocess---1.90.0.bcr.1",
-    "bzl.boost.intrusive---1.83.0.bcr.4",
     "bzl.boost.intrusive---1.87.0",
     "bzl.boost.intrusive---1.89.0.bcr.2",
     "bzl.boost.intrusive---1.90.0.bcr.1",
+    "bzl.boost.io---1.88.0.bcr.1",
     "bzl.boost.io---1.89.0.bcr.2",
     "bzl.boost.io---1.90.0.bcr.1",
     "bzl.boost.iostreams---1.88.0.bcr.4",
@@ -358,9 +352,9 @@ use_repo(
     "bzl.boost.math---1.87.0",
     "bzl.boost.math---1.89.0.bcr.2",
     "bzl.boost.math---1.90.0.bcr.1",
-    "bzl.boost.move---1.88.0.bcr.1",
     "bzl.boost.move---1.89.0.bcr.2",
     "bzl.boost.move---1.90.0.bcr.1",
+    "bzl.boost.mp11---1.83.0.bcr.4",
     "bzl.boost.mp11---1.87.0",
     "bzl.boost.mp11---1.89.0.bcr.2",
     "bzl.boost.mp11---1.90.0.bcr.1",
@@ -391,19 +385,19 @@ use_repo(
     "bzl.boost.pfr---1.89.0.bcr.2",
     "bzl.boost.pfr---1.90.0.bcr.1",
     "bzl.boost.phoenix---1.87.0",
+    "bzl.boost.phoenix---1.88.0.bcr.3",
     "bzl.boost.phoenix---1.89.0.bcr.2",
     "bzl.boost.phoenix---1.90.0.bcr.1",
     "bzl.boost.polygon---1.89.0.bcr.2",
     "bzl.boost.polygon---1.90.0.bcr.1",
-    "bzl.boost.pool---1.83.0.bcr.4",
     "bzl.boost.pool---1.87.0",
     "bzl.boost.pool---1.89.0.bcr.2",
     "bzl.boost.pool---1.90.0.bcr.1",
     "bzl.boost.predef---1.87.0",
     "bzl.boost.predef---1.89.0.bcr.2",
     "bzl.boost.predef---1.90.0.bcr.1",
-    "bzl.boost.preprocessor---1.83.0.bcr.4",
     "bzl.boost.preprocessor---1.87.0",
+    "bzl.boost.preprocessor---1.90.0",
     "bzl.boost.preprocessor---1.90.0.bcr.1",
     "bzl.boost.process---1.89.0.bcr.2",
     "bzl.boost.process---1.90.0.bcr.1",
@@ -413,7 +407,6 @@ use_repo(
     "bzl.boost.property_map---1.90.0.bcr.1",
     "bzl.boost.property_tree---1.89.0.bcr.2",
     "bzl.boost.property_tree---1.90.0.bcr.1",
-    "bzl.boost.proto---1.83.0.bcr.4",
     "bzl.boost.proto---1.87.0",
     "bzl.boost.proto---1.89.0.bcr.2",
     "bzl.boost.proto---1.90.0.bcr.1",
@@ -425,17 +418,16 @@ use_repo(
     "bzl.boost.random---1.87.0",
     "bzl.boost.random---1.89.0.bcr.2",
     "bzl.boost.random---1.90.0.bcr.1",
+    "bzl.boost.range---1.83.0.bcr.4",
     "bzl.boost.range---1.87.0",
     "bzl.boost.range---1.89.0.bcr.2",
     "bzl.boost.range---1.90.0.bcr.1",
-    "bzl.boost.ratio---1.83.0.bcr.4",
     "bzl.boost.ratio---1.87.0",
     "bzl.boost.ratio---1.89.0.bcr.2",
     "bzl.boost.ratio---1.90.0.bcr.1",
     "bzl.boost.rational---1.87.0",
     "bzl.boost.rational---1.89.0.bcr.2",
     "bzl.boost.rational---1.90.0.bcr.1",
-    "bzl.boost.regex---1.83.0.bcr.4",
     "bzl.boost.regex---1.87.0",
     "bzl.boost.regex---1.89.0.bcr.2",
     "bzl.boost.regex---1.90.0.bcr.1",
@@ -443,6 +435,7 @@ use_repo(
     "bzl.boost.scope---1.90.0.bcr.1",
     "bzl.boost.scope_exit---1.89.0.bcr.2",
     "bzl.boost.scope_exit---1.90.0.bcr.1",
+    "bzl.boost.serialization---1.83.0.bcr.4",
     "bzl.boost.serialization---1.89.0.bcr.2",
     "bzl.boost.serialization---1.90.0.bcr.1",
     "bzl.boost.signals2---1.89.0.bcr.2",
@@ -469,6 +462,7 @@ use_repo(
     "bzl.boost.thread---1.83.0.bcr.4",
     "bzl.boost.thread---1.89.0.bcr.2",
     "bzl.boost.thread---1.90.0.bcr.1",
+    "bzl.boost.throw_exception---1.83.0.bcr.4",
     "bzl.boost.throw_exception---1.87.0",
     "bzl.boost.throw_exception---1.89.0.bcr.2",
     "bzl.boost.throw_exception---1.90.0.bcr.1",
@@ -483,20 +477,18 @@ use_repo(
     "bzl.boost.tuple---1.87.0",
     "bzl.boost.tuple---1.89.0.bcr.2",
     "bzl.boost.tuple---1.90.0.bcr.1",
-    "bzl.boost.type_index---1.83.0.bcr.4",
     "bzl.boost.type_index---1.87.0",
+    "bzl.boost.type_index---1.88.0.bcr.3",
     "bzl.boost.type_index---1.89.0.bcr.2",
     "bzl.boost.type_index---1.90.0.bcr.1",
     "bzl.boost.type_traits---1.87.0",
     "bzl.boost.type_traits---1.89.0.bcr.2",
     "bzl.boost.type_traits---1.90.0.bcr.1",
-    "bzl.boost.typeof---1.83.0.bcr.4",
     "bzl.boost.typeof---1.87.0",
     "bzl.boost.typeof---1.89.0.bcr.2",
     "bzl.boost.typeof---1.90.0.bcr.1",
     "bzl.boost.units---1.89.0.bcr.2",
     "bzl.boost.units---1.90.0.bcr.1",
-    "bzl.boost.unordered---1.83.0.bcr.4",
     "bzl.boost.unordered---1.87.0",
     "bzl.boost.unordered---1.89.0.bcr.2",
     "bzl.boost.unordered---1.90.0.bcr.1",
@@ -507,22 +499,22 @@ use_repo(
     "bzl.boost.utility---1.90.0.bcr.1",
     "bzl.boost.uuid---1.89.0.bcr.2",
     "bzl.boost.uuid---1.90.0.bcr.1",
+    "bzl.boost.variant---1.83.0.bcr.4",
     "bzl.boost.variant---1.87.0",
-    "bzl.boost.variant---1.88.0.bcr.3",
     "bzl.boost.variant---1.89.0.bcr.2",
     "bzl.boost.variant---1.90.0.bcr.1",
-    "bzl.boost.variant2---1.83.0.bcr.4",
     "bzl.boost.variant2---1.87.0",
+    "bzl.boost.variant2---1.88.0.bcr.3",
     "bzl.boost.variant2---1.89.0.bcr.2",
     "bzl.boost.variant2---1.90.0.bcr.1",
     "bzl.boost.vmd---1.89.0.bcr.2",
     "bzl.boost.vmd---1.90.0.bcr.1",
     "bzl.boost.winapi---1.87.0",
-    "bzl.boost.winapi---1.90.0",
+    "bzl.boost.winapi---1.88.0.bcr.3",
     "bzl.boost.winapi---1.90.0.bcr.1",
     "bzl.boost.xpressive---1.89.0.bcr.2",
     "bzl.boost.xpressive---1.90.0.bcr.1",
-    "bzl.boost---1.83.0.bcr.4",
+    "bzl.boost---1.88.0.bcr.3",
     "bzl.boost---1.90.0.bcr.1",
     "bzl.boringssl---0.0.0-20211025-d4f1ab9",
     "bzl.boringssl---0.0.0-20230215-5c22014",
@@ -560,6 +552,7 @@ use_repo(
     "bzl.c-ares---1.15.0",
     "bzl.c-ares---1.16.1",
     "bzl.c-ares---1.19.1.bcr.1",
+    "bzl.c-ares---1.34.6",
     "bzl.c-blosc2---2.22.0",
     "bzl.c4core---0.2.6",
     "bzl.capnp-cpp---1.1.0",
@@ -613,6 +606,7 @@ use_repo(
     "bzl.cucumber-cpp---0.8.0.bcr.1",
     "bzl.cuda_toolchain_types---0.0.1",
     "bzl.cuda_toolkit---0.0.2",
+    "bzl.curl---8.12.0.bcr.1",
     "bzl.curl---8.7.1",
     "bzl.cxx.rs---1.0.194",
     "bzl.cxxopts---3.3.1",
@@ -631,20 +625,21 @@ use_repo(
     "bzl.download_utils---1.0.1",
     "bzl.effcee---0.0.0-20250222",
     "bzl.egl-registry---0.0.0-20250527",
-    "bzl.eigen---3.4.0.bcr.2",
     "bzl.eigen---3.4.0.bcr.3",
     "bzl.eigen---3.4.1.bcr.1",
+    "bzl.eigen---4.0.0-20241125.bcr.1",
     "bzl.elemental2---1.3.2",
     "bzl.emboss---2026.0212.185041",
     "bzl.emsdk---4.0.13",
-    "bzl.emsdk---5.0.5",
-    "bzl.engflowapis---2024.12.06-06.17.32",
+    "bzl.emsdk---5.0.7",
+    "bzl.engflowapis---2024.12.04-12.50.55",
     "bzl.engflowapis-java---2025.07.24-06.20.24",
     "bzl.envoy_api---0.0.0-20241214-918efc9",
     "bzl.envoy_api---0.0.0-20250128-4de3c74",
     "bzl.envoy_api---0.0.0-20251105-4a2b9a3",
     "bzl.envoy_api---0.0.0-20251216-6ef568c",
     "bzl.envoy_toolshed---0.3.25",
+    "bzl.evidence_store_bazel---0.0.1",
     "bzl.extra_rules_java---1.3",
     "bzl.fast_double_parser---0.8.0",
     "bzl.fast_float---8.0.2",
@@ -660,21 +655,21 @@ use_repo(
     "bzl.flex---2.6.4.bcr.5",
     "bzl.flip---1.6",
     "bzl.fmt---10.1.1",
+    "bzl.fmt---10.2.1.bcr.1",
     "bzl.fmt---11.1.3",
-    "bzl.fmt---11.1.4",
     "bzl.fmt---12.1.0",
     "bzl.fmt---8.1.1",
     "bzl.folly---2025.01.13.00.bcr.6",
     "bzl.fp16---0.0.0-20210320-0a92994",
     "bzl.freeimage---3.19.10.bcr.5",
-    "bzl.freetype---2.9",
+    "bzl.freetype---2.13.3.bcr.2",
     "bzl.fremtind_rules_vitest---0.2.1",
     "bzl.fshlib---0.2.0",
     "bzl.ftxui---6.1.9",
     "bzl.fuzztest---20260219.0",
     "bzl.fxdiv---0.0.0-20201209-63058ef",
     "bzl.gawk---5.3.2.bcr.1",
-    "bzl.gawk---5.3.2.bcr.6",
+    "bzl.gawk---5.3.2.bcr.4",
     "bzl.gazelle---0.29.0",
     "bzl.gazelle---0.30.0",
     "bzl.gazelle---0.33.0",
@@ -694,9 +689,9 @@ use_repo(
     "bzl.gazelle---0.47.0",
     "bzl.gazelle---0.50.0",
     "bzl.gazelle_cc---0.5.0",
-    "bzl.gazelle_fold---0.1.0",
+    "bzl.gazelle_fold---0.2.0",
     "bzl.gazelle_py---0.8.6",
-    "bzl.gazelle_ts---0.4.10",
+    "bzl.gazelle_ts---0.4.11",
     "bzl.gcc_toolchain---0.9.0",
     "bzl.generate_export_header---0.1.0",
     "bzl.gflags---2.2.2.bcr.1",
@@ -704,7 +699,7 @@ use_repo(
     "bzl.glog---0.6.0",
     "bzl.glog---0.7.0",
     "bzl.glog---0.7.1.bcr.1",
-    "bzl.glpk---5.0.bcr.5",
+    "bzl.glpk---5.0.bcr.3",
     "bzl.gonzojive_protobuf_javascript---3.21.5.esm",
     "bzl.google_bazel_common---0.0.1",
     "bzl.google_benchmark---1.8.2",
@@ -721,6 +716,7 @@ use_repo(
     "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
     "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
     "bzl.googleapis---0.0.0-20251003-2193a2bf",
+    "bzl.googleapis---0.0.0-20260109-6145b5ff",
     "bzl.googleapis---0.0.0-20260130-c0fcb356",
     "bzl.googleapis---0.0.0-20260223-edfe7983",
     "bzl.googleapis---0.0.0-20260402-c8ca5bce",
@@ -730,17 +726,16 @@ use_repo(
     "bzl.googletest---1.11.0",
     "bzl.googletest---1.14.0.bcr.1",
     "bzl.googletest---1.15.2",
-    "bzl.googletest---1.16.0.bcr.2",
     "bzl.googletest---1.17.0.bcr.2",
     "bzl.gotopt2---2.2.19",
     "bzl.gperftools---2.18.1",
     "bzl.grpc---1.41.0",
+    "bzl.grpc---1.48.1.bcr.3",
     "bzl.grpc---1.56.3.bcr.1",
     "bzl.grpc---1.68.0",
     "bzl.grpc---1.69.0",
     "bzl.grpc---1.70.1",
     "bzl.grpc---1.71.0",
-    "bzl.grpc---1.71.2",
     "bzl.grpc---1.72.0",
     "bzl.grpc---1.73.1",
     "bzl.grpc---1.74.1",
@@ -757,7 +752,6 @@ use_repo(
     "bzl.grpc_ecosystem_grpc_gateway---2.26.3",
     "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
     "bzl.grpc_kotlin---1.5.0",
-    "bzl.gutil---20260226.0",
     "bzl.gutil---20260309.0.bcr.1",
     "bzl.gz-common---7.0.0",
     "bzl.gz-common---7.1.0",
@@ -830,7 +824,7 @@ use_repo(
     "bzl.libpfm---4.11.0.bcr.2",
     "bzl.libpng---1.6.41",
     "bzl.libprotobuf-mutator---1.3",
-    "bzl.librdkafka---2.8.0.bcr.2",
+    "bzl.librdkafka---2.3.0.bcr.1",
     "bzl.libsodium---1.0.19",
     "bzl.libunwind---1.8.1",
     "bzl.libunwind---1.8.3",
@@ -838,43 +832,42 @@ use_repo(
     "bzl.liburing---2.5",
     "bzl.libuuid---2.39.3.bcr.1",
     "bzl.libwebp---1.5.0",
-    "bzl.libx11---1.8.12",
+    "bzl.libx11---1.8.12.bcr.5",
     "bzl.libxau---1.0.12.bcr.2",
     "bzl.libxcb---1.17.0.bcr.2",
     "bzl.libxtrans---1.5.2.bcr.2",
     "bzl.libyaml---0.2.5",
-    "bzl.libzip---1.10.1.bcr.1",
+    "bzl.libzip---1.11.4.bcr.2",
     "bzl.libzmq---4.3.5.bcr.4",
     "bzl.lit2md---1.0.1",
+    "bzl.llvm---0.7.9",
     "bzl.llvm-project---17.0.3.bcr.4",
     "bzl.lz4---1.10.0.bcr.1",
     "bzl.lz4---1.9.4.bcr.2",
     "bzl.lz4-erlang---1.9.2.5",
-    "bzl.m4---1.4.21.bcr.1",
+    "bzl.m4---1.4.20.bcr.2",
     "bzl.magic_enum---0.9.8",
     "bzl.maliput---1.15.0",
     "bzl.maliput---1.16.0",
-    "bzl.maliput_geopackage---0.3.1",
+    "bzl.maliput_geopackage---0.5.0",
     "bzl.maliput_malidrive---0.22.0",
-    "bzl.maliput_sparse---0.4.0",
-    "bzl.maliput_sparse---0.5.0",
+    "bzl.maliput_sparse---0.6.0",
     "bzl.marisa-trie---0.2.6",
     "bzl.masorange_rules_helm---1.7.1",
     "bzl.mbedtls---3.6.0.bcr.1",
-    "bzl.mbedtls---3.6.5",
     "bzl.modern-cpp-kafka---2024.07.03.bcr.1",
     "bzl.mvfst---2025.01.20.00.bcr.1",
     "bzl.nanobind_bazel---2.12.0",
     "bzl.nanopb---0.4.9.1.bcr.3",
-    "bzl.nasm---2.14.02",
+    "bzl.nasm---2.16.03",
     "bzl.ncurses---6.4.20221231.bcr.9",
     "bzl.ng-log---0.8.0-rc1",
-    "bzl.nlohmann_json---3.11.2",
     "bzl.nlohmann_json---3.11.3.bcr.1",
     "bzl.nlohmann_json---3.12.0.bcr.1",
     "bzl.nlohmann_json---3.6.1",
     "bzl.nogo_analyzer_bzlmod---0.1.0",
     "bzl.nsync---1.29.2",
+    "bzl.octomap---1.10.0",
     "bzl.octomap---1.9.7.bcr.1",
     "bzl.ode---0.16.6.bcr.1",
     "bzl.ofiuco---0.3.7",
@@ -900,9 +893,10 @@ use_repo(
     "bzl.openjph---0.26.3.bcr.1",
     "bzl.openssl---3.3.1.bcr.9",
     "bzl.openssl---3.5.4.bcr.1",
+    "bzl.openssl---3.5.5.bcr.4",
+    "bzl.opentelemetry-cpp---1.14.2.bcr.1",
     "bzl.opentelemetry-cpp---1.16.0",
     "bzl.opentelemetry-cpp---1.19.0",
-    "bzl.opentelemetry-cpp---1.22.0",
     "bzl.opentelemetry-cpp---1.24.0.bcr.1",
     "bzl.opentelemetry-proto---1.1.0",
     "bzl.opentelemetry-proto---1.3.1",
@@ -970,7 +964,7 @@ use_repo(
     "bzl.protobuf-matchers---0.1.2",
     "bzl.protoc-gen-validate---1.0.4.bcr.2",
     "bzl.protoc-gen-validate---1.2.1.bcr.2",
-    "bzl.protoc-gen-validate---1.3.0",
+    "bzl.protoc-gen-validate---1.3.3",
     "bzl.protothreads---0.1.6",
     "bzl.protovalidate---1.1.1",
     "bzl.protovalidate---1.2.0",
@@ -988,7 +982,7 @@ use_repo(
     "bzl.pybind11_bazel---3.0.1",
     "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
-    "bzl.qdldl---0.1.8.bcr.1",
+    "bzl.qdldl---0.1.7.bcr.1",
     "bzl.quill---11.1.0",
     "bzl.range-v3---0.12.0",
     "bzl.range-v3---0.12.1-20260505-108f93c",
@@ -998,7 +992,7 @@ use_repo(
     "bzl.re.bzl---0.2.0",
     "bzl.re2---2021-09-01",
     "bzl.re2---2023-09-01",
-    "bzl.re2---2024-02-01",
+    "bzl.re2---2024-05-01",
     "bzl.re2---2024-07-02.bcr.1",
     "bzl.re2---2025-08-12.bcr.1",
     "bzl.re2---2025-11-05.bcr.1",
@@ -1009,6 +1003,7 @@ use_repo(
     "bzl.robin-map---1.4.0",
     "bzl.rocksdb---9.11.2",
     "bzl.rpmpack---0.6.0",
+    "bzl.rsync---3.4.2",
     "bzl.ruff_prebuilt---0.15.12.1",
     "bzl.rules_abs---0.1.0",
     "bzl.rules_android---0.1.1",
@@ -1018,7 +1013,7 @@ use_repo(
     "bzl.rules_android---0.7.2",
     "bzl.rules_android_ndk---0.1.5",
     "bzl.rules_angular---0.1.0",
-    "bzl.rules_apko---1.5.46",
+    "bzl.rules_apko---1.5.47",
     "bzl.rules_appimage---1.20.0",
     "bzl.rules_apple---3.13.0",
     "bzl.rules_apple---3.16.0",
@@ -1039,7 +1034,6 @@ use_repo(
     "bzl.rules_batch---0.0.1",
     "bzl.rules_bazel_integration_test---0.37.1",
     "bzl.rules_bison---0.3",
-    "bzl.rules_bison---0.3.2",
     "bzl.rules_bison---0.4.bcr.1",
     "bzl.rules_browsers---0.4.0",
     "bzl.rules_bsx---1.0.1",
@@ -1145,7 +1139,7 @@ use_repo(
     "bzl.rules_graphql---0.1.3",
     "bzl.rules_haskell---1.0",
     "bzl.rules_heir---0.0.3",
-    "bzl.rules_helm---0.24.0",
+    "bzl.rules_helm---0.25.0",
     "bzl.rules_img---0.3.3",
     "bzl.rules_img---0.3.9",
     "bzl.rules_img_pull_tool---0.3.9",
@@ -1263,6 +1257,7 @@ use_repo(
     "bzl.rules_pkg---1.0.1",
     "bzl.rules_pkg---1.1.0",
     "bzl.rules_pkg---1.2.0",
+    "bzl.rules_pkg_providers---0.0.1",
     "bzl.rules_pkl---0.15.0",
     "bzl.rules_platform---0.1.0",
     "bzl.rules_playwright---0.5.3",
@@ -1275,6 +1270,7 @@ use_repo(
     "bzl.rules_proto---4.0.0",
     "bzl.rules_proto---5.3.0-21.7",
     "bzl.rules_proto---6.0.0-rc1",
+    "bzl.rules_proto---6.0.0-rc2",
     "bzl.rules_proto---6.0.2",
     "bzl.rules_proto---7.0.2",
     "bzl.rules_proto---7.1.0",
@@ -1294,13 +1290,12 @@ use_repo(
     "bzl.rules_proto_grpc_python---5.8.0",
     "bzl.rules_proto_grpc_scala---5.8.0",
     "bzl.rules_proto_grpc_swift---5.8.0",
-    "bzl.rules_pycross---0.8.1",
+    "bzl.rules_pycross---0.8.2",
     "bzl.rules_pydeps---0.5.0",
     "bzl.rules_python---0.10.2",
-    "bzl.rules_python---0.17.3",
     "bzl.rules_python---0.4.0",
     "bzl.rules_python---1.7.0",
-    "bzl.rules_python_gazelle_plugin---1.5.2",
+    "bzl.rules_python_gazelle_plugin---0.33.1",
     "bzl.rules_qemu---0.1.0",
     "bzl.rules_qt---0.0.6",
     "bzl.rules_req_compile---1.1.0",
@@ -1313,8 +1308,8 @@ use_repo(
     "bzl.rules_ruby---0.19.0",
     "bzl.rules_ruby---0.25.0",
     "bzl.rules_runfiles_group---0.0.1-rc.4",
+    "bzl.rules_rust---0.38.0",
     "bzl.rules_rust---0.45.1",
-    "bzl.rules_rust---0.49.3",
     "bzl.rules_rust---0.51.0",
     "bzl.rules_rust_mutants---0.69.1",
     "bzl.rules_rust_mutation---0.69.0",
@@ -1365,7 +1360,7 @@ use_repo(
     "bzl.rules_swift_resources---0.3.1",
     "bzl.rules_syft---0.0.2",
     "bzl.rules_synology---0.2.3",
-    "bzl.rules_systemrdl---0.1.1",
+    "bzl.rules_systemrdl---0.2.0",
     "bzl.rules_tcl---0.2.1",
     "bzl.rules_tensorrt_rtx---0.3.0",
     "bzl.rules_testing---0.9.0",
@@ -1388,7 +1383,7 @@ use_repo(
     "bzl.rules_vulkan---0.8.0",
     "bzl.rules_wasm---2.3.0",
     "bzl.rules_webtesting---0.4.1",
-    "bzl.rules_xcodeproj---4.0.1",
+    "bzl.rules_xcodeproj---4.1.0",
     "bzl.rules_ytt---0.4.0",
     "bzl.rules_zig---0.14.0",
     "bzl.ruy---0.0.0-20200416-9f53ba4",
@@ -1418,7 +1413,7 @@ use_repo(
     "bzl.spirv_headers---1.4.341.0",
     "bzl.spirv_tools---2026.1",
     "bzl.sqids_bazel---0.1.0",
-    "bzl.sqlite3---3.49.0.bcr.1",
+    "bzl.sqlite3---3.48.0",
     "bzl.sqlite3---3.50.3",
     "bzl.squashfs-tools---4.7.4",
     "bzl.stardoc---0.5.0",
@@ -1449,7 +1444,7 @@ use_repo(
     "bzl.swift_bep_parser---0.0.6",
     "bzl.swift_gazelle_plugin---0.2.2",
     "bzl.swiftlint---0.63.2",
-    "bzl.swig---4.1.0",
+    "bzl.swig---4.3.0.bcr.2",
     "bzl.swxmlhash---7.0.2.2",
     "bzl.systemc---3.0.2.bcr.1",
     "bzl.tar.bzl---0.10.1",
@@ -1478,8 +1473,8 @@ use_repo(
     "bzl.toolchains_avr---0.1.2",
     "bzl.toolchains_buildbuddy---0.0.4",
     "bzl.toolchains_llvm---1.7.0",
-    "bzl.toolchains_llvm_bootstrapped---0.5.3",
-    "bzl.toolchains_musl---0.1.27",
+    "bzl.toolchains_llvm_bootstrapped---0.2.1",
+    "bzl.toolchains_musl---0.1.27.bcr.1",
     "bzl.toolchains_protoc---0.2.1",
     "bzl.toolchains_protoc---0.3.1",
     "bzl.toolchains_protoc---0.5.0",
@@ -1496,8 +1491,8 @@ use_repo(
     "bzl.upb---0.0.0-20230516-61a97ef",
     "bzl.upb---0.0.0-20230907-e7430e6",
     "bzl.verible---0.0.3933",
+    "bzl.verilator---5.034.bcr.2",
     "bzl.verilator---5.036.bcr.3",
-    "bzl.verilator---5.046.bcr.4",
     "bzl.version_utils---0.1.0",
     "bzl.vhdl_ls_gen---0.3.0",
     "bzl.wangle---2025.02.10.00.bcr.2",
@@ -1514,6 +1509,7 @@ use_repo(
     "bzl.xds---0.0.0-20251210-ee656c7",
     "bzl.xml.bzl---0.2.3",
     "bzl.xorgproto---2024.1.bcr.1",
+    "bzl.xxhash---0.8.3.bcr.1",
     "bzl.xz---5.4.5.bcr.8",
     "bzl.yaml.bzl---0.1.2",
     "bzl.yaml-cpp---0.8.0.bcr.1",
@@ -1528,8 +1524,10 @@ use_repo(
     "bzl.zipkin-api---1.0.0.bcr.1",
     "bzl.zlib---1.2.11",
     "bzl.zlib---1.2.12",
+    "bzl.zlib---1.3",
     "bzl.zlib---1.3.1.bcr.8",
     "bzl.zlib-ng---2.0.7",
+    "bzl.zstd---1.5.5.bcr.2",
     "bzl.zstd---1.5.6",
     "bzl.zstd---1.5.7.bcr.1",
     "bzl.zstd-jni---1.5.6-9",
@@ -3206,22 +3204,13 @@ http_archive(
 )
 
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.2",
+    name = "bzl.abseil-cpp---20230802.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.2",
+    strip_prefix = "abseil-cpp-20230802.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20211102.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20211102.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250814.2",
@@ -3233,13 +3222,40 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    name = "bzl.abseil-cpp---20250127.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240722.0",
+    strip_prefix = "abseil-cpp-20250127.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20260107.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20260107.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20211102.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20211102.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250512.0",
@@ -3260,22 +3276,67 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20260107.1",
+    name = "bzl.abseil-cpp---20240116.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20260107.1",
+    strip_prefix = "abseil-cpp-20240116.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.0.bcr.1",
+    name = "bzl.abseil-cpp---20250814.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.0",
+    strip_prefix = "abseil-cpp-20250814.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240722.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250814.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250814.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.2",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20210324.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20210324.2",
+    type = "zip",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250512.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250512.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20230125.1",
@@ -3296,42 +3357,6 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250127.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250127.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.abseil-cpp---20260107.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3339,42 +3364,6 @@ starlark_repository.archive(
     strip_prefix = "abseil-cpp-20260107.0",
     type = "tar.gz",
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250512.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250512.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20210324.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20210324.2",
-    type = "zip",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-py---2.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-py-2.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-py---2.1.0",
@@ -3386,6 +3375,15 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.abseil-py---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-py-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aexml---4.7.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3395,13 +3393,13 @@ starlark_repository.archive(
     urls = ["https://github.com/tadija/AEXML/archive/refs/tags/4.7.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.antlr4-cpp-runtime---4.12.0",
+    name = "bzl.antlr4-cpp-runtime---4.13.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "antlr4-4.12.0/runtime/Cpp",
+    strip_prefix = "antlr4-4.13.2/runtime/Cpp",
     type = "tar.gz",
-    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.12.0.tar.gz"],
+    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ape---1.0.1",
@@ -3413,15 +3411,6 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_rules_lint---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "apple_rules_lint-0.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.apple_rules_lint---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3431,36 +3420,13 @@ starlark_repository.archive(
     urls = ["https://github.com/apple/apple_rules_lint/releases/download/0.4.0/apple_rules_lint-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.22.1",
+    name = "bzl.apple_rules_lint---0.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "apple_rules_lint-0.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
+    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---1.15.1",
@@ -3471,60 +3437,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.16.0",
+    name = "bzl.apple_support---1.24.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.17.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.21.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---2.1.0",
@@ -3535,12 +3453,84 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.apple_support---1.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.23.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.22.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.apple_support---2.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.4.0/apple_support.2.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.17.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.21.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---1.23.0",
@@ -3559,20 +3549,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.24.5",
+    name = "bzl.apple_support---1.24.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.23.1",
+    name = "bzl.apple_support---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.argparse---3.2.0",
@@ -3602,33 +3600,6 @@ starlark_repository.archive(
     urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-32-0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.asio---1.24.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "asio-asio-1-24-0/asio/include",
-    type = "zip",
-    urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-24-0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.9.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.9.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3636,78 +3607,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.13.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.16.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.42.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.42.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.11.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.11.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.9.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.9.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.7",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.38.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.38.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.6.1",
@@ -3719,24 +3618,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3744,15 +3625,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.8.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.14.0",
@@ -3764,13 +3636,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.1.0",
+    name = "bzl.aspect_bazel_lib---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.1.0",
+    strip_prefix = "bazel-lib-2.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.7.2",
@@ -3780,6 +3661,114 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.7.2",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.11.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.2/bazel-lib-v1.40.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.16.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.7",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.9.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.9.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.42.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.42.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.38.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.38.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.9.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.9.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_gazelle_prebuilt---0.0.8",
@@ -3845,51 +3834,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_jest/releases/download/v0.25.2/rules_jest-v0.25.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.3.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.3.8",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.1.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.1.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.3.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.3/rules_js-v2.3.3.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -3897,24 +3841,6 @@ starlark_repository.archive(
     strip_prefix = "rules_js-2.0.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.3.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.3.5",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.40.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---3.0.1",
@@ -3926,67 +3852,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.4.0",
+    name = "bzl.aspect_rules_js---2.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.4.0",
+    strip_prefix = "rules_js-2.1.3",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.7.0",
+    name = "bzl.aspect_rules_js---1.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.7.0",
+    strip_prefix = "rules_js-1.40.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.42.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.42.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.5.0",
@@ -3998,13 +3879,58 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.39.0",
+    name = "bzl.aspect_rules_js---2.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.39.0",
+    strip_prefix = "rules_js-2.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.34.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.6.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.9.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.9.2/rules_js-v2.9.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---3.1.1",
@@ -4016,13 +3942,76 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.1.1/rules_js-v3.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.9.2",
+    name = "bzl.aspect_rules_js---1.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.9.2",
+    strip_prefix = "rules_js-1.42.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.9.2/rules_js-v2.9.2.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.3.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.3/rules_js-v2.3.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.3.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.3.8",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.34.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.34.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.3.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.3.5",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js_rust_wasm_bindgen---0.0.2",
@@ -4060,13 +4049,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_py---1.0.0",
+    name = "bzl.aspect_rules_py---1.8.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_py-1.0.0",
+    strip_prefix = "rules_py-1.8.4",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.0.0/rules_py-v1.0.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.8.4/rules_py-v1.8.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.11.5",
@@ -4078,13 +4067,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.11.5/rules_py-v1.11.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_py---1.8.4",
+    name = "bzl.aspect_rules_py---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_py-1.8.4",
+    strip_prefix = "rules_py-1.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.8.4/rules_py-v1.8.4.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.0.0/rules_py-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_rollup---2.0.1",
@@ -4114,6 +4103,24 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_terser/releases/download/v2.1.0/rules_terser-v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_ts---3.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ts-3.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.7.0/rules_ts-v3.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_ts---3.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ts-3.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4141,24 +4148,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.8.9/rules_ts-v3.8.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.7.0/rules_ts-v3.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_webpack---0.17.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4166,24 +4155,6 @@ starlark_repository.archive(
     strip_prefix = "rules_webpack-0.17.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_webpack/releases/download/v0.17.1/rules_webpack-v0.17.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_tools_telemetry---0.2.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tools_telemetry-0.2.8",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_tools_telemetry---0.3.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tools_telemetry-0.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.3.3/tools_telemetry-v0.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_tools_telemetry---0.2.6",
@@ -4195,6 +4166,24 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.6/tools_telemetry-v0.2.6.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_tools_telemetry---0.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tools_telemetry-0.3.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.3.3/tools_telemetry-v0.3.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_tools_telemetry---0.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tools_telemetry-0.2.8",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.assimp---5.4.3.bcr.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4202,15 +4191,6 @@ starlark_repository.archive(
     strip_prefix = "assimp-5.4.3",
     type = "tar.gz",
     urls = ["https://github.com/assimp/assimp/archive/refs/tags/v5.4.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.assimp---6.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "assimp-6.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/assimp/assimp/archive/refs/tags/v6.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.awk.bzl---0.2.3",
@@ -4257,20 +4237,20 @@ starlark_repository.archive(
     urls = ["https://github.com/Tinder/bazel-diff/releases/download/v19.0.3/release.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_bats---0.35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.35.0/bazel-bats-v0.35.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_bats---0.38.23",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.38.23/bazel-bats-v0.38.23.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_bats---0.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/filmil/bazel-bats/releases/download/v0.35.0/bazel-bats-v0.35.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_cc_meta---0.2.0",
@@ -4300,168 +4280,6 @@ starlark_repository.archive(
     urls = ["https://github.com/buildbuddy-io/bazel_env.bzl/releases/download/v0.7.2/bazel_env.bzl-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.44.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.30.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.4.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.47.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.47.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.0/bazel_features-v1.47.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.43.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.43.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.24.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.24.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.18.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---0.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-0.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.19.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.32.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.32.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.46.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.20.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.20.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_features---1.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4469,15 +4287,6 @@ starlark_repository.archive(
     strip_prefix = "bazel_features-1.11.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.15.0",
@@ -4489,13 +4298,112 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.38.0",
+    name = "bzl.bazel_features---1.18.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.38.0",
+    strip_prefix = "bazel_features-1.18.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.38.0/bazel_features-v1.38.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.9.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.9.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.35.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.19.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.44.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.20.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.20.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.46.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.32.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.32.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.24.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.24.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.33.0",
@@ -4516,13 +4424,85 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.45.0/bazel_features-v1.45.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.35.0",
+    name = "bzl.bazel_features---1.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.35.0",
+    strip_prefix = "bazel_features-1.43.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.30.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.38.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.38.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.38.0/bazel_features-v1.38.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.47.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.47.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.0/bazel_features-v1.47.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_gomock---0.2.0",
@@ -4551,51 +4531,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazeltools/bazel_jar_jar/releases/download/v0.1.15/bazel_jar_jar-v0.1.15.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0-rc.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0-rc.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0-beta.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0-beta.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_lib---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4612,6 +4547,51 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-3.3.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0-beta.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0-beta.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0-rc.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0-rc.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_linux_packages---0.3.1",
@@ -4632,28 +4612,12 @@ starlark_repository.archive(
     urls = ["https://github.com/gregl83/bazel-paq/releases/download/v1.4.1/bazel-paq-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.1",
+    name = "bzl.bazel_skylib---1.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.4.1",
@@ -4672,20 +4636,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.2/bazel-skylib-1.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.9.0",
+    name = "bzl.bazel_skylib---1.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.8.0",
@@ -4704,20 +4660,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.3.0",
+    name = "bzl.bazel_skylib---1.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.2.1",
@@ -4728,12 +4676,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.5.0",
+    name = "bzl.bazel_skylib---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.2.0",
@@ -4744,12 +4700,36 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.bazel_skylib---1.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib_gazelle_plugin---1.9.0",
@@ -4760,30 +4740,21 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-gazelle-plugin-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_sonarqube---1.0.5",
+    name = "bzl.bazel_sonarqube---1.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/Zetten/bazel-sonarqube/releases/download/1.0.5/bazel_sonarqube.1.0.5.tar.gz"],
+    urls = ["https://github.com/Zetten/bazel-sonarqube/releases/download/1.0.6/bazel_sonarqube.1.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_tools---8.7.0rc2",
+    name = "bzl.bazel_tools---8.7.0",
     build_directives = ["gazelle:starlarkrepository_root tools"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-8.7.0rc2",
+    strip_prefix = "bazel-8.7.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel/archive/refs/tags/8.7.0rc2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.5/java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel/archive/refs/tags/8.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_worker_java---0.0.4",
@@ -4802,6 +4773,15 @@ starlark_repository.archive(
     strip_prefix = "bazel-worker-api-0.0.8/java",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.5/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_worker_java---0.0.10",
@@ -4830,15 +4810,6 @@ starlark_repository.archive(
     urls = ["https://github.com/sergeykhliustin/BazelPods/releases/download/1.12.5/release.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazelrc-preset.bzl---1.9.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazelrc-preset.bzl-1.9.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.9.2/bazelrc-preset.bzl-v1.9.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazelrc-preset.bzl---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4846,6 +4817,15 @@ starlark_repository.archive(
     strip_prefix = "bazelrc-preset.bzl-1.6.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.6.0/bazelrc-preset.bzl-v1.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazelrc-preset.bzl---1.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazelrc-preset.bzl-1.9.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.9.2/bazelrc-preset.bzl-v1.9.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bison---3.8.2.bcr.5",
@@ -4885,22 +4865,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost---1.83.0.bcr.4",
+    name = "bzl.boost---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "boost-boost-1.83.0",
+    strip_prefix = "boost-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.algorithm---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "algorithm-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.algorithm---1.90.0.bcr.1",
@@ -4921,6 +4892,24 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.algorithm---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "algorithm-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.align---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "align-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.align---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -4939,13 +4928,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.align---1.90.0.bcr.1",
+    name = "bzl.boost.any---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.90.0",
+    strip_prefix = "any-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.any---1.90.0.bcr.1",
@@ -4957,13 +4946,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.any---1.89.0.bcr.2",
+    name = "bzl.boost.array---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "any-boost-1.89.0",
+    strip_prefix = "array-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.array---1.90.0.bcr.1",
@@ -4984,33 +4973,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.array---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.array---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.asio---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "asio-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.asio---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5027,6 +4989,15 @@ starlark_repository.archive(
     strip_prefix = "asio-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.asio---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "asio-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.assert---1.89.0.bcr.2",
@@ -5056,13 +5027,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.assert---1.83.0.bcr.4",
+    name = "bzl.boost.assign---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "assert-boost-1.83.0",
+    strip_prefix = "assign-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.assign---1.89.0.bcr.2",
@@ -5074,13 +5045,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.assign---1.90.0.bcr.1",
+    name = "bzl.boost.atomic---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "assign-boost-1.90.0",
+    strip_prefix = "atomic-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.atomic---1.90.0.bcr.1",
@@ -5090,15 +5061,6 @@ starlark_repository.archive(
     strip_prefix = "atomic-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.atomic---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "atomic-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.atomic---1.89.0.bcr.2",
@@ -5119,15 +5081,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.beast---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "beast-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.beast---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5135,6 +5088,15 @@ starlark_repository.archive(
     strip_prefix = "beast-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.beast---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "beast-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.bimap---1.89.0.bcr.2",
@@ -5155,13 +5117,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/bimap/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.bind---1.89.0.bcr.2",
+    name = "bzl.boost.bind---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.89.0",
+    strip_prefix = "bind-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.bind---1.87.0",
@@ -5173,13 +5135,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.bind---1.90.0.bcr.1",
+    name = "bzl.boost.bind---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.90.0",
+    strip_prefix = "bind-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.callable_traits---1.89.0.bcr.2",
@@ -5200,15 +5162,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.charconv---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "charconv-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.charconv---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5218,13 +5171,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.chrono---1.90.0.bcr.1",
+    name = "bzl.boost.charconv---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "chrono-boost-1.90.0",
+    strip_prefix = "charconv-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.chrono---1.89.0.bcr.2",
@@ -5236,6 +5189,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.chrono---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "chrono-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.chrono---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5245,13 +5207,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.circular_buffer---1.90.0.bcr.1",
+    name = "bzl.boost.chrono---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "circular_buffer-boost-1.90.0",
+    strip_prefix = "chrono-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/circular_buffer/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.circular_buffer---1.89.0.bcr.2",
@@ -5263,13 +5225,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/circular_buffer/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.compat---1.89.0.bcr.2",
+    name = "bzl.boost.circular_buffer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "compat-boost-1.89.0",
+    strip_prefix = "circular_buffer-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/compat/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/circular_buffer/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.compat---1.90.0.bcr.1",
@@ -5281,6 +5243,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/compat/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.compat---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "compat-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/compat/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.compute---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5290,13 +5261,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/compute/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.concept_check---1.89.0.bcr.2",
+    name = "bzl.boost.concept_check---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.89.0",
+    strip_prefix = "concept_check-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.concept_check---1.90.0.bcr.1",
@@ -5308,13 +5279,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.concept_check---1.87.0",
+    name = "bzl.boost.concept_check---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.87.0",
+    strip_prefix = "concept_check-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.config---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "config-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.config---1.90.0.bcr.1",
@@ -5335,13 +5315,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.config---1.87.0",
+    name = "bzl.boost.container---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "config-boost-1.87.0",
+    strip_prefix = "container-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container---1.90.0.bcr.1",
@@ -5353,22 +5333,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container---1.89.0.bcr.2",
+    name = "bzl.boost.container---1.87.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "container-boost-1.89.0",
+    strip_prefix = "container-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.container---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "container-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container_hash---1.87.0",
@@ -5380,15 +5351,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container_hash---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.container_hash---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5398,22 +5360,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container_hash---1.88.0.bcr.3",
+    name = "bzl.boost.container_hash---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.88.0",
+    strip_prefix = "container_hash-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.context---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "context-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.context---1.89.0.bcr.2",
@@ -5425,22 +5378,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.context---1.88.0.bcr.3",
+    name = "bzl.boost.context---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "context-boost-1.88.0",
+    strip_prefix = "context-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.conversion---1.89.0.bcr.2",
@@ -5452,6 +5396,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.conversion---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "conversion-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5459,15 +5412,6 @@ starlark_repository.archive(
     strip_prefix = "conversion-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.core---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.core---1.89.0.bcr.2",
@@ -5479,6 +5423,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.core---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "core-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.core---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5486,24 +5439,6 @@ starlark_repository.archive(
     strip_prefix = "core-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.coroutine---1.89.0.bcr.2",
@@ -5515,13 +5450,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.coroutine2---1.90.0.bcr.1",
+    name = "bzl.boost.coroutine---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine2-boost-1.90.0",
+    strip_prefix = "coroutine-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.coroutine---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "coroutine-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.coroutine2---1.89.0.bcr.2",
@@ -5531,6 +5475,15 @@ starlark_repository.archive(
     strip_prefix = "coroutine2-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.coroutine2---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "coroutine2-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.crc---1.90.0.bcr.1",
@@ -5578,6 +5531,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.describe---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "describe-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.describe---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5596,13 +5558,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.describe---1.89.0.bcr.2",
+    name = "bzl.boost.detail---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.89.0",
+    strip_prefix = "detail-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.detail---1.90.0.bcr.1",
@@ -5614,15 +5576,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.detail---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "detail-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.detail---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5630,6 +5583,15 @@ starlark_repository.archive(
     strip_prefix = "detail-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.detail---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "detail-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.dll---1.89.0.bcr.2",
@@ -5650,13 +5612,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/dll/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.dynamic_bitset---1.87.0",
+    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.87.0",
+    strip_prefix = "dynamic_bitset-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
@@ -5668,31 +5630,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
+    name = "bzl.boost.dynamic_bitset---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.90.0",
+    strip_prefix = "dynamic_bitset-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.endian---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.endian---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.endian---1.87.0",
@@ -5704,22 +5648,31 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.exception---1.89.0.bcr.2",
+    name = "bzl.boost.endian---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "exception-boost-1.89.0",
+    strip_prefix = "endian-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.exception---1.87.0",
+    name = "bzl.boost.endian---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "exception-boost-1.87.0",
+    strip_prefix = "endian-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.endian---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "endian-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.exception---1.90.0.bcr.1",
@@ -5731,6 +5684,24 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.exception---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.exception---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.exception---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5738,15 +5709,6 @@ starlark_repository.archive(
     strip_prefix = "exception-boost-1.83.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.filesystem---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "filesystem-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.filesystem---1.90.0.bcr.1",
@@ -5758,13 +5720,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.foreach---1.89.0.bcr.2",
+    name = "bzl.boost.filesystem---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "foreach-boost-1.89.0",
+    strip_prefix = "filesystem-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/foreach/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.foreach---1.90.0.bcr.1",
@@ -5776,13 +5738,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/foreach/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.format---1.89.0.bcr.2",
+    name = "bzl.boost.foreach---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "format-boost-1.89.0",
+    strip_prefix = "foreach-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/foreach/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.format---1.90.0.bcr.1",
@@ -5792,6 +5754,15 @@ starlark_repository.archive(
     strip_prefix = "format-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.format---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "format-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.function---1.90.0.bcr.1",
@@ -5821,22 +5792,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.function---1.83.0.bcr.4",
+    name = "bzl.boost.function---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "function-boost-1.83.0",
+    strip_prefix = "function-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.function_types---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.function_types---1.90.0.bcr.1",
@@ -5848,6 +5810,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.function_types---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "function_types-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.function_types---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5855,15 +5826,6 @@ starlark_repository.archive(
     strip_prefix = "function_types-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.function_types---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.functional---1.90.0.bcr.1",
@@ -5875,15 +5837,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.functional---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.functional---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5893,13 +5846,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.fusion---1.90.0.bcr.1",
+    name = "bzl.boost.functional---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.90.0",
+    strip_prefix = "functional-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.fusion---1.87.0",
@@ -5911,6 +5864,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.fusion---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fusion-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.fusion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5918,15 +5880,6 @@ starlark_repository.archive(
     strip_prefix = "fusion-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.fusion---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.geometry---1.90.0.bcr.1",
@@ -5947,15 +5900,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.graph---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "graph-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/graph/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.graph---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -5963,6 +5907,15 @@ starlark_repository.archive(
     strip_prefix = "graph-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/graph/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.graph---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "graph-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/graph/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.hash2---1.89.0.bcr.2",
@@ -6046,13 +5999,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.integer---1.90.0.bcr.1",
+    name = "bzl.boost.integer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "integer-boost-1.90.0",
+    strip_prefix = "integer-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.integer---1.89.0.bcr.2",
@@ -6064,22 +6017,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.integer---1.87.0",
+    name = "bzl.boost.integer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "integer-boost-1.87.0",
+    strip_prefix = "integer-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.integer---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "integer-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.interprocess---1.89.0.bcr.2",
@@ -6100,15 +6044,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.intrusive---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "intrusive-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.intrusive---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6116,6 +6051,15 @@ starlark_repository.archive(
     strip_prefix = "intrusive-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.intrusive---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "intrusive-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.intrusive---1.90.0.bcr.1",
@@ -6127,13 +6071,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.intrusive---1.83.0.bcr.4",
+    name = "bzl.boost.io---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "intrusive-boost-1.83.0",
+    strip_prefix = "io-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.io---1.90.0.bcr.1",
@@ -6145,13 +6089,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.io---1.89.0.bcr.2",
+    name = "bzl.boost.io---1.88.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "io-boost-1.89.0",
+    strip_prefix = "io-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.iostreams---1.88.0.bcr.4",
@@ -6163,15 +6107,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/iostreams/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.iterator---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.iterator---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6179,6 +6114,15 @@ starlark_repository.archive(
     strip_prefix = "iterator-boost-1.87.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.iterator---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "iterator-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.iterator---1.89.0.bcr.2",
@@ -6190,15 +6134,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.json---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "json-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.json---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6206,6 +6141,15 @@ starlark_repository.archive(
     strip_prefix = "json-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.json---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "json-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.lambda---1.90.0.bcr.1",
@@ -6226,15 +6170,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.lambda2---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lambda2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.lambda2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6242,6 +6177,15 @@ starlark_repository.archive(
     strip_prefix = "lambda2-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.lambda2---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "lambda2-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.leaf---1.89.0.bcr.2",
@@ -6262,15 +6206,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.lexical_cast---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lexical_cast-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.lexical_cast---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6278,6 +6213,15 @@ starlark_repository.archive(
     strip_prefix = "lexical_cast-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.lexical_cast---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "lexical_cast-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.lexical_cast---1.87.0",
@@ -6316,15 +6260,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/lockfree/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.log---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "log-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/log/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.log---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6334,13 +6269,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/log/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.logic---1.89.0.bcr.2",
+    name = "bzl.boost.log---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "logic-boost-1.89.0",
+    strip_prefix = "log-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/log/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.logic---1.90.0.bcr.1",
@@ -6350,6 +6285,15 @@ starlark_repository.archive(
     strip_prefix = "logic-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.logic---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "logic-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.math---1.90.0.bcr.1",
@@ -6379,15 +6323,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.move---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "move-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.move---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6397,13 +6332,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.move---1.88.0.bcr.1",
+    name = "bzl.boost.move---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "move-boost-1.87.0",
+    strip_prefix = "move-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.mp11---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "mp11-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mp11---1.87.0",
@@ -6424,13 +6368,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.mp11---1.90.0.bcr.1",
+    name = "bzl.boost.mp11---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.90.0",
+    strip_prefix = "mp11-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mpl---1.89.0.bcr.2",
@@ -6487,6 +6431,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.multi_index---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "multi_index-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.multi_index---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6496,13 +6449,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.multi_index---1.89.0.bcr.2",
+    name = "bzl.boost.multiprecision---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "multi_index-boost-1.89.0",
+    strip_prefix = "multiprecision-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.multiprecision---1.90.0.bcr.1",
@@ -6523,15 +6476,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.multiprecision---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "multiprecision-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.mysql---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6550,15 +6494,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.numeric_conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.numeric_conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6566,6 +6501,15 @@ starlark_repository.archive(
     strip_prefix = "numeric_conversion-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.numeric_conversion---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "numeric_conversion-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.numeric_conversion---1.89.0.bcr.2",
@@ -6595,13 +6539,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ublas/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.optional---1.89.0.bcr.2",
+    name = "bzl.boost.optional---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "optional-boost-1.89.0",
+    strip_prefix = "optional-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.optional---1.87.0",
@@ -6613,13 +6557,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.optional---1.90.0.bcr.1",
+    name = "bzl.boost.optional---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "optional-boost-1.90.0",
+    strip_prefix = "optional-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.outcome---1.90.0.bcr.1",
@@ -6667,15 +6611,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.phoenix---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "phoenix-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.phoenix---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6694,13 +6629,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.polygon---1.89.0.bcr.2",
+    name = "bzl.boost.phoenix---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "polygon-boost-1.89.0",
+    strip_prefix = "phoenix-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.phoenix---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "phoenix-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.polygon---1.90.0.bcr.1",
@@ -6712,6 +6656,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.polygon---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "polygon-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.pool---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6719,15 +6672,6 @@ starlark_repository.archive(
     strip_prefix = "pool-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.pool---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.pool---1.87.0",
@@ -6739,22 +6683,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.pool---1.83.0.bcr.4",
+    name = "bzl.boost.pool---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.83.0",
+    strip_prefix = "pool-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.predef---1.89.0.bcr.2",
+    name = "bzl.boost.predef---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.89.0",
+    strip_prefix = "predef-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.predef---1.90.0.bcr.1",
@@ -6766,13 +6710,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.predef---1.87.0",
+    name = "bzl.boost.predef---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.87.0",
+    strip_prefix = "predef-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.preprocessor---1.87.0",
@@ -6793,13 +6737,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.preprocessor---1.83.0.bcr.4",
+    name = "bzl.boost.preprocessor---1.90.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "preprocessor-boost-1.83.0",
+    strip_prefix = "preprocessor-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.process---1.90.0.bcr.1",
@@ -6838,15 +6782,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/program_options/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.property_map---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "property_map-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.property_map---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6856,13 +6791,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.property_tree---1.90.0.bcr.1",
+    name = "bzl.boost.property_map---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "property_tree-boost-1.90.0",
+    strip_prefix = "property_map-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.property_tree---1.89.0.bcr.2",
@@ -6874,6 +6809,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.property_tree---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "property_tree-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.proto---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6881,15 +6825,6 @@ starlark_repository.archive(
     strip_prefix = "proto-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.proto---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.proto---1.87.0",
@@ -6901,22 +6836,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.proto---1.83.0.bcr.4",
+    name = "bzl.boost.proto---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.83.0",
+    strip_prefix = "proto-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.ptr_container---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ptr_container-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ptr_container/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.ptr_container---1.89.0.bcr.2",
@@ -6928,6 +6854,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ptr_container/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.ptr_container---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ptr_container-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/ptr_container/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.python---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -6935,15 +6870,6 @@ starlark_repository.archive(
     strip_prefix = "python-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/python/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.qvm---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "qvm-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.qvm---1.89.0.bcr.2",
@@ -6955,13 +6881,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.random---1.89.0.bcr.2",
+    name = "bzl.boost.qvm---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "random-boost-1.89.0",
+    strip_prefix = "qvm-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.random---1.90.0.bcr.1",
@@ -6982,13 +6908,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.range---1.87.0",
+    name = "bzl.boost.random---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.87.0",
+    strip_prefix = "random-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.range---1.90.0.bcr.1",
@@ -7009,13 +6935,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.ratio---1.89.0.bcr.2",
+    name = "bzl.boost.range---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.89.0",
+    strip_prefix = "range-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.range---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "range-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.ratio---1.90.0.bcr.1",
@@ -7027,6 +6962,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.ratio---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ratio-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.ratio---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7036,22 +6980,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.ratio---1.83.0.bcr.4",
+    name = "bzl.boost.rational---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.83.0",
+    strip_prefix = "rational-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.rational---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.rational---1.89.0.bcr.2",
@@ -7063,13 +6998,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.rational---1.90.0.bcr.1",
+    name = "bzl.boost.rational---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.90.0",
+    strip_prefix = "rational-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.regex---1.89.0.bcr.2",
@@ -7097,15 +7032,6 @@ starlark_repository.archive(
     strip_prefix = "regex-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.regex---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.scope---1.89.0.bcr.2",
@@ -7144,6 +7070,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.serialization---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "serialization-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.serialization---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7153,13 +7088,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.serialization---1.90.0.bcr.1",
+    name = "bzl.boost.serialization---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "serialization-boost-1.90.0",
+    strip_prefix = "serialization-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.signals2---1.89.0.bcr.2",
@@ -7180,15 +7115,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/signals2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.smart_ptr---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7205,6 +7131,15 @@ starlark_repository.archive(
     strip_prefix = "smart_ptr-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "smart_ptr-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.sort---1.90.0.bcr.1",
@@ -7243,6 +7178,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/spirit/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.stacktrace---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "stacktrace-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.stacktrace---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7252,13 +7196,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.stacktrace---1.89.0.bcr.2",
+    name = "bzl.boost.static_assert---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "stacktrace-boost-1.89.0",
+    strip_prefix = "static_assert-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.static_assert---1.89.0.bcr.2",
@@ -7279,15 +7223,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.static_assert---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.static_string---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7306,15 +7241,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.system---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.system---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7322,6 +7248,15 @@ starlark_repository.archive(
     strip_prefix = "system-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.system---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "system-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.system---1.90.0.bcr.1",
@@ -7333,15 +7268,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.test---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "test-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.test---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7349,6 +7275,15 @@ starlark_repository.archive(
     strip_prefix = "test-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.test---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "test-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.thread---1.89.0.bcr.2",
@@ -7378,13 +7313,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.throw_exception---1.89.0.bcr.2",
+    name = "bzl.boost.throw_exception---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.89.0",
+    strip_prefix = "throw_exception-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.throw_exception---1.87.0",
@@ -7396,22 +7331,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.throw_exception---1.90.0.bcr.1",
+    name = "bzl.boost.throw_exception---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.90.0",
+    strip_prefix = "throw_exception-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.timer---1.90.0.bcr.1",
+    name = "bzl.boost.throw_exception---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "timer-boost-1.90.0",
+    strip_prefix = "throw_exception-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.timer---1.89.0.bcr.2",
@@ -7423,13 +7358,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tokenizer---1.87.0",
+    name = "bzl.boost.timer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tokenizer-boost-1.87.0",
+    strip_prefix = "timer-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.tokenizer---1.89.0.bcr.2",
@@ -7439,6 +7374,15 @@ starlark_repository.archive(
     strip_prefix = "tokenizer-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.tokenizer---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tokenizer-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.tokenizer---1.90.0.bcr.1",
@@ -7459,15 +7403,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tti---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tti-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.tti---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7477,13 +7412,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tuple---1.87.0",
+    name = "bzl.boost.tti---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.87.0",
+    strip_prefix = "tti-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.tuple---1.90.0.bcr.1",
@@ -7504,13 +7439,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.type_index---1.90.0.bcr.1",
+    name = "bzl.boost.tuple---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.90.0",
+    strip_prefix = "tuple-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.type_index---1.89.0.bcr.2",
@@ -7531,13 +7466,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.type_index---1.83.0.bcr.4",
+    name = "bzl.boost.type_index---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.83.0",
+    strip_prefix = "type_index-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.type_index---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "type_index-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.type_traits---1.87.0",
@@ -7576,15 +7520,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.typeof---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "typeof-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.typeof---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7594,22 +7529,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.typeof---1.83.0.bcr.4",
+    name = "bzl.boost.typeof---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "typeof-boost-1.83.0",
+    strip_prefix = "typeof-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.units---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "units-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.units---1.89.0.bcr.2",
@@ -7621,6 +7547,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.units---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "units-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.unordered---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7628,15 +7563,6 @@ starlark_repository.archive(
     strip_prefix = "unordered-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.unordered---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.unordered---1.90.0.bcr.1",
@@ -7648,13 +7574,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.unordered---1.83.0.bcr.4",
+    name = "bzl.boost.unordered---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.83.0",
+    strip_prefix = "unordered-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.url---1.89.0.bcr.2",
@@ -7675,13 +7601,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.utility---1.89.0.bcr.2",
+    name = "bzl.boost.utility---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.89.0",
+    strip_prefix = "utility-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.utility---1.90.0.bcr.1",
@@ -7693,22 +7619,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.utility---1.87.0",
+    name = "bzl.boost.utility---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.87.0",
+    strip_prefix = "utility-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.uuid---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "uuid-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.uuid---1.90.0.bcr.1",
@@ -7718,6 +7635,15 @@ starlark_repository.archive(
     strip_prefix = "uuid-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.uuid---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "uuid-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.variant---1.87.0",
@@ -7747,31 +7673,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.variant---1.88.0.bcr.3",
+    name = "bzl.boost.variant---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.88.0",
+    strip_prefix = "variant-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.variant2---1.90.0.bcr.1",
@@ -7783,13 +7691,31 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.variant2---1.83.0.bcr.4",
+    name = "bzl.boost.variant2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.83.0",
+    strip_prefix = "variant2-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.83.0.tar.gz"],
+    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.variant2---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant2-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.variant2---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "variant2-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.vmd---1.90.0.bcr.1",
@@ -7810,15 +7736,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/vmd/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.winapi---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.winapi---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7828,13 +7745,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.winapi---1.90.0",
+    name = "bzl.boost.winapi---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.89.0",
+    strip_prefix = "winapi-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.winapi---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "winapi-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.xpressive---1.90.0.bcr.1",
@@ -7855,76 +7781,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/xpressive/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20230215-5c22014",
+    name = "bzl.boringssl---0.20260413.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
-    type = "zip",
-    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20240913.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20240913.0/",
+    strip_prefix = "boringssl-0.20260413.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20241209.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241209.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20251124.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20251124.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260327.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260327.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20241024.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241024.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20240530-2db0eb3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-2db0eb3f96a5756298dcd7f9319e56a98585bd10",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20240930.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20240930.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20250514.0",
@@ -7954,6 +7817,42 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20250212.0/boringssl-0.20250212.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boringssl---0.20240913.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20240913.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20230215-5c22014",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
+    type = "zip",
+    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20240530-2db0eb3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-2db0eb3f96a5756298dcd7f9319e56a98585bd10",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20240930.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20240930.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boringssl---0.20251002.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -7963,13 +7862,40 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20251002.0/boringssl-0.20251002.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20260413.0",
+    name = "bzl.boringssl---0.20241209.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260413.0/",
+    strip_prefix = "boringssl-0.20241209.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20260327.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20260327.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20251124.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20251124.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241024.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241024.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.brotli---1.1.0",
@@ -7990,15 +7916,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/brotli/archive/refs/tags/v1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.build_stack_rules_proto---4.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-v4.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/stackb/rules_proto/releases/download/v4.1.1/rules_proto-v4.1.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.build_stack_rules_proto---4.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8006,6 +7923,15 @@ starlark_repository.archive(
     strip_prefix = "rules_proto-v4.2.0",
     type = "tar.gz",
     urls = ["https://github.com/stackb/rules_proto/releases/download/v4.2.0/rules_proto-v4.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.build_stack_rules_proto---4.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-v4.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/stackb/rules_proto/releases/download/v4.1.1/rules_proto-v4.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.build_stack_scala_gazelle---0.1.1",
@@ -8035,15 +7961,6 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8051,24 +7968,6 @@ starlark_repository.archive(
     strip_prefix = "buildifier-prebuilt-8.2.1",
     type = "tar.gz",
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---7.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-7.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.0",
@@ -8080,12 +7979,22 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.5.1.2",
+    name = "bzl.buildifier_prebuilt---7.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-7.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---7.3.1",
@@ -8095,6 +8004,23 @@ starlark_repository.archive(
     strip_prefix = "buildifier-prebuilt-7.3.1",
     type = "tar.gz",
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.5.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildozer---8.5.1",
@@ -8150,15 +8076,6 @@ starlark_repository.archive(
     urls = ["https://github.com/zaucy/bzlws/releases/download/0.2.0/bzlws-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.c-ares---1.19.1.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "c-ares-1.19.1",
-    type = "tar.gz",
-    urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.c-ares---1.16.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8175,6 +8092,24 @@ starlark_repository.archive(
     strip_prefix = "c-ares-1.15.0",
     type = "tar.gz",
     urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.c-ares---1.19.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "c-ares-1.19.1",
+    type = "tar.gz",
+    urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.c-ares---1.34.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "c-ares-1.34.5",
+    type = "tar.gz",
+    urls = ["https://github.com/c-ares/c-ares/releases/download/v1.34.5/c-ares-1.34.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.c-blosc2---2.22.0",
@@ -8267,15 +8202,6 @@ starlark_repository.archive(
     urls = ["https://github.com/artem-ogre/CDT/archive/refs/tags/1.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-cpp---0.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cel-cpp-0.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/cel-cpp/archive/refs/tags/v0.15.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cel-cpp---0.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8285,13 +8211,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-cpp/archive/refs/tags/v0.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-spec---0.23.0",
+    name = "bzl.cel-cpp---0.15.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.23.0",
+    strip_prefix = "cel-cpp-0.15.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
+    urls = ["https://github.com/google/cel-cpp/archive/refs/tags/v0.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cel-spec---0.24.0",
@@ -8321,6 +8247,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.15.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.cel-spec---0.23.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cel-spec-0.23.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.ceres-solver---2.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8338,20 +8273,20 @@ starlark_repository.archive(
     urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.30.0/bazel-starlib.v0.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cgrindel_bazel_starlib---0.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.28.0/bazel-starlib.v0.28.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cgrindel_bazel_starlib---0.27.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.27.0/bazel-starlib.v0.27.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cgrindel_bazel_starlib---0.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.28.0/bazel-starlib.v0.28.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.civetweb---1.16.bcr.4",
@@ -8389,15 +8324,6 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/closure-templates/releases/download/v1.0.1/closure-templates-v1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.7",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8407,15 +8333,6 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.3/cmake_configure_file-v0.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.2/cmake_configure_file-0.1.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8423,6 +8340,24 @@ starlark_repository.archive(
     strip_prefix = "cmake_configure_file-0.1.4",
     type = "tar.gz",
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.4/cmake_configure_file-v0.1.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cmake_configure_file---0.1.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cmake_configure_file-0.1.7",
+    type = "tar.gz",
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cmake_configure_file---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cmake_configure_file-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.2/cmake_configure_file-0.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.codspeed_google_benchmark_compat---2.1.0",
@@ -8479,15 +8414,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.24.0/rules_jvm-v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.contrib_rules_jvm---0.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm-0.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.28.0/rules_jvm-v0.28.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.contrib_rules_jvm---0.33.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8495,6 +8421,15 @@ starlark_repository.archive(
     strip_prefix = "rules_jvm-0.33.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.33.0/rules_jvm-v0.33.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.contrib_rules_jvm---0.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm-0.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.28.0/rules_jvm-v0.28.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.copybara---0.0.0-20250728-6672ce2",
@@ -8659,6 +8594,15 @@ starlark_repository.archive(
     urls = ["https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.curl---8.12.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "curl-8.12.0",
+    type = "tar.gz",
+    urls = ["https://github.com/curl/curl/releases/download/curl-8_12_0/curl-8.12.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.cxx.rs---1.0.194",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8677,15 +8621,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.3.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cython---3.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cython-3.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/cython/cython/archive/refs/tags/3.2.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cython---3.0.11-1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8693,6 +8628,15 @@ starlark_repository.archive(
     strip_prefix = "cython-3.0.11-1",
     type = "tar.gz",
     urls = ["https://github.com/cython/cython/archive/refs/tags/3.0.11-1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cython---3.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cython-3.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/cython/cython/archive/refs/tags/3.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.darts-clone---0.32",
@@ -8830,13 +8774,13 @@ starlark_repository.archive(
     urls = ["https://gitlab.com/libeigen/eigen/-/package_files/233618439/download"],
 )
 starlark_repository.archive(
-    name = "bzl.eigen---3.4.0.bcr.2",
+    name = "bzl.eigen---4.0.0-20241125.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "eigen-3.4.0",
+    strip_prefix = "eigen-8ad4344ca79f2f248bc5ed70eec72e4b9c4d5e88",
     type = "zip",
-    urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip"],
+    urls = ["https://gitlab.com/libeigen/eigen/-/archive/8ad4344ca79f2f248bc5ed70eec72e4b9c4d5e88/eigen-8ad4344ca79f2f248bc5ed70eec72e4b9c4d5e88.zip"],
 )
 starlark_repository.archive(
     name = "bzl.elemental2---1.3.2",
@@ -8865,21 +8809,21 @@ starlark_repository.archive(
     urls = ["https://github.com/emscripten-core/emsdk/archive/refs/tags/4.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.emsdk---5.0.5",
+    name = "bzl.emsdk---5.0.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "emsdk-5.0.5/bazel",
+    strip_prefix = "emsdk-5.0.7/bazel",
     type = "tar.gz",
-    urls = ["https://github.com/emscripten-core/emsdk/archive/refs/tags/5.0.5.tar.gz"],
+    urls = ["https://github.com/emscripten-core/emsdk/archive/refs/tags/5.0.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.engflowapis---2024.12.06-06.17.32",
+    name = "bzl.engflowapis---2024.12.04-12.50.55",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.12.06-06.17.32/engflowapis-2024.12.06-06.17.32.tar.gz"],
+    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.12.04-12.50.55/engflowapis-2024.12.04-12.50.55.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.engflowapis-java---2025.07.24-06.20.24",
@@ -8936,6 +8880,15 @@ starlark_repository.archive(
     urls = ["https://github.com/envoyproxy/toolshed/releases/download/bazel-v0.3.25/toolshed-bazel-v0.3.25.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.evidence_store_bazel---0.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "evidence_store_bazel-v0.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/nesono/evidence_store/releases/download/evidence_store_bazel-v0.0.1/evidence_store_bazel-v0.0.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.extra_rules_java---1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8953,15 +8906,6 @@ starlark_repository.archive(
     urls = ["https://github.com/lemire/fast_double_parser/archive/refs/tags/v0.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.fast_float---8.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fast_float-8.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.fast_float---8.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -8969,6 +8913,15 @@ starlark_repository.archive(
     strip_prefix = "fast_float-8.0.2",
     type = "tar.gz",
     urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.fast_float---8.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fast_float-8.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.fcl---0.7.0.bcr.2",
@@ -9015,15 +8968,6 @@ starlark_repository.archive(
     urls = ["https://github.com/facebookincubator/fizz/releases/download/v2025.02.10.00/fizz-v2025.02.10.00.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.flatbuffers---25.9.23",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "flatbuffers-25.9.23",
-    type = "tar.gz",
-    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.flatbuffers---25.2.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9031,6 +8975,15 @@ starlark_repository.archive(
     strip_prefix = "flatbuffers-25.2.10",
     type = "tar.gz",
     urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.flatbuffers---25.9.23",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "flatbuffers-25.9.23",
+    type = "tar.gz",
+    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.flatbuffers---25.12.19",
@@ -9060,13 +9013,13 @@ starlark_repository.archive(
     urls = ["https://github.com/NVlabs/flip/archive/79675788aa642fbb4732effe2b45b082ff4c4d52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.fmt---12.1.0",
+    name = "bzl.fmt---8.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-12.1.0",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"],
+    strip_prefix = "fmt-8.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.fmt---10.1.1",
@@ -9078,15 +9031,6 @@ starlark_repository.archive(
     urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.fmt---8.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-8.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.fmt---11.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9096,13 +9040,22 @@ starlark_repository.archive(
     urls = ["https://github.com/fmtlib/fmt/releases/download/11.1.3/fmt-11.1.3.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.fmt---11.1.4",
+    name = "bzl.fmt---12.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-11.1.4",
+    strip_prefix = "fmt-12.1.0",
     type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip"],
+    urls = ["https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.fmt---10.2.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-10.2.1",
+    type = "zip",
+    urls = ["https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.folly---2025.01.13.00.bcr.6",
@@ -9131,13 +9084,13 @@ starlark_repository.archive(
     urls = ["https://github.com/danoli3/FreeImage/archive/refs/tags/3.19.10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.freetype---2.9",
+    name = "bzl.freetype---2.13.3.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "freetype-2.9",
+    strip_prefix = "freetype-2.13.3",
     type = "tar.gz",
-    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.9.tar.gz"],
+    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.fremtind_rules_vitest---0.2.1",
@@ -9192,29 +9145,37 @@ starlark_repository.archive(
     urls = ["https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.gawk---5.3.2.bcr.6",
+    name = "bzl.gawk---5.3.2.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     strip_prefix = "gawk-5.3.2",
     type = "tar.xz",
-    urls = ["https://mirror.bazel.build/ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
+    urls = ["https://mirrors.kernel.org/gnu/gawk/gawk-5.3.2.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.43.0",
+    name = "bzl.gazelle---0.30.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.34.0",
+    name = "bzl.gazelle---0.50.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.37.0",
@@ -9225,20 +9186,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.39.1",
+    name = "bzl.gazelle---0.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.50.0",
+    name = "bzl.gazelle---0.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.29.0",
@@ -9250,14 +9219,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.45.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gazelle---0.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9266,12 +9227,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.35.0",
+    name = "bzl.gazelle---0.45.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.47.0",
@@ -9280,54 +9249,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.47.0/bazel-gazelle-v0.47.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.36.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.41.0",
@@ -9346,6 +9267,38 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gazelle---0.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.36.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gazelle_cc---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9355,13 +9308,13 @@ starlark_repository.archive(
     urls = ["https://github.com/EngFlow/gazelle_cc/releases/download/v0.5.0/gazelle_cc-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle_fold---0.1.0",
+    name = "bzl.gazelle_fold---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gazelle_fold-0.1.0",
+    strip_prefix = "gazelle_fold-0.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/andyscott/gazelle_fold/releases/download/v0.1.0/gazelle_fold-v0.1.0.tar.gz"],
+    urls = ["https://github.com/andyscott/gazelle_fold/releases/download/v0.2.0/gazelle_fold-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle_py---0.8.6",
@@ -9373,13 +9326,13 @@ starlark_repository.archive(
     urls = ["https://github.com/perplexityai/gazelle_py/releases/download/v0.8.6/gazelle_py-v0.8.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle_ts---0.4.10",
+    name = "bzl.gazelle_ts---0.4.11",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gazelle_ts-0.4.10",
+    strip_prefix = "gazelle_ts-0.4.11",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/gazelle_ts/releases/download/v0.4.10/gazelle_ts-v0.4.10.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/gazelle_ts/releases/download/v0.4.11/gazelle_ts-v0.4.11.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gcc_toolchain---0.9.0",
@@ -9418,6 +9371,15 @@ starlark_repository.archive(
     urls = ["https://download.gnome.org/sources/glib/2.82/glib-2.82.2.tar.xz"],
 )
 starlark_repository.archive(
+    name = "bzl.glog---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "glog-0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.glog---0.7.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9436,22 +9398,14 @@ starlark_repository.archive(
     urls = ["https://github.com/google/glog/archive/refs/tags/v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.glog---0.6.0",
+    name = "bzl.glpk---5.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "glog-0.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.glpk---5.0.bcr.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
+    sha256 = "4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15",
     strip_prefix = "glpk-5.0",
     type = "tar.gz",
-    urls = ["https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
+    urls = ["http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gonzojive_protobuf_javascript---3.21.5.esm",
@@ -9472,22 +9426,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/bazel-common/releases/download/0.0.1/bazel-common-0.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.4",
+    name = "bzl.google_benchmark---1.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.4",
+    strip_prefix = "benchmark-1.8.2",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.5",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.9.2",
@@ -9508,6 +9453,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.google_benchmark---1.8.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.8.4",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9526,13 +9480,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.2",
+    name = "bzl.google_benchmark---1.9.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.2",
+    strip_prefix = "benchmark-1.9.5",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_cloud_cpp---3.3.0",
@@ -9553,22 +9507,13 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.0.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
+    name = "bzl.googleapis---0.0.0-20240819-fe8ba054a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
+    strip_prefix = "googleapis-fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0",
+    type = "tar.gz",
+    urls = ["https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20260422-20ac242a",
@@ -9578,33 +9523,6 @@ starlark_repository.archive(
     strip_prefix = "googleapis-20ac242a6b3a723cb10c1a0201209261addaf7d8",
     type = "zip",
     urls = ["https://github.com/googleapis/googleapis/archive/20ac242a6b3a723cb10c1a0201209261addaf7d8.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20240326-1c8d509c5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
-    type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
-    type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20240819-fe8ba054a",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0",
-    type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20260130-c0fcb356",
@@ -9634,6 +9552,51 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/googleapis/archive/edfe7983b9d99d6244b4d7636d25fa6e752a2041.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
+    type = "tar.gz",
+    urls = ["https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20240326-1c8d509c5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
+    type = "tar.gz",
+    urls = ["https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260109-6145b5ff",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-6145b5ffe99d290c3d840136f310490d732acb04",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/6145b5ffe99d290c3d840136f310490d732acb04.zip"],
+)
+starlark_repository.archive(
     name = "bzl.googleapis-rules-registry---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9652,15 +9615,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.15.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.googletest---1.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9670,13 +9624,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.14.0.bcr.1",
+    name = "bzl.googletest---1.15.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.14.0",
+    strip_prefix = "googletest-1.15.2",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.17.0.bcr.2",
@@ -9688,13 +9642,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.16.0.bcr.2",
+    name = "bzl.googletest---1.14.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.16.0",
+    strip_prefix = "googletest-1.14.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gotopt2---2.2.19",
@@ -9714,58 +9668,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gperftools/gperftools/releases/download/gperftools-2.18.1/gperftools-2.18.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.68.0",
+    name = "bzl.grpc---1.56.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.68.0",
+    strip_prefix = "grpc-1.56.3",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.74.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.74.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.76.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.76.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.70.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.69.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.73.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.73.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.71.0",
@@ -9777,6 +9686,33 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.71.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc---1.73.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.73.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.70.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.68.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.68.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc---1.72.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9786,22 +9722,31 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.72.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.41.0",
+    name = "bzl.grpc---1.76.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.41.0",
-    type = "zip",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
+    strip_prefix = "grpc-1.76.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.56.3.bcr.1",
+    name = "bzl.grpc---1.69.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.56.3",
+    strip_prefix = "grpc-1.69.0",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.74.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.74.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.80.0",
@@ -9813,13 +9758,22 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.80.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.71.2",
+    name = "bzl.grpc---1.41.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.71.2",
+    strip_prefix = "grpc-1.41.0",
+    type = "zip",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.48.1.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.48.1",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.71.2.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.48.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
@@ -9831,6 +9785,24 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/ff41eb3fc9209e6197595b54f7addfa244c0bdb6.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc-java---1.66.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.66.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.69.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.69.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc-java---1.78.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9838,6 +9810,15 @@ starlark_repository.archive(
     strip_prefix = "grpc-java-1.78.0",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.78.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.67.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.67.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.67.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-java---1.62.2",
@@ -9858,33 +9839,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.71.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc-java---1.66.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.66.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.67.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.67.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.67.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.69.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.grpc-proto---0.0.0-20240627-ec30f58.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9894,6 +9848,14 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-proto/archive/ec30f589e2519d595688b9a42f88a91bdd6b733f.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.29.0/grpc-gateway-v2.29.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc_ecosystem_grpc_gateway---2.26.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9901,14 +9863,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-gateway-2.26.3",
     type = "tar.gz",
     urls = ["https://github.com/grpc-ecosystem/grpc-gateway/archive/refs/tags/v2.26.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.29.0/grpc-gateway-v2.29.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc_kotlin---1.5.0",
@@ -9927,15 +9881,6 @@ starlark_repository.archive(
     strip_prefix = "gutil-release-20260309",
     type = "zip",
     urls = ["https://github.com/google/gutil/releases/download/20260309.0/gutil-release-20260309.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.gutil---20260226.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gutil-release-20260226",
-    type = "zip",
-    urls = ["https://github.com/google/gutil/releases/download/20260226.0/gutil-release-20260226.zip"],
 )
 starlark_repository.archive(
     name = "bzl.gz-common---7.2.0-pre1",
@@ -9974,15 +9919,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-fuel-tools/archive/refs/tags/gz-fuel-tools11_11.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-math---9.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-math-gz-math9_9.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-math---9.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -9992,13 +9928,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-msgs---12.0.1",
+    name = "bzl.gz-math---9.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-msgs-gz-msgs12_12.0.1",
+    strip_prefix = "gz-math-gz-math9_9.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.1.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-msgs---12.0.0",
@@ -10010,13 +9946,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-physics---9.2.0",
+    name = "bzl.gz-msgs---12.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-physics-gz-physics9_9.2.0",
+    strip_prefix = "gz-msgs-gz-msgs12_12.0.1",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.2.0.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-physics---9.0.0",
@@ -10028,6 +9964,15 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gz-physics---9.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-physics-gz-physics9_9.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-physics/archive/refs/tags/gz-physics9_9.2.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gz-plugin---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10035,15 +9980,6 @@ starlark_repository.archive(
     strip_prefix = "gz-plugin-gz-plugin4_4.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/tags/gz-plugin4_4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gz-rendering---10.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-rendering-gz-rendering10_10.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-rendering---10.0.1",
@@ -10055,13 +9991,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-sensors---10.0.1",
+    name = "bzl.gz-rendering---10.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-sensors-gz-sensors10_10.0.1",
+    strip_prefix = "gz-rendering-gz-rendering10_10.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.1.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-sensors---10.0.0",
@@ -10073,6 +10009,15 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gz-sensors---10.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-sensors-gz-sensors10_10.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gz-sim---10.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10082,15 +10027,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-sim/archive/refs/tags/gz-sim10_10.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-transport---15.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-transport-gz-transport15_15.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-transport---15.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10098,6 +10034,15 @@ starlark_repository.archive(
     strip_prefix = "gz-transport-gz-transport15_15.0.2",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-transport---15.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-transport-gz-transport15_15.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-utils---4.0.0",
@@ -10118,15 +10063,6 @@ starlark_repository.archive(
     urls = ["https://github.com/GZGavinZhao/gzgz_rules_sass/releases/download/v1.0.4/gzgz_rules_sass-v1.0.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.helly25_bashtest---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bashtest-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.helly25_bashtest---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10134,6 +10070,15 @@ starlark_repository.archive(
     strip_prefix = "bashtest-0.1.0",
     type = "tar.gz",
     urls = ["https://github.com/helly25/bashtest/releases/download/0.1.0/bashtest-0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.helly25_bashtest---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bashtest-0.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.helly25_bzl---0.3.1",
@@ -10214,15 +10159,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.13.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.highway---1.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "highway-1.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.highway---1.3.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10230,6 +10166,15 @@ starlark_repository.archive(
     strip_prefix = "highway-1.3.0",
     type = "tar.gz",
     urls = ["https://github.com/google/highway/releases/download/1.3.0/highway-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.highway---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "highway-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highwayhash---0.0.0-20240305-5ad3bf8.bcr.1",
@@ -10295,15 +10240,6 @@ starlark_repository.archive(
     urls = ["https://github.com/j2kun/isl/releases/download/0.27/isl-0.27.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.j2cl---20260402",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "j2cl-20260402",
-    type = "tar.gz",
-    urls = ["https://github.com/google/j2cl/releases/download/v20260402/j2cl-v20260402.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.j2cl---20250630",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10311,6 +10247,15 @@ starlark_repository.archive(
     strip_prefix = "j2cl-20250630",
     type = "tar.gz",
     urls = ["https://github.com/google/j2cl/releases/download/v20250630/j2cl-v20250630.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.j2cl---20260402",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "j2cl-20260402",
+    type = "tar.gz",
+    urls = ["https://github.com/google/j2cl/releases/download/v20260402/j2cl-v20260402.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jeffmanzione_intern---1.0.2",
@@ -10340,13 +10285,13 @@ starlark_repository.archive(
     urls = ["https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"],
 )
 starlark_repository.archive(
-    name = "bzl.jq.bzl---0.6.0",
+    name = "bzl.jq.bzl---0.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.6.0",
+    strip_prefix = "jq.bzl-0.6.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.0/jq.bzl-v0.6.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jq.bzl---0.4.0",
@@ -10367,22 +10312,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.1.0/jq.bzl-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.jq.bzl---0.6.1",
+    name = "bzl.jq.bzl---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.6.1",
+    strip_prefix = "jq.bzl-0.6.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.jsinterop_base---1.2.0-RC1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jsinterop-base-1.2.0-RC1",
-    type = "tar.gz",
-    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.0/jq.bzl-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsinterop_base---1.1.1",
@@ -10394,6 +10330,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/jsinterop-base/releases/download/1.1.1/jsinterop-base-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.jsinterop_base---1.2.0-RC1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jsinterop-base-1.2.0-RC1",
+    type = "tar.gz",
+    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jsinterop_generator---20250910",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10403,15 +10348,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/jsinterop-generator/releases/download/v20250910/jsinterop-generator-v20250910.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.jsoncpp---1.9.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jsoncpp-1.9.5",
-    type = "tar.gz",
-    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.jsoncpp---1.9.6.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10419,6 +10355,15 @@ starlark_repository.archive(
     strip_prefix = "jsoncpp-1.9.6",
     type = "tar.gz",
     urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.jsoncpp---1.9.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jsoncpp-1.9.5",
+    type = "tar.gz",
+    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsonnet---0.21.0",
@@ -10574,13 +10519,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.librdkafka---2.8.0.bcr.2",
+    name = "bzl.librdkafka---2.3.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "librdkafka-2.8.0",
+    strip_prefix = "librdkafka-2.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.8.0.tar.gz"],
+    urls = ["https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libsodium---1.0.19",
@@ -10592,15 +10537,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jedisct1/libsodium/releases/download/1.0.19-RELEASE/libsodium-1.0.19.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libunwind---1.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "libunwind-1.8.1",
-    type = "tar.gz",
-    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.8.1/libunwind-1.8.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.libunwind---1.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10608,6 +10544,15 @@ starlark_repository.archive(
     strip_prefix = "libunwind-1.8.3",
     type = "tar.gz",
     urls = ["https://github.com/libunwind/libunwind/releases/download/v1.8.3/libunwind-1.8.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.libunwind---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "libunwind-1.8.1",
+    type = "tar.gz",
+    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.8.1/libunwind-1.8.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.liburing---2.10",
@@ -10646,13 +10591,13 @@ starlark_repository.archive(
     urls = ["https://github.com/webmproject/libwebp/archive/refs/tags/v1.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libx11---1.8.12",
+    name = "bzl.libx11---1.8.12.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     strip_prefix = "libx11-libX11-1.8.12",
     type = "tar.gz",
-    urls = ["https://gitlab.freedesktop.org/xorg/lib/libx11/-/archive/libX11-1.8.12/libx11-libX11-1.8.12.tar.gz"],
+    urls = ["https://github.com/wep21/libx11/archive/refs/tags/libX11-1.8.12.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libxau---1.0.12.bcr.2",
@@ -10691,13 +10636,13 @@ starlark_repository.archive(
     urls = ["https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libzip---1.10.1.bcr.1",
+    name = "bzl.libzip---1.11.4.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "libzip-1.10.1",
+    strip_prefix = "libzip-1.11.4",
     type = "tar.gz",
-    urls = ["https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz"],
+    urls = ["https://github.com/nih-at/libzip/releases/download/v1.11.4/libzip-1.11.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libzmq---4.3.5.bcr.4",
@@ -10717,6 +10662,15 @@ starlark_repository.archive(
     urls = ["https://github.com/filmil/lit2md/releases/download/v1.0.1/lit2md-v1.0.1.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.llvm---0.7.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "hermetic-llvm-0.7.9",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/hermetic-llvm/releases/download/v0.7.9/hermetic-llvm-v0.7.9.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.llvm-project---17.0.3.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10724,15 +10678,6 @@ starlark_repository.archive(
     strip_prefix = "llvm-project-17.0.3.src",
     type = "tar.xz",
     urls = ["https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-project-17.0.3.src.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.lz4---1.9.4.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lz4-1.9.4",
-    type = "tar.gz",
-    urls = ["https://github.com/lz4/lz4/releases/download/v1.9.4/lz4-1.9.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.lz4---1.10.0.bcr.1",
@@ -10744,6 +10689,15 @@ starlark_repository.archive(
     urls = ["https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.lz4---1.9.4.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "lz4-1.9.4",
+    type = "tar.gz",
+    urls = ["https://github.com/lz4/lz4/releases/download/v1.9.4/lz4-1.9.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.lz4-erlang---1.9.2.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10753,13 +10707,13 @@ starlark_repository.archive(
     urls = ["https://github.com/rabbitmq/lz4-erlang/releases/download/v1.9.2.5/lz4-erlang-1.9.2.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.m4---1.4.21.bcr.1",
+    name = "bzl.m4---1.4.20.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "m4-1.4.21",
+    strip_prefix = "m4-1.4.20",
     type = "tar.xz",
-    urls = ["https://mirror.bazel.build/ftp.gnu.org/gnu/m4/m4-1.4.21.tar.xz"],
+    urls = ["https://mirrors.kernel.org/gnu/m4/m4-1.4.20.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.magic_enum---0.9.8",
@@ -10768,15 +10722,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/Neargye/magic_enum/releases/download/v0.9.8/magic_enum-v0.9.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.maliput---1.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "maliput-1.16.0",
-    type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput/releases/download/1.16.0/maliput-1.16.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.maliput---1.15.0",
@@ -10788,13 +10733,22 @@ starlark_repository.archive(
     urls = ["https://github.com/maliput/maliput/releases/download/1.15.0/maliput-1.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.maliput_geopackage---0.3.1",
+    name = "bzl.maliput---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "maliput_geopackage-0.3.1",
+    strip_prefix = "maliput-1.16.0",
     type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput_geopackage/releases/download/0.3.1/maliput_geopackage-0.3.1.tar.gz"],
+    urls = ["https://github.com/maliput/maliput/releases/download/1.16.0/maliput-1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.maliput_geopackage---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "maliput_geopackage-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/maliput/maliput_geopackage/releases/download/0.5.0/maliput_geopackage-0.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.maliput_malidrive---0.22.0",
@@ -10806,22 +10760,13 @@ starlark_repository.archive(
     urls = ["https://github.com/maliput/maliput_malidrive/releases/download/0.22.0/maliput_malidrive-0.22.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.maliput_sparse---0.5.0",
+    name = "bzl.maliput_sparse---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "maliput_sparse-0.5.0",
+    strip_prefix = "maliput_sparse-0.6.0",
     type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput_sparse/releases/download/0.5.0/maliput_sparse-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.maliput_sparse---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "maliput_sparse-0.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput_sparse/releases/download/0.4.0/maliput_sparse-0.4.0.tar.gz"],
+    urls = ["https://github.com/maliput/maliput_sparse/releases/download/0.6.0/maliput_sparse-0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.marisa-trie---0.2.6",
@@ -10849,15 +10794,6 @@ starlark_repository.archive(
     strip_prefix = "mbedtls-3.6.0",
     type = "tar.bz2",
     urls = ["https://github.com/Mbed-TLS/mbedtls/releases/download/v3.6.0/mbedtls-3.6.0.tar.bz2"],
-)
-starlark_repository.archive(
-    name = "bzl.mbedtls---3.6.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "mbedtls-3.6.5",
-    type = "tar.bz2",
-    urls = ["https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.5/mbedtls-3.6.5.tar.bz2"],
 )
 starlark_repository.archive(
     name = "bzl.modern-cpp-kafka---2024.07.03.bcr.1",
@@ -10896,14 +10832,13 @@ starlark_repository.archive(
     urls = ["https://github.com/nanopb/nanopb/releases/download/nanopb-0.4.9.1/nanopb-0.4.9.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.nasm---2.14.02",
+    name = "bzl.nasm---2.16.03",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    sha256 = "b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc",
-    strip_prefix = "nasm-2.14.02",
+    strip_prefix = "nasm-2.16.03",
     type = "tar.gz",
-    urls = ["http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz"],
+    urls = ["https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ncurses---6.4.20221231.bcr.9",
@@ -10924,14 +10859,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ng-log/ng-log/archive/refs/tags/v0.8.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.11.3.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
-)
-starlark_repository.archive(
     name = "bzl.nlohmann_json---3.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10940,20 +10867,20 @@ starlark_repository.archive(
     urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.11.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
+)
+starlark_repository.archive(
     name = "bzl.nlohmann_json---3.12.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.11.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip"],
 )
 starlark_repository.archive(
     name = "bzl.nogo_analyzer_bzlmod---0.1.0",
@@ -10983,6 +10910,15 @@ starlark_repository.archive(
     urls = ["https://github.com/OctoMap/octomap/archive/refs/tags/v1.9.7.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.octomap---1.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "octomap-1.10.0",
+    type = "zip",
+    urls = ["https://github.com/OctoMap/octomap/releases/download/v1.10.0/octomap-1.10.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.ode---0.16.6.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -10992,15 +10928,6 @@ starlark_repository.archive(
     urls = ["https://bitbucket.org/odedevs/ode/get/0.16.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.ofiuco---0.3.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ofiuco-0.3.7",
-    type = "tar.gz",
-    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.ofiuco---0.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11008,6 +10935,15 @@ starlark_repository.archive(
     strip_prefix = "ofiuco-0.9.0",
     type = "tar.gz",
     urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.9.0/ofiuco-0.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.ofiuco---0.3.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ofiuco-0.3.7",
+    type = "tar.gz",
+    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ogre-next---2.3.3.bcr.3",
@@ -11082,15 +11018,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openconfig/attestz/archive/refs/tags/v0.6.10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.openconfig_bootz---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bootz-0.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/openconfig/bootz/archive/refs/tags/v0.7.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.openconfig_bootz---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11098,6 +11025,15 @@ starlark_repository.archive(
     strip_prefix = "bootz-0.5.0",
     type = "tar.gz",
     urls = ["https://github.com/openconfig/bootz/archive/refs/tags/v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.openconfig_bootz---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bootz-0.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/openconfig/bootz/archive/refs/tags/v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.openconfig_gnmi---0.14.1",
@@ -11136,15 +11072,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.openexr---3.3.3.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "openexr-3.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.3/openexr-3.3.3.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.openexr---3.4.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11152,6 +11079,15 @@ starlark_repository.archive(
     strip_prefix = "openexr-3.4.10",
     type = "tar.gz",
     urls = ["https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.4.10/openexr-3.4.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.openexr---3.3.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "openexr-3.3.3",
+    type = "tar.gz",
+    urls = ["https://github.com/AcademySoftwareFoundation/openexr/releases/download/v3.3.3/openexr-3.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.openfst---1.8.4.bcr.1",
@@ -11190,6 +11126,15 @@ starlark_repository.archive(
     urls = ["https://github.com/openssl/openssl/releases/download/openssl-3.3.1/openssl-3.3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.openssl---3.5.5.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "openssl-3.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/openssl/openssl/releases/download/openssl-3.5.5/openssl-3.5.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.openssl---3.5.4.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11208,15 +11153,6 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.19.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11226,13 +11162,31 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.22.0",
+    name = "bzl.opentelemetry-cpp---1.19.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.22.0",
+    strip_prefix = "opentelemetry-cpp-1.19.0",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.22.0.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-cpp---1.14.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-cpp-1.14.2",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-proto---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-proto-1.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.8.0",
@@ -11269,15 +11223,6 @@ starlark_repository.archive(
     strip_prefix = "opentelemetry-proto-1.4.0",
     type = "tar.gz",
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentracing-cpp---1.6.0",
@@ -11369,15 +11314,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kylef/PathKit/archive/refs/tags/1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pcre2---10.43",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pcre2-pcre2-10.43",
-    type = "tar.gz",
-    urls = ["https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.43.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pcre2---10.45",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11385,6 +11321,15 @@ starlark_repository.archive(
     strip_prefix = "pcre2-10.45",
     type = "tar.bz2",
     urls = ["https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.bz2"],
+)
+starlark_repository.archive(
+    name = "bzl.pcre2---10.43",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pcre2-pcre2-10.43",
+    type = "tar.gz",
+    urls = ["https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.43.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.periphery---3.7.4",
@@ -11455,14 +11400,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jwmcglynn/pixelmatch-cpp17/archive/refs/tags/v1.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.platforms---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11471,12 +11408,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---1.0.0",
+    name = "bzl.platforms---0.0.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.7",
@@ -11487,20 +11424,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.4",
+    name = "bzl.platforms---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.5",
+    name = "bzl.platforms---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.8",
@@ -11519,12 +11456,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.10",
+    name = "bzl.platforms---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms_contrib---0.2.3",
@@ -11572,15 +11517,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ProdriveTechnologies/bazel-latex/archive/c552d5bd09e4e9e49040ede60dd97720acb1cbb7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.prometheus-cpp---1.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "prometheus-cpp-with-submodules",
-    type = "tar.gz",
-    urls = ["https://github.com/jupp0r/prometheus-cpp/releases/download/v1.2.4/prometheus-cpp-with-submodules.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.prometheus-cpp---1.3.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11588,6 +11524,15 @@ starlark_repository.archive(
     strip_prefix = "prometheus-cpp-with-submodules",
     type = "tar.gz",
     urls = ["https://github.com/jupp0r/prometheus-cpp/releases/download/v1.3.0/prometheus-cpp-with-submodules.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.prometheus-cpp---1.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "prometheus-cpp-with-submodules",
+    type = "tar.gz",
+    urls = ["https://github.com/jupp0r/prometheus-cpp/releases/download/v1.2.4/prometheus-cpp-with-submodules.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.proto-converter---0.0.0-20230607-d77ff30",
@@ -11599,24 +11544,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/proto-converter/archive/d77ff301f48bf2e7a0f8935315e847c1a8e00017.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---34.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protobuf-34.0.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---24.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-24.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.protobuf---27.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11624,24 +11551,6 @@ starlark_repository.archive(
     strip_prefix = "protobuf-27.5",
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---31.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---3.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-3.19.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---34.1",
@@ -11653,51 +11562,6 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---27.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.2",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---3.19.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-3.19.6",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---30.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.2",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.5",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.2",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.protobuf---31.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11705,42 +11569,6 @@ starlark_repository.archive(
     strip_prefix = "protobuf-31.1",
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---35.0-rc1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-35.0-rc1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0-rc1/protobuf-35.0-rc1.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.4/protobuf-33.4.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---32.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-32.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---32.0",
@@ -11752,6 +11580,78 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.protobuf---34.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-34.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protobuf-34.0.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.2",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---30.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-30.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---3.19.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-3.19.6",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---35.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-35.0-rc1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0-rc1/protobuf-35.0-rc1.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---24.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-24.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---31.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.protobuf---30.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11759,6 +11659,24 @@ starlark_repository.archive(
     strip_prefix = "protobuf-30.0",
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---32.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-32.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---3.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-3.19.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---33.0",
@@ -11770,13 +11688,40 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---30.1",
+    name = "bzl.protobuf---30.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.1",
+    strip_prefix = "protobuf-30.2",
     type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.4/protobuf-33.4.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.2",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.5",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf-matchers---0.1.1",
@@ -11813,13 +11758,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.2.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protoc-gen-validate---1.3.0",
+    name = "bzl.protoc-gen-validate---1.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "protoc-gen-validate-1.3.0",
+    strip_prefix = "protoc-gen-validate-1.3.3",
     type = "tar.gz",
-    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.0.tar.gz"],
+    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protothreads---0.1.6",
@@ -11911,6 +11856,15 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.1/pybind11_bazel-3.0.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.pybind11_bazel---2.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-2.12.0",
+    type = "zip",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.pybind11_bazel---3.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11918,6 +11872,15 @@ starlark_repository.archive(
     strip_prefix = "pybind11_bazel-3.0.0",
     type = "tar.gz",
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---2.13.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-2.13.6",
+    type = "tar.gz",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.11.1",
@@ -11938,24 +11901,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.12.0",
-    type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.13.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.13.6",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -11974,13 +11919,13 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.qdldl---0.1.8.bcr.1",
+    name = "bzl.qdldl---0.1.7.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "qdldl-0.1.8",
+    strip_prefix = "qdldl-0.1.7",
     type = "tar.gz",
-    urls = ["https://github.com/osqp/qdldl/archive/refs/tags/v0.1.8.tar.gz"],
+    urls = ["https://github.com/osqp/qdldl/archive/refs/tags/v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.quill---11.1.0",
@@ -12046,15 +11991,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jvolkman/re.bzl/releases/download/v0.2.0/re.bzl-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2021-09-01",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2021-09-01",
-    type = "zip",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
-)
-starlark_repository.archive(
     name = "bzl.re2---2025-08-12.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12062,6 +11998,15 @@ starlark_repository.archive(
     strip_prefix = "re2-2025-08-12",
     type = "zip",
     urls = ["https://github.com/google/re2/releases/download/2025-08-12/re2-2025-08-12.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2021-09-01",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2021-09-01",
+    type = "zip",
+    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
 )
 starlark_repository.archive(
     name = "bzl.re2---2023-09-01",
@@ -12073,15 +12018,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2025-11-05.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2025-11-05",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
-)
-starlark_repository.archive(
     name = "bzl.re2---2024-07-02.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12091,13 +12027,22 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2024-02-01",
+    name = "bzl.re2---2025-11-05.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-02-01",
+    strip_prefix = "re2-2025-11-05",
     type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-02-01/re2-2024-02-01.zip"],
+    urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2024-05-01",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2024-05-01",
+    type = "zip",
+    urls = ["https://github.com/google/re2/releases/download/2024-05-01/re2-2024-05-01.zip"],
 )
 starlark_repository.archive(
     name = "bzl.readerwriterqueue---1.0.6",
@@ -12118,15 +12063,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Celtoys/Remotery/archive/refs/tags/v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.riegeli---0.0.0-20250822-9f2744d",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "riegeli-9f2744dc23e81d84c02f6f51244e9e9bb9802d57",
-    type = "tar.gz",
-    urls = ["https://github.com/google/riegeli/archive/9f2744dc23e81d84c02f6f51244e9e9bb9802d57.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.riegeli---0.0.0-20240927-cdfb25a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12134,6 +12070,15 @@ starlark_repository.archive(
     strip_prefix = "riegeli-cdfb25afbc3a024a57156d7f4f3a98bcf239d278",
     type = "tar.gz",
     urls = ["https://github.com/google/riegeli/archive/cdfb25afbc3a024a57156d7f4f3a98bcf239d278.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.riegeli---0.0.0-20250822-9f2744d",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "riegeli-9f2744dc23e81d84c02f6f51244e9e9bb9802d57",
+    type = "tar.gz",
+    urls = ["https://github.com/google/riegeli/archive/9f2744dc23e81d84c02f6f51244e9e9bb9802d57.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.robin-map---1.4.0",
@@ -12163,6 +12108,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/rpmpack/releases/download/v0.6.0/rpmpack-0.6.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rsync---3.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rsync-3.4.2",
+    type = "tar.gz",
+    urls = ["https://github.com/RsyncProject/rsync/releases/download/v3.4.2/rsync-3.4.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.ruff_prebuilt---0.15.12.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12179,15 +12133,6 @@ starlark_repository.archive(
     strip_prefix = "rules_abs-0.1.0",
     type = "tar",
     urls = ["https://github.com/michaeljs1990/rules_abs/releases/download/0.1.0/rules_abs-0.1.0.tar"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_android---0.7.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android---0.7.1",
@@ -12208,15 +12153,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.4/rules_android-v0.6.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.6.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.6.6",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_android---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12224,6 +12160,24 @@ starlark_repository.archive(
     strip_prefix = "rules_android-0.1.1",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android---0.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.7.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android---0.6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android_ndk---0.1.5",
@@ -12244,13 +12198,13 @@ starlark_repository.archive(
     urls = ["https://github.com/devversion/rules_angular/releases/download/v0.1.0/rules_angular-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apko---1.5.46",
+    name = "bzl.rules_apko---1.5.47",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_apko-1.5.46",
+    strip_prefix = "rules_apko-1.5.47",
     type = "tar.gz",
-    urls = ["https://github.com/chainguard-dev/rules_apko/releases/download/v1.5.46/rules_apko-v1.5.46.tar.gz"],
+    urls = ["https://github.com/chainguard-dev/rules_apko/releases/download/v1.5.47/rules_apko-v1.5.47.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_appimage---1.20.0",
@@ -12260,14 +12214,6 @@ starlark_repository.archive(
     strip_prefix = "rules_appimage-1.20.0",
     type = "tar.gz",
     urls = ["https://github.com/lalten/rules_appimage/releases/download/v1.20.0/rules_appimage-v1.20.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---3.5.1",
@@ -12286,52 +12232,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_apple---4.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_apple---4.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.1.0/rules_apple.4.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.0/rules_apple.4.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.2/rules_apple.4.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.0.1",
@@ -12342,12 +12256,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.3.3",
+    name = "bzl.rules_apple---4.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.1.0/rules_apple.4.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.0/rules_apple.4.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.2/rules_apple.4.5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---3.5.0",
@@ -12425,14 +12379,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.3/rules_bison-v0.3.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_bison---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.3.2/rules_bison-v0.3.2.tar.xz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_browsers---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12450,15 +12396,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bfreis/rules_bsx/releases/download/v1.0.1/rules_bsx-v1.0.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_buf---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_buf-0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.3.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_buf---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12466,6 +12403,15 @@ starlark_repository.archive(
     strip_prefix = "rules_buf-abbbfce7c3fccf1d4b87afa28140d9ce53f80057",
     type = "zip",
     urls = ["https://github.com/bufbuild/rules_buf/archive/abbbfce7c3fccf1d4b87afa28140d9ce53f80057.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_buf---0.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_buf-0.5.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.4/rules_buf-0.5.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_buf---0.5.2",
@@ -12477,13 +12423,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.2/rules_buf-0.5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_buf---0.5.4",
+    name = "bzl.rules_buf---0.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_buf-0.5.4",
+    strip_prefix = "rules_buf-0.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.4/rules_buf-0.5.4.tar.gz"],
+    urls = ["https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_build_error---0.11.0",
@@ -12503,33 +12449,6 @@ starlark_repository.archive(
     urls = ["https://github.com/JalonWong/rules_c_proto/releases/download/v0.1.0/rules_c_proto-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.13",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.13",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cc---0.2.15",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12537,139 +12456,6 @@ starlark_repository.archive(
     strip_prefix = "rules_cc-0.2.15",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.12",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.12",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.18",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.18",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.14",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.14",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.16",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.16",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.6",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.17",
@@ -12681,13 +12467,49 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.17/rules_cc-0.2.17.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.9",
+    name = "bzl.rules_cc---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.9",
+    strip_prefix = "rules_cc-0.0.8",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.13",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.13",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.8",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.12",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.14",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.1",
@@ -12699,12 +12521,128 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.9.0",
+    name = "bzl.rules_cc---0.2.18",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.18",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.16",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.10.1",
@@ -12721,6 +12659,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.0/rules_cc_autoconf-0.10.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_hdrs_map---0.31.1",
@@ -12820,15 +12766,6 @@ starlark_repository.archive(
     urls = ["https://github.com/lalten/rules_cpan/releases/download/v1.1.0/rules_cpan-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cuda---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cuda-v0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.3.0/rules_cuda-v0.3.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cuda---0.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12845,6 +12782,15 @@ starlark_repository.archive(
     strip_prefix = "rules_cuda-v0.2.5",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.2.5/rules_cuda-v0.2.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cuda---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cuda-v0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.3.0/rules_cuda-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cue---0.18.0",
@@ -12944,15 +12890,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jacobshirley/rules_docs/releases/download/v0.2.0/rules_docs-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_dotnet---0.21.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_dotnet-0.21.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_dotnet/releases/download/v0.21.5/rules_dotnet-v0.21.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_dotnet---0.20.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -12960,6 +12897,15 @@ starlark_repository.archive(
     strip_prefix = "rules_dotnet-0.20.5",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_dotnet/releases/download/v0.20.5/rules_dotnet-v0.20.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_dotnet---0.21.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_dotnet-0.21.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_dotnet/releases/download/v0.21.5/rules_dotnet-v0.21.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_doxygen---2.6.2",
@@ -13007,6 +12953,14 @@ starlark_repository.archive(
     urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.16.0/rules_erlang-3.16.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_flex---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_flex---0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13023,12 +12977,13 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.3/rules_flex-v0.3.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_flex---0.4.1",
+    name = "bzl.rules_foreign_cc---0.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+    strip_prefix = "rules_foreign_cc-0.12.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_foreign_cc---0.9.0",
@@ -13040,15 +12995,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_foreign_cc---0.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_foreign_cc-0.12.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_formatjs---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13058,15 +13004,6 @@ starlark_repository.archive(
     urls = ["https://github.com/formatjs/rules_formatjs/releases/download/v0.5.0/rules_formatjs-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_fuzzing---0.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_fuzzing-v0.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_fuzzing/releases/download/v0.6.0/rules_fuzzing-v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_fuzzing---0.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13074,6 +13011,15 @@ starlark_repository.archive(
     strip_prefix = "rules_fuzzing-0.5.2",
     type = "zip",
     urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_fuzzing---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_fuzzing-v0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_fuzzing/releases/download/v0.6.0/rules_fuzzing-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_gazebo---0.0.6",
@@ -13130,68 +13076,12 @@ starlark_repository.archive(
     urls = ["https://github.com/iocat/rules_gleam/releases/download/v0.1.14/rules_gleam-v0.1.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.50.1",
+    name = "bzl.rules_go---0.57.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.41.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.59.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.54.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.58.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.52.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.60.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.39.1",
@@ -13202,36 +13092,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.49.0",
+    name = "bzl.rules_go---0.58.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.53.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.51.0",
@@ -13242,6 +13108,38 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_go---0.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.50.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.52.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
+)
+starlark_repository.archive(
     name = "bzl.rules_go---0.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13250,36 +13148,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.48.0",
+    name = "bzl.rules_go---0.41.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.57.0",
+    name = "bzl.rules_go---0.54.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.43.0",
+    name = "bzl.rules_go---0.53.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.45.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.54.0",
@@ -13290,12 +13180,68 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc1",
+    name = "bzl.rules_go---0.46.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.60.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.49.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.45.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.48.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.43.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.59.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0-rc2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_graalvm---0.11.1",
@@ -13334,12 +13280,12 @@ starlark_repository.archive(
     urls = ["https://github.com/j2kun/rules_heir/releases/download/v0.0.3/rules_heir-0.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_helm---0.24.0",
+    name = "bzl.rules_helm---0.25.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_helm/releases/download/0.24.0/rules_helm-v0.24.0.tar.gz"],
+    urls = ["https://github.com/periareon/rules_helm/releases/download/0.25.0/rules_helm-v0.25.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_img---0.3.9",
@@ -13374,20 +13320,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.9/rules_img_tool-v0.3.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_ios---6.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-ios/rules_ios/releases/download/6.0.1/rules_ios.6.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_ios---5.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-ios/rules_ios/releases/download/5.0.0/rules_ios.5.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_ios---6.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-ios/rules_ios/releases/download/6.0.1/rules_ios.6.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ispc---0.0.6",
@@ -13408,60 +13354,20 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_itest/releases/download/v0.0.52/rules_itest-v0.0.52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---5.3.5",
+    name = "bzl.rules_java---8.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.6.1",
+    name = "bzl.rules_java---8.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.9.0/rules_java-8.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---5.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---6.5.2",
@@ -13472,12 +13378,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.7.1",
+    name = "bzl.rules_java---7.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.8.0",
@@ -13488,12 +13394,116 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_java---5.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_java---6.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.15.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.9.0/rules_java-8.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.7.0",
@@ -13512,20 +13522,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.6.5",
+    name = "bzl.rules_java---5.3.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.1.0",
+    name = "bzl.rules_java---8.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.11.0/rules_java-8.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---9.0.3",
@@ -13536,84 +13554,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_java---8.15.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.11.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.11.0/rules_java-8.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jni---0.11.1",
@@ -13667,6 +13613,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.8/rules_jvm_external-6.8.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.1/rules_jvm_external-6.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13674,24 +13629,6 @@ starlark_repository.archive(
     strip_prefix = "rules_jvm_external-6.0",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---4.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-4.4.2",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.5",
@@ -13703,6 +13640,33 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_jvm_external---5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_jvm_external---5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13712,6 +13676,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.7",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -13719,6 +13692,15 @@ starlark_repository.archive(
     strip_prefix = "rules_jvm_external-6.3",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---4.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-4.4.2",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.9",
@@ -13739,72 +13721,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.1/rules_jvm_external-6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.6",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.7",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_kconfig---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_kconfig/releases/download/0.4.0/rules_kconfig-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.1.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.9/rules_kotlin-v2.1.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---1.9.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kotlin---1.9.0",
@@ -13815,12 +13737,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.2.2/rules_kotlin-v2.2.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_kotlin---2.3.20",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_kotlin---1.9.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kotlin---2.1.3",
@@ -13831,12 +13769,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.2.2",
+    name = "bzl.rules_kotlin---2.1.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.2.2/rules_kotlin-v2.2.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.9/rules_kotlin-v2.1.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kustomize---0.5.3",
@@ -13872,12 +13818,28 @@ starlark_repository.archive(
     urls = ["https://storage.googleapis.com/pigweed-bazel-tarballs/rules_libusb-8720113729935528369-7f91dc339a79292ab8aa5ca127572e54b0b586e8.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_license---0.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_license---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_license---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_license---0.0.7",
@@ -13896,20 +13858,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_license---0.0.3",
+    name = "bzl.rules_m4---0.3.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---0.0.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.3.bcr.1",
@@ -13918,14 +13872,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3/rules_m4-v0.3.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_m4---0.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.2.3",
@@ -13988,13 +13934,22 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/rules_multirun/releases/download/0.9.0/rules_multirun.0.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---0.11.0",
+    name = "bzl.rules_multitool---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-0.11.0",
+    strip_prefix = "rules_multitool-0.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_multitool---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_multitool-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_multitool---1.11.1",
@@ -14015,22 +13970,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---0.4.0",
+    name = "bzl.rules_multitool---0.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-0.4.0",
+    strip_prefix = "rules_multitool-0.11.0",
     type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_multitool---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-1.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mypy---0.40.0",
@@ -14076,31 +14022,13 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.13.0/rules_nixpkgs-0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.4",
+    name = "bzl.rules_nodejs---6.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.4",
+    strip_prefix = "rules_nodejs-6.3.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.5.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.2.0",
@@ -14112,13 +14040,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.3",
+    name = "bzl.rules_nodejs---6.7.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.3",
+    strip_prefix = "rules_nodejs-6.7.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.5.0",
@@ -14130,12 +14058,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---5.5.3",
+    name = "bzl.rules_nodejs---6.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---5.8.2",
@@ -14146,22 +14075,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.4",
+    name = "bzl.rules_nodejs---6.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.4",
+    strip_prefix = "rules_nodejs-6.5.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.3.0",
@@ -14173,13 +14093,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.4.0",
+    name = "bzl.rules_nodejs---6.7.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.4.0",
+    strip_prefix = "rules_nodejs-6.7.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.3.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---5.8.3",
@@ -14190,6 +14119,23 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-core-5.8.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_nodejs---5.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_oci---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14197,6 +14143,15 @@ starlark_repository.archive(
     strip_prefix = "rules_oci-2.3.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_oci---2.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-2.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.0/rules_oci-v2.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_oci---1.7.4",
@@ -14217,15 +14172,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_oci---2.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-2.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.0/rules_oci-v2.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_openscad---0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14242,6 +14188,14 @@ starlark_repository.archive(
     strip_prefix = "rules_pact-1.1.9",
     type = "tar.gz",
     urls = ["https://github.com/opicaud/rules_pact/releases/download/v1.1.9/rules_pact-v1.1.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_perl---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---0.2.4",
@@ -14262,14 +14216,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pex---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14287,20 +14233,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bookingcom/rules_pitest/releases/download/v0.0.2/rules_mylang-v0.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.1.0",
+    name = "bzl.rules_pkg---0.9.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_pkg---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg---1.2.0",
@@ -14311,20 +14249,36 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---0.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pkg---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg_providers---0.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tgz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/rules_pkg_providers-0.0.1/rules_pkg_providers-0.0.1.tgz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkl---0.15.0",
@@ -14406,22 +14360,13 @@ starlark_repository.archive(
     urls = ["https://github.com/hexdae/rules_probe_rs/releases/download/v0.0.6/rules_probe_rs-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---7.0.2",
+    name = "bzl.rules_proto---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-7.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---7.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-7.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
+    strip_prefix = "rules_proto-4.0.0",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---6.0.0-rc1",
@@ -14442,15 +14387,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-4.0.0",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_proto---5.3.0-21.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14460,13 +14396,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto_grpc---5.0.0",
+    name = "bzl.rules_proto---7.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto_grpc-5.0.0",
+    strip_prefix = "rules_proto-7.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.0/rules_proto_grpc-5.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto---7.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-7.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto---6.0.0-rc2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-6.0.0-rc2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc2/rules_proto-6.0.0-rc2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc---5.0.1",
@@ -14476,6 +14430,15 @@ starlark_repository.archive(
     strip_prefix = "rules_proto_grpc-5.0.1",
     type = "tar.gz",
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.1/rules_proto_grpc-5.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto_grpc---5.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto_grpc-5.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.0/rules_proto_grpc-5.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc---5.8.0",
@@ -14604,13 +14567,13 @@ starlark_repository.archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.8.0/rules_proto_grpc_swift-5.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pycross---0.8.1",
+    name = "bzl.rules_pycross---0.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_pycross-0.8.1",
+    strip_prefix = "rules_pycross-0.8.2",
     type = "tar.gz",
-    urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.1/rules_pycross-v0.8.1.tar.gz"],
+    urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.2/rules_pycross-v0.8.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pydeps---0.5.0",
@@ -14631,6 +14594,14 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.7.0/rules_python-1.7.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_python---0.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_python---0.10.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14640,30 +14611,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.4.0",
+    name = "bzl.rules_python_gazelle_plugin---0.33.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-0.33.1/gazelle",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---0.17.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.17.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.17.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python_gazelle_plugin---1.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.5.2/gazelle",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.2/rules_python-1.5.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.33.1/rules_python-0.33.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_qemu---0.1.0",
@@ -14718,6 +14672,15 @@ starlark_repository.archive(
     urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/4.14.1.2/robolectric-bazel-4.14.1.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_rs---0.0.76",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_rs-0.0.76",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.76/rules_rs-v0.0.76.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_rs---0.0.73",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14734,15 +14697,6 @@ starlark_repository.archive(
     strip_prefix = "rules_rs-0.0.68",
     type = "tar.gz",
     urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.76",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.76",
-    type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.76/rules_rs-v0.0.76.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ruby---0.19.0",
@@ -14788,12 +14742,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.49.3",
+    name = "bzl.rules_rust---0.38.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.49.3/rules_rust-v0.49.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.38.0/rules_rust-v0.38.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_mutants---0.69.1",
@@ -14812,6 +14766,15 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_rust_mutants/releases/download/0.69.0/rules_rust_mutants-0.69.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_rust_wasm_bindgen---0.69.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "extensions/wasm_bindgen",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.69.0/rules_rust-0.69.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_rust_wasm_bindgen---0.65.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14828,15 +14791,6 @@ starlark_repository.archive(
     strip_prefix = "extensions/wasm_bindgen",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.70.0/rules_rust-0.70.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rust_wasm_bindgen---0.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "extensions/wasm_bindgen",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.69.0/rules_rust-0.69.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_s3---1.0.1",
@@ -14866,13 +14820,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.5/rules_scala-v7.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.2.4",
+    name = "bzl.rules_scala---7.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.2.4",
+    strip_prefix = "rules_scala-7.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.4/rules_scala-v7.2.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.1.3",
@@ -14884,15 +14838,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.3/rules_scala-v7.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_scala---7.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14900,6 +14845,15 @@ starlark_repository.archive(
     strip_prefix = "rules_scala-7.2.2",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.4/rules_scala-v7.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala_native---0.1.0",
@@ -14911,15 +14865,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Programming-Rivers/rules_scala_native/releases/download/v0.1.0/rules_scala_native-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_sh---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_sh-0.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/tweag/rules_sh/releases/download/v0.5.0/rules_sh-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_sh---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14929,30 +14874,21 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_sh/releases/download/v0.4.0/rules_sh-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_sh---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_sh-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/tweag/rules_sh/releases/download/v0.5.0/rules_sh-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_shar---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/filmil/rules_shar/releases/download/v1.0.0/rules_shar-v1.0.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.4.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.4.0",
@@ -14964,15 +14900,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.0/rules_shell-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_shell---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -14980,6 +14907,33 @@ starlark_repository.archive(
     strip_prefix = "rules_shell-0.5.0",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.7.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.8.0",
@@ -15000,21 +14954,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.2.0/rules_shell-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.7.1",
+    name = "bzl.rules_shell---0.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.7.1",
+    strip_prefix = "rules_shell-0.6.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shellcheck---0.3.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.3.3/rules_shellcheck-0.3.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellcheck---0.6.2",
@@ -15023,6 +14969,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.6.2/rules_shellcheck-0.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shellcheck---0.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/aignas/rules_shellcheck/releases/download/0.3.3/rules_shellcheck-0.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellspec---0.1.6",
@@ -15060,60 +15014,12 @@ starlark_repository.archive(
     urls = ["https://github.com/tharakadesilva/rules_spring_aot/releases/download/v0.1.0/rules_spring_aot-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---1.18.0",
+    name = "bzl.rules_swift---3.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.3.0/rules_swift.3.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.4.2",
@@ -15124,12 +15030,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.2/rules_swift.3.4.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.0",
+    name = "bzl.rules_swift---3.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.3.0/rules_swift.3.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.6.1",
@@ -15148,12 +15094,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.3.0/rules_swift.2.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.1.2",
+    name = "bzl.rules_swift---1.18.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift_package_manager---1.16.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.16.1/rules_swift_package_manager.v1.16.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_package_manager---1.15.0",
@@ -15170,14 +15132,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.9.0/rules_swift_package_manager.v1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift_package_manager---1.16.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.16.1/rules_swift_package_manager.v1.16.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_previews---0.1.1",
@@ -15216,12 +15170,12 @@ starlark_repository.archive(
     urls = ["https://github.com/chickenandpork/rules_synology/releases/download/v0.2.3/rules_synology-v0.2.3.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_systemrdl---0.1.1",
+    name = "bzl.rules_systemrdl---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_systemrdl/releases/download/0.1.1/rules_systemrdl-0.1.1.tar.gz"],
+    urls = ["https://github.com/hw-bzl/rules_systemrdl/releases/download/0.2.0/rules_systemrdl-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_tcl---0.2.1",
@@ -15275,13 +15229,13 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_typst/releases/download/0.2.0/rules_typst-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_uv---0.21.0",
+    name = "bzl.rules_uv---0.89.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_uv-0.21.0",
+    strip_prefix = "rules_uv-0.89.2",
     type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_uv---0.44.0",
@@ -15293,13 +15247,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_uv---0.89.2",
+    name = "bzl.rules_uv---0.21.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_uv-0.89.2",
+    strip_prefix = "rules_uv-0.21.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
+    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_venv---0.15.0",
@@ -15310,14 +15264,6 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.15.0/rules_venv-0.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_venv---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_venv---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15326,20 +15272,20 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.16.0/rules_venv-0.16.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_venv---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_venv---0.17.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_verilator---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilator---0.1.0",
@@ -15351,13 +15297,12 @@ starlark_repository.archive(
     urls = ["https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.1.0/bazel_rules_verilator-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_verilog---1.1.0",
+    name = "bzl.rules_verilator---0.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_rules_verilog-1.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/bazel_rules_verilog/releases/download/v1.1.0/bazel_rules_verilog-1.1.0.tar.gz"],
+    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilog---1.1.1",
@@ -15366,6 +15311,15 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/hw-bzl/rules_verilog/releases/download/1.1.1/rules_verilog-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_verilog---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_rules_verilog-1.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/hw-bzl/bazel_rules_verilog/releases/download/v1.1.0/bazel_rules_verilog-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_vhdl---0.1.1",
@@ -15411,12 +15365,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.4.1/rules_webtesting-0.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_xcodeproj---4.0.1",
+    name = "bzl.rules_xcodeproj---4.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/MobileNativeFoundation/rules_xcodeproj/releases/download/4.0.1/release.tar.gz"],
+    urls = ["https://github.com/MobileNativeFoundation/rules_xcodeproj/releases/download/4.1.0/release.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ytt---0.4.0",
@@ -15491,15 +15445,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.sdformat---16.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "sdformat-sdformat16_16.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.sdformat---16.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15507,6 +15452,15 @@ starlark_repository.archive(
     strip_prefix = "sdformat-sdformat16_16.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.sdformat---16.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "sdformat-sdformat16_16.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.sha256.bzl---0.0.1",
@@ -15544,15 +15498,6 @@ starlark_repository.archive(
     urls = ["https://github.com/apache/skywalking-data-collect-protocol/archive/refs/tags/v10.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.snappy---1.2.2.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "snappy-1.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.snappy---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15560,6 +15505,15 @@ starlark_repository.archive(
     strip_prefix = "snappy-1.2.0",
     type = "tar.gz",
     urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.snappy---1.2.2.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "snappy-1.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.soplex---7.1.4.bcr.4",
@@ -15579,15 +15533,6 @@ starlark_repository.archive(
     urls = ["https://github.com/spotify/sourcekit-bazel-bsp/releases/download/0.8.3/release.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.sourcekitten---0.37.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "SourceKitten-0.37.2",
-    type = "tar.gz",
-    urls = ["https://github.com/jpsim/SourceKitten/releases/download/0.37.2/SourceKitten-0.37.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.sourcekitten---0.37.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15597,21 +15542,21 @@ starlark_repository.archive(
     urls = ["https://github.com/jpsim/SourceKitten/releases/download/0.37.3/SourceKitten-0.37.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.sourcekitten---0.37.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "SourceKitten-0.37.2",
+    type = "tar.gz",
+    urls = ["https://github.com/jpsim/SourceKitten/releases/download/0.37.2/SourceKitten-0.37.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.sparrowhawk---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/ryanli/sparrowhawk/releases/download/v2.1.0/sparrowhawk-2.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.spdlog---1.17.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "spdlog-1.17.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.17.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.spdlog---1.12.0",
@@ -15623,15 +15568,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.spdlog---1.10.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "spdlog-1.10.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.spdlog---1.15.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15639,6 +15575,24 @@ starlark_repository.archive(
     strip_prefix = "spdlog-1.15.3",
     type = "tar.gz",
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.spdlog---1.17.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "spdlog-1.17.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.17.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.spdlog---1.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "spdlog-1.10.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.sphinxdocs---2.0.0",
@@ -15686,13 +15640,13 @@ starlark_repository.archive(
     urls = ["https://sqlite.org/2025/sqlite-amalgamation-3500300.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.sqlite3---3.49.0.bcr.1",
+    name = "bzl.sqlite3---3.48.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "sqlite-amalgamation-3490000",
+    strip_prefix = "sqlite-amalgamation-3480000",
     type = "zip",
-    urls = ["https://sqlite.org/2025/sqlite-amalgamation-3490000.zip"],
+    urls = ["https://sqlite.org/2025/sqlite-amalgamation-3480000.zip"],
 )
 starlark_repository.archive(
     name = "bzl.squashfs-tools---4.7.4",
@@ -15704,6 +15658,14 @@ starlark_repository.archive(
     urls = ["https://github.com/plougher/squashfs-tools/releases/download/4.7.4/squashfs-tools-4.7.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.stardoc---0.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.stardoc---0.6.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15712,28 +15674,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.8.1",
+    name = "bzl.stardoc---0.5.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.7.0",
@@ -15744,28 +15690,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.5.3",
+    name = "bzl.stardoc---0.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.7.1",
@@ -15776,6 +15706,30 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.stardoc---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.stardoc---0.7.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15784,12 +15738,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.2/stardoc-0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.5.6",
+    name = "bzl.stardoc---0.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.subspace---2.6.2",
@@ -15801,15 +15755,6 @@ starlark_repository.archive(
     urls = ["https://github.com/dallison/subspace/releases/download/2.6.2/subspace-2.6.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.supply-chain-go---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.6/lib/supplychain-go",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.supply-chain-go---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15817,6 +15762,15 @@ starlark_repository.archive(
     strip_prefix = "supply-chain-0.0.10/lib/supplychain-go",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.10/supply-chain-v0.0.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.supply-chain-go---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.6/lib/supplychain-go",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.supply_chain_tools---0.0.1",
@@ -15942,13 +15896,13 @@ starlark_repository.archive(
     urls = ["https://github.com/realm/SwiftLint/releases/download/0.63.2/bazel.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swig---4.1.0",
+    name = "bzl.swig---4.3.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "swig-4.1.0",
+    strip_prefix = "swig-4.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/swig/swig/archive/refs/tags/v4.1.0.tar.gz"],
+    urls = ["https://github.com/swig/swig/archive/refs/tags/v4.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swxmlhash---7.0.2.2",
@@ -15969,15 +15923,6 @@ starlark_repository.archive(
     urls = ["https://github.com/accellera-official/systemc/archive/refs/tags/3.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.tar.bzl---0.10.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -15996,13 +15941,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.5.5",
+    name = "bzl.tar.bzl---0.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.5.5",
+    strip_prefix = "tar.bzl-0.2.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.5/tar.bzl-v0.5.5.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tar.bzl---0.5.1",
@@ -16014,15 +15959,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.tar.bzl---0.10.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16032,6 +15968,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.4/tar.bzl-v0.10.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.tar.bzl---0.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.5/tar.bzl-v0.5.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.tar.bzl---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16039,6 +15984,15 @@ starlark_repository.archive(
     strip_prefix = "tar.bzl-0.6.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tcl_lang---9.0.2.bcr.1",
@@ -16086,15 +16040,6 @@ starlark_repository.archive(
     urls = ["https://storage.googleapis.com/rime-public/mirror/thrax-1.3.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tink_cc---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tink-cc-2.3.0",
-    type = "zip",
-    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.3.0/tink-cc-2.3.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.tink_cc---2.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16102,6 +16047,15 @@ starlark_repository.archive(
     strip_prefix = "tink-cc-2.6.0",
     type = "zip",
     urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.6.0/tink-cc-2.6.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.tink_cc---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tink-cc-2.3.0",
+    type = "zip",
+    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.3.0/tink-cc-2.3.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.tinyobjloader---2.0.0-rc1.bcr.2",
@@ -16203,21 +16157,30 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.7.0/toolchains_llvm-v1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_llvm_bootstrapped---0.5.3",
+    name = "bzl.toolchains_llvm_bootstrapped---0.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_llvm_bootstrapped-0.5.3",
+    strip_prefix = "toolchains_llvm_bootstrapped-0.2.1",
     type = "tar.gz",
-    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.5.3/toolchains_llvm_bootstrapped-0.5.3.tar.gz"],
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.2.1/toolchains_llvm_bootstrapped-0.2.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_musl---0.1.27",
+    name = "bzl.toolchains_musl---0.1.27.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl_toolchain-v0.1.27.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.toolchains_protoc---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_protoc-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_protoc---0.3.1",
@@ -16245,15 +16208,6 @@ starlark_repository.archive(
     strip_prefix = "toolchains_protoc-0.5.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.5.0/toolchains_protoc-v0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.toolchains_protoc---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_protoc-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_riscv_gnu---1.0.0",
@@ -16372,13 +16326,13 @@ starlark_repository.archive(
     urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.036.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.verilator---5.046.bcr.4",
+    name = "bzl.verilator---5.034.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "verilator-5.046",
+    strip_prefix = "verilator-5.034",
     type = "tar.gz",
-    urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.046.tar.gz"],
+    urls = ["https://github.com/verilator/verilator/archive/refs/tags/v5.034.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.version_utils---0.1.0",
@@ -16433,13 +16387,13 @@ starlark_repository.archive(
     urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.1/windows_support-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.with_cfg.bzl---0.14.6",
+    name = "bzl.with_cfg.bzl---0.14.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "with_cfg.bzl-0.14.6",
+    strip_prefix = "with_cfg.bzl-0.14.1",
     type = "tar.gz",
-    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.6/with_cfg.bzl-v0.14.6.tar.gz"],
+    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.1/with_cfg.bzl-v0.14.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.with_cfg.bzl---0.12.0",
@@ -16451,13 +16405,13 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.12.0/with_cfg.bzl-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.with_cfg.bzl---0.14.1",
+    name = "bzl.with_cfg.bzl---0.14.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "with_cfg.bzl-0.14.1",
+    strip_prefix = "with_cfg.bzl-0.14.6",
     type = "tar.gz",
-    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.1/with_cfg.bzl-v0.14.1.tar.gz"],
+    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.6/with_cfg.bzl-v0.14.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.wolfd_bazel_compile_commands---0.5.2",
@@ -16486,15 +16440,6 @@ starlark_repository.archive(
     urls = ["https://github.com/tuist/XcodeProj/archive/refs/tags/9.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.xds---0.0.0-20240423-555b57e",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "xds-555b57ec207be86f811fb0c04752db6f85e3d7e2",
-    type = "tar.gz",
-    urls = ["https://github.com/cncf/xds/archive/555b57ec207be86f811fb0c04752db6f85e3d7e2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.xds---0.0.0-20251210-ee656c7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16502,6 +16447,15 @@ starlark_repository.archive(
     strip_prefix = "xds-ee656c7534f5d7dc23d44dd611689568f72017a6",
     type = "tar.gz",
     urls = ["https://github.com/cncf/xds/archive/ee656c7534f5d7dc23d44dd611689568f72017a6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.xds---0.0.0-20240423-555b57e",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "xds-555b57ec207be86f811fb0c04752db6f85e3d7e2",
+    type = "tar.gz",
+    urls = ["https://github.com/cncf/xds/archive/555b57ec207be86f811fb0c04752db6f85e3d7e2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.xml.bzl---0.2.3",
@@ -16522,6 +16476,15 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/xorgproto/archive/refs/tags/xorgproto-2024.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.xxhash---0.8.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "xxHash-0.8.3",
+    type = "tar.gz",
+    urls = ["https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.xz---5.4.5.bcr.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16529,6 +16492,14 @@ starlark_repository.archive(
     strip_prefix = "xz-5.4.5",
     type = "tar.gz",
     urls = ["https://github.com/tukaani-project/xz/releases/download/v5.4.5/xz-5.4.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yaml-cpp---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.yaml-cpp---0.8.0.bcr.1",
@@ -16540,14 +16511,6 @@ starlark_repository.archive(
     urls = ["https://github.com/stonier/yaml-cpp/releases/download/0.8.0/yaml-cpp-0.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yaml-cpp---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yaml.bzl---0.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16557,15 +16520,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/yaml.bzl/releases/download/v0.1.2/yaml.bzl-v0.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yams---6.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "clean",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Yams-6.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yams---6.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16573,6 +16527,15 @@ starlark_repository.archive(
     strip_prefix = "Yams-6.2.0",
     type = "tar.gz",
     urls = ["https://github.com/jpsim/Yams/archive/refs/tags/6.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yams---6.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Yams-6.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.yq.bzl---0.1.1",
@@ -16629,6 +16592,15 @@ starlark_repository.archive(
     urls = ["https://github.com/openzipkin/zipkin-api/archive/refs/tags/1.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.zlib---1.3.1.bcr.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zlib-1.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.zlib---1.2.11",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16647,13 +16619,13 @@ starlark_repository.archive(
     urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.12.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.zlib---1.3.1.bcr.8",
+    name = "bzl.zlib---1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.3.1",
+    strip_prefix = "zlib-1.3",
     type = "tar.gz",
-    urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"],
+    urls = ["https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.zlib-ng---2.0.7",
@@ -16665,6 +16637,15 @@ starlark_repository.archive(
     urls = ["https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.zstd---1.5.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "clean",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zstd-1.5.6",
+    type = "tar.gz",
+    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.zstd---1.5.7.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
@@ -16674,13 +16655,13 @@ starlark_repository.archive(
     urls = ["https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.zstd---1.5.6",
+    name = "bzl.zstd---1.5.5.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "clean",
     languages = ["starlarkrepository"],
-    strip_prefix = "zstd-1.5.6",
+    strip_prefix = "zstd-1.5.5",
     type = "tar.gz",
-    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"],
+    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.zstd-jni---1.5.6-9",


### PR DESCRIPTION
- New commitAuthorAvatarLink / commitAuthorNameLink helpers pattern-match bot usernames (*-bot, *[bot], bot/*) and render a Dependabot octicon with no profile link, instead of a broken github.com/<bot>.png. Used by homeRecentTimeline (so Recently Updated/Added and the maintainer activity feed pick it up) and bazelVersionDetail. De-duplicates the avatar+link markup that was copy-pasted across both templates.
- Adds a "Bazel Documentation" sidebar link.
- New CLAUDE.md captures soy/closure/bazel gotchas hit on this branch (no `and`/`or` keywords, no template calls in {if}, soy.renderAsElement inline-literal pattern, output_user_root locking, etc.).
- Submodule + generated MODULE.bazel bumps.