### PR TITLE
Flag detail polish + Categories/Tags tabs + sitemap

### DIFF
--- a/app/bcr/app.js
+++ b/app/bcr/app.js
@@ -1,5 +1,6 @@
 goog.module("bcrfrontend.App");
 
+const BazelFlagDb = goog.require("proto.build.stack.bazel.help.v1.BazelFlagDb");
 const ComponentEventType = goog.require("goog.ui.Component.EventType");
 const Registry = goog.require("proto.build.stack.bazel.registry.v1.Registry");
 const asserts = goog.require("goog.asserts");
@@ -410,8 +411,8 @@ class RegistryApp extends App {
 
 	/**
 	 * Cycle to the next/previous sibling within the current section. Works
-	 * on /maintainers/<handle> (cycles maintainers) and /modules/<name>/...
-	 * (cycles modules). No-op elsewhere.
+	 * on /maintainers/<handle>, /modules/<name>/..., and
+	 * /bazel/flags/<flag-name>. No-op elsewhere.
 	 *
 	 * @param {number} direction +1 for next, -1 for previous
 	 * @param {!events.BrowserEvent=} opt_e
@@ -430,33 +431,56 @@ class RegistryApp extends App {
 			.filter(Boolean);
 		if (segments.length < 2) return;
 
-		/** @type {!Array<string>} */
-		let names = [];
 		if (segments[0] === "maintainers") {
-			createMaintainersMap(this.registry_).forEach((_, key) => {
-				names.push(key);
-			});
-		} else if (segments[0] === "modules") {
-			createModuleMap(this.registry_).forEach((_, key) => {
-				names.push(key);
-			});
-		} else {
+			const names = [...createMaintainersMap(this.registry_).keys()];
+			this.cycleSibling_(["maintainers"], names, segments[1], direction);
 			return;
 		}
+		if (segments[0] === "modules") {
+			const names = [...createModuleMap(this.registry_).keys()];
+			this.cycleSibling_(["modules"], names, segments[1], direction);
+			return;
+		}
+		if (
+			segments[0] === "bazel" &&
+			segments[1] === "flags" &&
+			segments.length >= 3 &&
+			segments[2] !== "list" &&
+			segments[2] !== "tag"
+		) {
+			// /bazel/flags/<flag-name> — cycle through every flag in the DB.
+			this.bazelFlagDbLoader_().then((db) => {
+				const typed = /** @type {!BazelFlagDb} */ (db);
+				const names = typed.getFlagList().map((f) => f.getName());
+				this.cycleSibling_(["bazel", "flags"], names, segments[2], direction);
+			});
+			return;
+		}
+	}
 
-		names.sort((a, b) => {
+	/**
+	 * Sorts `names` alphabetically and navigates to `[...prefix, sibling]`
+	 * where `sibling` is the entry `direction` positions away from
+	 * `currentName` (wrapping at the ends).
+	 *
+	 * @private
+	 * @param {!Array<string>} prefix path prefix segments (e.g. ["modules"]).
+	 * @param {!Array<string>} names siblings in the current section.
+	 * @param {string} currentName segment value to match (URL-encoded ok).
+	 * @param {number} direction +1 or -1.
+	 */
+	cycleSibling_(prefix, names, currentName, direction) {
+		if (names.length === 0) return;
+		const sorted = names.slice().sort((a, b) => {
 			const la = a.toLowerCase();
 			const lb = b.toLowerCase();
 			return la < lb ? -1 : la > lb ? 1 : 0;
 		});
-		if (names.length === 0) return;
-
-		const current = decodeURIComponent(segments[1]);
-		const idx = names.indexOf(current);
+		const current = decodeURIComponent(currentName);
+		const idx = sorted.indexOf(current);
 		if (idx === -1) return;
-
-		const next = (idx + direction + names.length) % names.length;
-		this.setLocation([segments[0], names[next]]);
+		const next = (idx + direction + sorted.length) % sorted.length;
+		this.setLocation([...prefix, sorted[next]]);
 	}
 
 	/**

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -10,6 +10,7 @@ import {
     octiconChevronRight16,
     octiconChevronUp24,
     octiconCode16,
+    octiconCommentDiscussion16,
     octiconDependabot16,
     octiconDependabot24,
     octiconDotFill16,
@@ -436,13 +437,13 @@ import {
     </a>
     <a class="Link--primary d-flex flex-items-center mb-2"
       href="javascript:void(0)" data-action="next-sibling">
-      <span class="color-fg-muted">Next Module / Maintainer</span>
+      <span class="color-fg-muted">Next Module / Maintainer / Flag</span>
       <span class="dotted-leader"></span>
       {kbd(key: ']')}
     </a>
     <a class="Link--primary d-flex flex-items-center mb-2"
       href="javascript:void(0)" data-action="prev-sibling">
-      <span class="color-fg-muted">Previous Module / Maintainer</span>
+      <span class="color-fg-muted">Previous Module / Maintainer / Flag</span>
       <span class="dotted-leader"></span>
       {kbd(key: '[')}
     </a>
@@ -493,7 +494,7 @@ import {
   {@param? title: string}
   {@param size: int}
   {let $safeName: $name ?? '' /}
-  {let $isBot: $safeName.endsWith('-bot') || $safeName.indexOf('[bot]') >= 0 || $safeName.startsWith('bot/') /}
+  {let $isBot: $safeName.indexOf('[bot]') >= 0 || $safeName == 'publish-to-bcr-bot' /}
 {if $safeName && $isBot}
   <div class="TimelineItem-badge timeline-avatar-badge"
        title="{$title ?? '@' + $safeName}"
@@ -527,7 +528,7 @@ import {
   {@param? displayName: string}
   {@param class: string}
   {let $safeName: $name ?? '' /}
-  {let $isBot: $safeName.endsWith('-bot') || $safeName.indexOf('[bot]') >= 0 || $safeName.startsWith('bot/') /}
+  {let $isBot: $safeName.indexOf('[bot]') >= 0 || $safeName == 'publish-to-bcr-bot' /}
   {if $safeName}
     {if $isBot}
       <span class="{$class}">{$displayName ?? $safeName}</span>
@@ -817,6 +818,56 @@ import {
 {/template}
 
 
+{template bazelFlagsCategoriesTable}
+  {@param categories: list<[name: string, count: int]>}
+<div>
+  {if length($categories) > 0}
+    <div class="Box Box--condensed">
+      {for $cat in $categories}
+        <a href="/#/bazel/flags/category/{$cat.name |escapeUri}"
+           class="Box-row d-flex flex-items-center"
+           style="text-decoration: none;">
+          <span class="text-bold">{$cat.name}</span>
+          <span class="color-fg-muted text-small ml-auto">
+            {$cat.count} flag{$cat.count == 1 ? '' : 's'}
+          </span>
+        </a>
+      {/for}
+    </div>
+  {else}
+    <div class="blankslate p-3">
+      <p>No categories found.</p>
+    </div>
+  {/if}
+</div>
+{/template}
+
+
+{template bazelFlagsTagsTable}
+  {@param tags: list<[name: string, count: int]>}
+<div>
+  {if length($tags) > 0}
+    <div class="Box Box--condensed">
+      {for $tag in $tags}
+        <a href="/#/bazel/flags/tag/{$tag.name |escapeUri}"
+           class="Box-row d-flex flex-items-center"
+           style="text-decoration: none;">
+          <span class="text-bold">{$tag.name}</span>
+          <span class="color-fg-muted text-small ml-auto">
+            {$tag.count} flag{$tag.count == 1 ? '' : 's'}
+          </span>
+        </a>
+      {/for}
+    </div>
+  {else}
+    <div class="blankslate p-3">
+      <p>No tags found.</p>
+    </div>
+  {/if}
+</div>
+{/template}
+
+
 {template bazelFlagsResultsList}
   {@param items: list<[flag: BazelFlag, description: string, current: bool]>}
 <div>
@@ -909,8 +960,21 @@ import {
   {@param totalSymbols: int}
   {@param totalBazelVersions: int}
   {@param uiCommitSha: string}
-<div class="PageLayout PageLayout--panePos-end PageLayout--hasPaneDivider PageLayout--responsive-stackRegions mt-3">
+<div class="PageLayout PageLayout--panePos-start PageLayout--hasPaneDivider PageLayout--responsive-stackRegions PageLayout--responsive-panePos-start mt-3">
 <div class="PageLayout-columns">
+
+  <div class="PageLayout-pane">
+    {call bcrSidePane}
+      {param registry: $registry /}
+      {param totalModules: $totalModules /}
+      {param totalModuleVersions: $totalModuleVersions /}
+      {param totalMaintainers: $totalMaintainers /}
+      {param totalSymbols: $totalSymbols /}
+      {param totalBazelVersions: $totalBazelVersions /}
+      {param uiCommitSha: $uiCommitSha /}
+    {/call}
+  </div>
+
   <div class="PageLayout-content px-3">
     <div class="mb-2">
       <a class="Link--muted f6" href="/#/bazel/flags/list">
@@ -918,7 +982,7 @@ import {
       </a>
     </div>
 
-    <h2 class="h2 d-flex flex-items-center mb-2">
+    <h2 class="h2 d-flex flex-items-center">
       <span class="text-mono">--{$flag.getName()}</span>
       {if $flag.getShort()}
         <span class="color-fg-muted text-mono ml-3 f4">-{$flag.getShort()}</span>
@@ -926,89 +990,119 @@ import {
       {copyToClipboardButton(content: '--' + $flag.getName())}
     </h2>
 
-    <div class="d-flex flex-wrap mb-3">
+    {if $flag.getToggle()}
+      <h3 class="h3 d-flex flex-items-center ml-1 color-fg-muted">
+        <span class="text-mono">--no{$flag.getName()}</span>
+        {copyToClipboardButton(content: '--no' + $flag.getName())}
+      </h3>
+    {/if}
+
+    <div class="d-flex flex-wrap mt-2">
       {if $flag.getType()}
-        <label class="Label Label--secondary mr-2 mb-1">{$flag.getType()}</label>
+        <label class="Label Label--secondary mr-2 mb-1"><span class="text-mono text-bold">{$flag.getType()}</span></label>
       {/if}
       {if $flag.getDefault()}
-        <label class="Label Label--secondary mr-2 mb-1">default: {$flag.getDefault()}</label>
-      {/if}
-      {if $flag.getToggle()}
-        <label class="Label Label--accent mr-2 mb-1">--[no]<span class="text-mono">{$flag.getName()}</span></label>
-      {/if}
-      {if $flag.getCategory()}
-        <label class="Label Label--secondary mr-2 mb-1">{$flag.getCategory()}</label>
+        <label class="Label Label--secondary mr-2 mb-1">default: <span class="text-mono text-bold">{$flag.getDefault()}</span></label>
       {/if}
     </div>
 
     {if length($flag.getDescriptionList()) > 0}
-      <div class="markdown-body color-fg-default mb-4 {css('marked')}">
+      <div class="markdown-body color-fg-default mt-3 {css('marked')}">
         {for $line in $flag.getDescriptionList()}
           {$line}{\n}
         {/for}
       </div>
     {/if}
 
-  </div>
+    <div class="mt-3">
+      <a class="Link--muted d-flex flex-items-center mb-1"
+          href="https://cs.opensource.google/search?q={$flag.getName()}&ss=bazel"
+          target="_blank" rel="noopener noreferrer">
+        <span class="mr-2">{octiconCode16()}</span>
+        <span>Search Bazel source for <span class="text-mono text-semibold">{$flag.getName()}</span></span>
+      </a>
+      <a class="Link--muted d-flex flex-items-center mb-1"
+          href="https://bazelbuild.slack.com/?q={$flag.getName()}"
+          target="_blank" rel="noopener noreferrer">
+        <span class="mr-2">{octiconCommentDiscussion16()}</span>
+        <span>Search Bazel Slack for <span class="text-mono text-semibold">{$flag.getName()}</span></span>
+      </a>
+    </div>
 
-  <div class="PageLayout-pane">
-    <div>
-      <div>
-        {sectionHeader(title: 'Available in')}
-        {if length($versions) > 0}
-          <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
-            {for $v in $versions}
-              {if $v.active}
-                <a class="Label Label--success" href="/#/bazel/{$v.name}" style="text-decoration: none;">
-                  {$v.name}
-                </a>
-              {else}
-                <span class="Label Label--secondary color-fg-subtle" style="opacity: 0.4">
-                  {$v.name}
-                </span>
-              {/if}
-            {/for}
-          </div>
-        {else}
-          <div class="color-fg-muted">No bazel versions recorded for this flag.</div>
-        {/if}
-      </div>
-
+    {if $flag.getCategory()}
       {sectionDivider()}
 
-      <div>
-        {sectionHeader(title: 'Applies to')}
-        {if length($commands) > 0}
-          <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
-            {for $cmd in $commands}
-              <a class="Label {if $cmd.active}Label--accent{else}Label--secondary color-fg-subtle{/if}"
-                 href="/#/bazel/command/{$cmd.name}"
-                 style="text-decoration: none;{if !$cmd.active} opacity: 0.4;{/if}">
-                {$cmd.name}
-              </a>
-            {/for}
-          </div>
-        {else}
-          <div class="color-fg-muted">No subcommands recorded.</div>
-        {/if}
-      </div>
-
-      {if length($flag.getTagList()) > 0}
-        {sectionDivider()}
-
-        <div>
-          {sectionHeader(title: 'Tags')}
-          <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
-            {for $tag in $flag.getTagList()}
-              <a class="Label Label--secondary" href="/#/bazel/flags/tag/{$tag}" style="text-decoration: none;">
-                {$tag}
-              </a>
-            {/for}
-          </div>
+      <div class="mb-3">
+        {sectionHeader(title: 'Category')}
+        <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+          <a class="Label Label--secondary"
+             href="/#/bazel/flags/category/{$flag.getCategory() |escapeUri}"
+             style="text-decoration: none;">
+            {$flag.getCategory()}
+          </a>
         </div>
+      </div>
+    {/if}
+
+    {if length($flag.getTagList()) > 0}
+      {sectionDivider()}
+
+      <div class="mb-3">
+        {sectionHeader(title: 'Tags')}
+        <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+          {for $tag in $flag.getTagList()}
+            <a class="Label Label--secondary" href="/#/bazel/flags/tag/{$tag}" style="text-decoration: none;">
+              {$tag}
+            </a>
+          {/for}
+        </div>
+      </div>
+    {/if}
+
+    {sectionDivider()}
+
+    <div class="mb-3">
+      {sectionHeader(title: 'Applies to')}
+      {if length($commands) > 0}
+        <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+          {for $cmd in $commands}
+            <a class="Label {if $cmd.active}Label--accent{else}Label--secondary color-fg-subtle{/if}"
+               href="/#/bazel/command/{$cmd.name}"
+               style="text-decoration: none;{if !$cmd.active} opacity: 0.4;{/if}">
+              {$cmd.name}
+            </a>
+          {/for}
+        </div>
+      {else}
+        <div class="color-fg-muted">No subcommands recorded.</div>
       {/if}
     </div>
+
+    {sectionDivider()}
+
+    <div class="mb-3">
+      {sectionHeader(title: 'Available in')}
+      {if length($versions) > 0}
+        <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
+          {for $v in $versions}
+            {if $v.active}
+              <a class="Label Label--success" href="/#/bazel/{$v.name}" style="text-decoration: none;">
+                {$v.name}
+              </a>
+            {else}
+              <span class="Label Label--secondary color-fg-subtle" style="opacity: 0.4">
+                {$v.name}
+              </span>
+            {/if}
+          {/for}
+        </div>
+      {else}
+        <div class="color-fg-muted">No bazel versions recorded for this flag.</div>
+      {/if}
+    </div>
+
   </div>
+
 </div>
 </div>
 {/template}

--- a/app/bcr/bazel_flags.js
+++ b/app/bcr/bazel_flags.js
@@ -22,10 +22,12 @@ const {
 const {
 	bazelFlagDetail,
 	bazelFlagGroup,
+	bazelFlagsCategoriesTable,
 	bazelFlagsListComponent,
 	bazelFlagsListSelectNav,
 	bazelFlagsResultsList,
 	bazelFlagsSelect,
+	bazelFlagsTagsTable,
 } = goog.require("soy.bcrfrontend.app");
 const { counterLabel } = goog.require("soy.registry");
 const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
@@ -36,6 +38,9 @@ const { commitSha: uiCommitSha } = goog.require("bcrfrontend.uiVersion");
 const TabName = {
 	LIST: "list",
 	TAG: "tag",
+	TAGS: "tags",
+	CATEGORY: "category",
+	CATEGORIES: "categories",
 };
 
 /**
@@ -95,6 +100,15 @@ class BazelFlagsSelect extends ContentSelect {
 			return;
 		}
 
+		if (name === TabName.CATEGORY) {
+			this.addTab(
+				TabName.CATEGORY,
+				new BazelFlagsByCategorySelect(this.registry_, this.dom_),
+			);
+			this.select(name, route);
+			return;
+		}
+
 		// Treat any other segment as a flag name; the detail component
 		// resolves it against the lazy-loaded DB.
 		this.addTab(
@@ -143,6 +157,45 @@ class BazelFlagsByTagSelect extends ContentSelect {
 	}
 }
 exports.BazelFlagsByTagSelect = BazelFlagsByTagSelect;
+
+/**
+ * Sub-Select at /bazel/flags/category/. Consumes the next (URL-encoded)
+ * segment as a help-category title and instantiates
+ * BazelFlagsByCategoryComponent for it.
+ */
+class BazelFlagsByCategorySelect extends ContentSelect {
+	/**
+	 * @param {!Registry} registry
+	 * @param {?dom.DomHelper=} opt_domHelper
+	 */
+	constructor(registry, opt_domHelper) {
+		super(opt_domHelper);
+
+		/** @private @const @type {!Registry} */
+		this.registry_ = registry;
+	}
+
+	/**
+	 * @override
+	 */
+	createDom() {
+		this.setElementInternal(soy.renderAsElement(bazelFlagsSelect));
+	}
+
+	/**
+	 * @override
+	 * @param {string} name
+	 * @param {!Route} route
+	 */
+	selectFail(name, route) {
+		this.addTab(
+			name,
+			new BazelFlagsByCategoryComponent(this.registry_, name, this.dom_),
+		);
+		this.select(name, route);
+	}
+}
+exports.BazelFlagsByCategorySelect = BazelFlagsByCategorySelect;
 
 /**
  * Tabbed page at /bazel/flags/list. Today the only tab is "List"; the
@@ -208,6 +261,24 @@ class BazelFlagsListSelectNav extends SelectNav {
 			() => new BazelFlagsListComponent(this.registry_, this.dom_),
 		);
 
+		this.addNavTabLazy(
+			TabName.CATEGORIES,
+			"Categories",
+			"Help-text categories the flags belong to",
+			undefined,
+			`${this.getPathUrl()}/${TabName.CATEGORIES}`,
+			() => new BazelFlagsCategoriesComponent(this.registry_, this.dom_),
+		);
+
+		this.addNavTabLazy(
+			TabName.TAGS,
+			"Tags",
+			"Tags attached to flags (incompatible_change, experimental, …)",
+			undefined,
+			`${this.getPathUrl()}/${TabName.TAGS}`,
+			() => new BazelFlagsTagsComponent(this.registry_, this.dom_),
+		);
+
 		getApplication(this)
 			.getRegistryWithSymbols()
 			.then(() => {
@@ -215,24 +286,44 @@ class BazelFlagsListSelectNav extends SelectNav {
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
 
-		// Inject the flag count into the "Flags" nav tab once the DB loads.
-		// addNavTabLazy was called with count=undefined so the Counter badge
-		// isn't pre-rendered; we append it here.
+		// Inject counts into the three nav tabs once the DB loads.
+		// addNavTabLazy was called with count=undefined so the Counter badges
+		// aren't pre-rendered; we append them here.
 		getApplication(this)
 			.getBazelFlagDb()
 			.then((db) => {
 				if (this.isDisposed()) return;
 				const typed = /** @type {!BazelFlagDb} */ (db);
-				const count = typed.getFlagList().length;
+				const flagCount = typed.getFlagList().length;
+				/** @type {!Set<string>} */
+				const categorySet = new Set();
+				/** @type {!Set<string>} */
+				const tagSet = new Set();
+				for (const flag of typed.getFlagList()) {
+					const c = flag.getCategory();
+					if (c) categorySet.add(c);
+					for (const t of flag.getTagList()) {
+						if (t) tagSet.add(t);
+					}
+				}
 				const root = this.getElement();
 				if (!root) return;
-				const navItem = root.querySelector(`[data-name="${TabName.LIST}"]`);
-				if (navItem && !navItem.querySelector(".Counter")) {
-					navItem.appendChild(
-						soy.renderAsElement(counterLabel, { count: count }),
-					);
-				}
-				refreshBcrSidePaneBazelFlags(document.body, count);
+				/**
+				 * @param {string} name
+				 * @param {number} count
+				 */
+				const setBadge = (name, count) => {
+					const tab = root.querySelector(`[data-name="${name}"]`);
+					if (tab && !tab.querySelector(".Counter")) {
+						tab.appendChild(
+							soy.renderAsElement(counterLabel, { count: count }),
+						);
+					}
+				};
+				setBadge(TabName.LIST, flagCount);
+				setBadge(TabName.CATEGORIES, categorySet.size);
+				setBadge(TabName.TAGS, tagSet.size);
+				refreshBcrSidePaneBazelFlags(document.body, flagCount);
 			});
 	}
 }
@@ -347,6 +438,151 @@ class BazelFlagsListComponent extends Component {
 			bazelFlagsResultsList,
 			{ items: items },
 		);
+	}
+}
+
+/**
+ * Categories tab at /bazel/flags/list/categories — renders a table of every
+ * distinct category in the DB with the flag count for each. Each row links
+ * to /bazel/flags/category/<encoded-category>.
+ */
+class BazelFlagsCategoriesComponent extends Component {
+	/**
+	 * @param {!Registry} registry
+	 * @param {?dom.DomHelper=} opt_domHelper
+	 */
+	constructor(registry, opt_domHelper) {
+		super(opt_domHelper);
+
+		/** @private @const @type {!Registry} */
+		this.registry_ = registry;
+	}
+
+	/**
+	 * @override
+	 */
+	createDom() {
+		const placeholder = dom.createDom("div", { class: "p-3 color-fg-muted" });
+		placeholder.textContent = "Loading flag database…";
+		this.setElementInternal(placeholder);
+	}
+
+	/**
+	 * @override
+	 */
+	enterDocument() {
+		super.enterDocument();
+		getApplication(this)
+			.getBazelFlagDb()
+			.then((db) => {
+				if (this.isDisposed()) return;
+				const typed = /** @type {!BazelFlagDb} */ (db);
+				/** @type {!Map<string, number>} */
+				const counts = new Map();
+				for (const flag of typed.getFlagList()) {
+					const cat = flag.getCategory();
+					if (!cat) continue;
+					counts.set(cat, (counts.get(cat) || 0) + 1);
+				}
+				/** @type {!Array<!{name: string, count: number}>} */
+				const categories = [];
+				counts.forEach((count, name) => {
+					categories.push({ name: name, count: count });
+				});
+				categories.sort((a, b) => {
+					const la = a.name.toLowerCase();
+					const lb = b.name.toLowerCase();
+					return la < lb ? -1 : la > lb ? 1 : 0;
+				});
+
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const rendered = soy.renderAsElement(bazelFlagsCategoriesTable, {
+					categories: categories,
+				});
+				root.appendChild(rendered);
+			})
+			.catch((err) => {
+				if (this.isDisposed()) return;
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const flash = dom.createDom("div", { class: "flash flash-error" });
+				flash.textContent = `Failed to load flag database: ${err}`;
+				root.appendChild(flash);
+			});
+	}
+}
+
+/**
+ * Tags tab at /bazel/flags/list/tags — renders a table of every distinct
+ * tag in the DB with the flag count for each. Each row links to
+ * /bazel/flags/tag/<tag>.
+ */
+class BazelFlagsTagsComponent extends Component {
+	/**
+	 * @param {!Registry} registry
+	 * @param {?dom.DomHelper=} opt_domHelper
+	 */
+	constructor(registry, opt_domHelper) {
+		super(opt_domHelper);
+
+		/** @private @const @type {!Registry} */
+		this.registry_ = registry;
+	}
+
+	/**
+	 * @override
+	 */
+	createDom() {
+		const placeholder = dom.createDom("div", { class: "p-3 color-fg-muted" });
+		placeholder.textContent = "Loading flag database…";
+		this.setElementInternal(placeholder);
+	}
+
+	/**
+	 * @override
+	 */
+	enterDocument() {
+		super.enterDocument();
+		getApplication(this)
+			.getBazelFlagDb()
+			.then((db) => {
+				if (this.isDisposed()) return;
+				const typed = /** @type {!BazelFlagDb} */ (db);
+				/** @type {!Map<string, number>} */
+				const counts = new Map();
+				for (const flag of typed.getFlagList()) {
+					for (const t of flag.getTagList()) {
+						if (!t) continue;
+						counts.set(t, (counts.get(t) || 0) + 1);
+					}
+				}
+				/** @type {!Array<!{name: string, count: number}>} */
+				const tags = [];
+				counts.forEach((count, name) => {
+					tags.push({ name: name, count: count });
+				});
+				tags.sort((a, b) => {
+					const la = a.name.toLowerCase();
+					const lb = b.name.toLowerCase();
+					return la < lb ? -1 : la > lb ? 1 : 0;
+				});
+
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const rendered = soy.renderAsElement(bazelFlagsTagsTable, {
+					tags: tags,
+				});
+				root.appendChild(rendered);
+			})
+			.catch((err) => {
+				if (this.isDisposed()) return;
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const flash = dom.createDom("div", { class: "flash flash-error" });
+				flash.textContent = `Failed to load flag database: ${err}`;
+				root.appendChild(flash);
+			});
 	}
 }
 
@@ -531,6 +767,105 @@ class BazelFlagsByCommandComponent extends Component {
 	}
 }
 exports.BazelFlagsByCommandComponent = BazelFlagsByCommandComponent;
+
+/**
+ * Group page at /bazel/flags/category/<encoded-category>: lists every flag
+ * whose canonical category title matches. The path segment is URL-encoded
+ * because help category titles are full-sentence descriptions with spaces
+ * and punctuation; we decodeURIComponent before comparing.
+ */
+class BazelFlagsByCategoryComponent extends Component {
+	/**
+	 * @param {!Registry} registry
+	 * @param {string} encodedCategory The URL-encoded category from the path.
+	 * @param {?dom.DomHelper=} opt_domHelper
+	 */
+	constructor(registry, encodedCategory, opt_domHelper) {
+		super(opt_domHelper);
+
+		/** @private @const @type {!Registry} */
+		this.registry_ = registry;
+
+		/** @private @const @type {string} */
+		this.categoryName_ = decodeSafe(encodedCategory);
+	}
+
+	/**
+	 * @override
+	 */
+	createDom() {
+		const placeholder = dom.createDom("div", { class: "p-3 color-fg-muted" });
+		placeholder.textContent = "Loading flag database…";
+		this.setElementInternal(placeholder);
+	}
+
+	/**
+	 * @override
+	 */
+	enterDocument() {
+		super.enterDocument();
+		getApplication(this)
+			.getBazelFlagDb()
+			.then((db) => {
+				if (this.isDisposed()) return;
+				const typed = /** @type {!BazelFlagDb} */ (db);
+				const flags = typed
+					.getFlagList()
+					.filter(
+						(/** @type {!BazelFlag} */ f) =>
+							f.getCategory() === this.categoryName_,
+					);
+				const items = buildFlagItems(flags, typed);
+
+				const modules = createModuleMap(this.registry_);
+				const maintainers = createMaintainersMap(this.registry_);
+				let totalModuleVersions = 0;
+				for (const module of modules.values()) {
+					totalModuleVersions += module.getVersionsList().length;
+				}
+
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const rendered = soy.renderAsElement(bazelFlagGroup, {
+					title: `Flags in category "${this.categoryName_}"`,
+					emptyMessage: `No flags found in category "${this.categoryName_}".`,
+					items: items,
+					registry: this.registry_,
+					totalModules: modules.size,
+					totalModuleVersions: totalModuleVersions,
+					totalMaintainers: maintainers.size,
+					totalSymbols: computeTotalSymbols(this.registry_),
+					totalBazelVersions: computeTotalBazelVersions(this.registry_),
+					uiCommitSha: uiCommitSha,
+				});
+				root.appendChild(rendered);
+				refreshBcrSidePaneBazelFlags(document.body, typed.getFlagList().length);
+			})
+			.catch((err) => {
+				if (this.isDisposed()) return;
+				const root = this.getElementStrict();
+				root.innerHTML = "";
+				const flash = dom.createDom("div", { class: "flash flash-error" });
+				flash.textContent = `Failed to load flag database: ${err}`;
+				root.appendChild(flash);
+			});
+	}
+}
+
+/**
+ * decodeURIComponent that returns the input unchanged if decoding throws
+ * (malformed %xx sequence). Belt-and-suspenders for hand-typed URLs.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function decodeSafe(s) {
+	try {
+		return decodeURIComponent(s);
+	} catch (e) {
+		return s;
+	}
+}
 
 /**
  * Builds the [flag, description, current] row data shared between the all-

--- a/app/bcr/style.css
+++ b/app/bcr/style.css
@@ -283,25 +283,6 @@ pre code {
 }
 
 /* ========================================
- * Line Numbers for <code> blocks
- * ======================================== */
-
-code {
-	counter-reset: step;
-	counter-increment: step 0;
-}
-
-code .line::before {
-	content: counter(step);
-	counter-increment: step;
-	width: 1rem;
-	margin-right: 1.5rem;
-	display: inline-block;
-	text-align: right;
-	color: rgba(115, 138, 148, 0.4);
-}
-
-/* ========================================
  * Recently Updated Timeline
  * ======================================== */
 

--- a/app/bcr/syntax.js
+++ b/app/bcr/syntax.js
@@ -29,7 +29,6 @@ function getEffectiveColorMode(ownerDocument) {
 async function highlight(preEl) {
 	const codeEl = preEl.firstElementChild || preEl;
 	const lang = codeEl.getAttribute("lang") || "py";
-	const lineNumbers = codeEl.hasAttribute("linenumbers") || true; // TODO(pcj): why is this not working?  (seems to always be beneficial tho)
 	const text = codeEl.textContent;
 	const theme =
 		"github-" +
@@ -37,7 +36,6 @@ async function highlight(preEl) {
 	const html = await dom.getWindow()["codeToHtml"](text, {
 		lang: lang,
 		theme: theme,
-		lineNumbers: lineNumbers,
 	});
 	preEl.outerHTML = html;
 	dom.dataset.set(preEl, "highlighted", lang);

--- a/cmd/bazelflagdbcompiler/bazelflagdbcompiler.go
+++ b/cmd/bazelflagdbcompiler/bazelflagdbcompiler.go
@@ -150,7 +150,11 @@ func buildFlagDb(registry *bhpb.BazelHelpRegistry) *bhpb.BazelFlagDb {
 					}
 					// versions iterated ascending; last wins for canonical metadata.
 					st.canonical = opt
-					st.category = cat.Title
+					// Bazel's help output prints category titles as headings
+					// like "Options that control build execution:" — useful as
+					// a section break in raw output, awkward as a subtitle in
+					// the UI. Strip the trailing colon (and any whitespace).
+					st.category = strings.TrimRight(strings.TrimSpace(cat.Title), ":")
 				}
 			}
 		}

--- a/cmd/sitemapcompiler/BUILD.bazel
+++ b/cmd/sitemapcompiler/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bazel-contrib/bcr-frontend/cmd/sitemapcompiler",
     visibility = ["//visibility:private"],
     deps = [
+        "//build/stack/bazel/help/v1:help",
         "//build/stack/bazel/registry/v1:registry",
         "//pkg/protoutil",
     ],

--- a/cmd/sitemapcompiler/sitemapcompiler.go
+++ b/cmd/sitemapcompiler/sitemapcompiler.go
@@ -5,10 +5,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path"
 	"time"
 
+	bhpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/help/v1"
 	bzpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/registry/v1"
 	"github.com/bazel-contrib/bcr-frontend/pkg/protoutil"
 )
@@ -29,9 +31,10 @@ type URL struct {
 }
 
 type Config struct {
-	RegistryFile string
-	OutputFile   string
-	BaseURL      string
+	RegistryFile    string
+	BazelFlagDbFile string
+	OutputFile      string
+	BaseURL         string
 }
 
 func main() {
@@ -65,7 +68,17 @@ func run(args []string) error {
 		return fmt.Errorf("failed to read registry file: %w", err)
 	}
 
-	sitemap, err := generateSitemap(registry, cfg.BaseURL)
+	// The flag DB is optional — dummy/test builds compile a sitemap with
+	// no flag entries.
+	var flagDb *bhpb.BazelFlagDb
+	if cfg.BazelFlagDbFile != "" {
+		flagDb = &bhpb.BazelFlagDb{}
+		if err := protoutil.ReadFile(cfg.BazelFlagDbFile, flagDb); err != nil {
+			return fmt.Errorf("failed to read bazel flag db file: %w", err)
+		}
+	}
+
+	sitemap, err := generateSitemap(registry, flagDb, cfg.BaseURL)
 	if err != nil {
 		return fmt.Errorf("failed to generate sitemap: %w", err)
 	}
@@ -81,6 +94,7 @@ func run(args []string) error {
 func parseFlags(args []string) (cfg Config, err error) {
 	fs := flag.NewFlagSet("sitemapcompiler", flag.ExitOnError)
 	fs.StringVar(&cfg.RegistryFile, "registry_file", "", "path to the registry protobuf file")
+	fs.StringVar(&cfg.BazelFlagDbFile, "bazel_flag_db_file", "", "optional path to the bazel flag database protobuf (enables /bazel/flags URLs)")
 	fs.StringVar(&cfg.OutputFile, "output_file", "", "path to the output sitemap.xml file")
 	fs.StringVar(&cfg.BaseURL, "base_url", "", "base URL for the sitemap (e.g., https://example.com)")
 	fs.Usage = func() {
@@ -94,7 +108,7 @@ func parseFlags(args []string) (cfg Config, err error) {
 	return
 }
 
-func generateSitemap(registry *bzpb.Registry, baseURL string) (*URLSet, error) {
+func generateSitemap(registry *bzpb.Registry, flagDb *bhpb.BazelFlagDb, baseURL string) (*URLSet, error) {
 	sitemap := &URLSet{
 		Xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9",
 		URLs:  make([]URL, 0),
@@ -113,6 +127,90 @@ func generateSitemap(registry *bzpb.Registry, baseURL string) (*URLSet, error) {
 		ChangeFreq: "daily",
 		Priority:   0.9,
 	})
+
+	// Add Bazel core index pages.
+	for _, p := range []string{"/bazel", "/bazel/versions", "/bazel/flags", "/bazel/flags/list"} {
+		sitemap.URLs = append(sitemap.URLs, URL{
+			Loc:        baseURL + p,
+			ChangeFreq: "weekly",
+			Priority:   0.9,
+		})
+	}
+
+	// Add per-version Bazel pages from the bazel_tools pseudo-module.
+	for _, module := range registry.Modules {
+		if module.Name != "bazel_tools" {
+			continue
+		}
+		for _, version := range module.Versions {
+			if version.Version == "" {
+				continue
+			}
+			u := URL{
+				Loc:        fmt.Sprintf("%s/bazel/%s", baseURL, version.Version),
+				ChangeFreq: "monthly",
+				Priority:   0.7,
+			}
+			if version.Commit != nil && version.Commit.Date != "" {
+				if t, err := time.Parse(time.RFC3339, version.Commit.Date); err == nil {
+					u.LastMod = t.Format("2006-01-02")
+				}
+			}
+			sitemap.URLs = append(sitemap.URLs, u)
+		}
+		break
+	}
+
+	// Add per-flag, per-tag, per-category, and per-command pages from the
+	// flag DB.
+	if flagDb != nil {
+		seenTags := make(map[string]struct{})
+		seenCats := make(map[string]struct{})
+		for _, f := range flagDb.Flag {
+			if f.Name == "" {
+				continue
+			}
+			sitemap.URLs = append(sitemap.URLs, URL{
+				Loc:        fmt.Sprintf("%s/bazel/flags/%s", baseURL, f.Name),
+				ChangeFreq: "monthly",
+				Priority:   0.6,
+			})
+			for _, tag := range f.Tag {
+				if tag == "" {
+					continue
+				}
+				if _, ok := seenTags[tag]; ok {
+					continue
+				}
+				seenTags[tag] = struct{}{}
+				sitemap.URLs = append(sitemap.URLs, URL{
+					Loc:        fmt.Sprintf("%s/bazel/flags/tag/%s", baseURL, tag),
+					ChangeFreq: "monthly",
+					Priority:   0.5,
+				})
+			}
+			if f.Category != "" {
+				if _, ok := seenCats[f.Category]; !ok {
+					seenCats[f.Category] = struct{}{}
+					sitemap.URLs = append(sitemap.URLs, URL{
+						Loc:        fmt.Sprintf("%s/bazel/flags/category/%s", baseURL, url.PathEscape(f.Category)),
+						ChangeFreq: "monthly",
+						Priority:   0.5,
+					})
+				}
+			}
+		}
+		for _, cmd := range flagDb.Commands {
+			if cmd == "" {
+				continue
+			}
+			sitemap.URLs = append(sitemap.URLs, URL{
+				Loc:        fmt.Sprintf("%s/bazel/command/%s", baseURL, cmd),
+				ChangeFreq: "monthly",
+				Priority:   0.5,
+			})
+		}
+	}
 
 	// Iterate through all modules
 	for _, module := range registry.Modules {

--- a/rules/module_registry.bzl
+++ b/rules/module_registry.bzl
@@ -379,7 +379,7 @@ def _compile_colors_action(ctx, colors_json, languages_json):
 
     return output
 
-def _compile_sitemap_action(ctx, registry_pb):
+def _compile_sitemap_action(ctx, registry_pb, bazel_flag_db_pb):
     output = ctx.actions.declare_file("sitemap.xml")
 
     # Build arguments for the compiler
@@ -390,11 +390,13 @@ def _compile_sitemap_action(ctx, registry_pb):
     args.add(registry_pb)
     args.add("--base_url")
     args.add(ctx.attr.registry_url)
+    args.add("--bazel_flag_db_file")
+    args.add(bazel_flag_db_pb)
 
     ctx.actions.run(
         executable = ctx.executable._sitemapcompiler,
         arguments = [args],
-        inputs = [registry_pb],
+        inputs = [registry_pb, bazel_flag_db_pb],
         outputs = [output],
         mnemonic = "CompileSitemap",
         progress_message = "Compiling sitemap",
@@ -471,10 +473,10 @@ def _module_registry_impl(ctx):
     registry_pb = _compile_registry_action(ctx, "registry.pb", modules, symbols_pb)
     registrylite_pb = _compile_registry_action(ctx, "registrylite.pb", modules)
 
-    sitemap_xml = _compile_sitemap_action(ctx, registry_pb)
-    prerender_urls = _write_prerender_urls_action(ctx, deps)
     bazel_help = _compile_bazel_help_registry_action(ctx, bazel_versions)
     bazel_flag_db = _compile_bazel_flag_db_action(ctx, bazel_help)
+    sitemap_xml = _compile_sitemap_action(ctx, registry_pb, bazel_flag_db)
+    prerender_urls = _write_prerender_urls_action(ctx, deps)
 
     return [
         DefaultInfo(files = depset([registry_pb])),


### PR DESCRIPTION
UI:
- Flag detail page restructured: bcrSidePane on the left (consistent with other pages), content/Available-in/Applies-to/Tags stacked in the right pane. Toggle flags now show a secondary `--no<name>` heading with its own copy button. Type and default render in monospace inside their Label chips. Category surfaced as a clickable Label section that links to a new group page.
- New tabs in /bazel/flags: Categories and Tags. Each renders a sortable Box table of distinct values with per-row flag counts; rows link to the matching /bazel/flags/category/<name> or /bazel/flags/tag/<name> group page. Counter badges populate after the lazy DB load.
- New /bazel/flags/category/<encoded> route + BazelFlagsByCategorySelect / BazelFlagsByCategoryComponent. Path segment is URL-encoded because category titles are full sentences; decoded safely on the way back.
- Bot avatar pattern narrowed to GitHub Apps (`*[bot]`) and the explicit `publish-to-bcr-bot` username; real users whose handle ends in `-bot` no longer get the bot icon.
- Flag detail "Links" section gains a Slack search link.
- next/prev keyboard shortcuts now cycle alphabetically through flag names on /bazel/flags/<flag-name>.
- Code-block line numbering removed (CSS counter rules + shiki option).

Backend:
- bazelflagdbcompiler strips trailing colons + whitespace from category titles so the UI never sees "Options that govern…:".
- sitemapcompiler reads the flag DB and emits per-flag, per-tag, per-category, and per-command URLs, plus /bazel index pages and a /bazel/<v> entry per bazel_tools version. module_registry.bzl reorders so the flag DB feeds into the sitemap action.