### PR TITLE
fix: use path-based hrefs for internal links so they open in a new tab

### DIFF
--- a/app/bcr/app.js
+++ b/app/bcr/app.js
@@ -409,7 +409,7 @@ class RegistryApp extends App {
 	 * Handle element click event and search for an el with a 'data-route'
 	 * or data-clippy element.  If found, send it.
 	 *
-	 * @param {!events.Event} e
+	 * @param {!events.BrowserEvent} e
 	 */
 	handleElementClick(e) {
 		const target = /** @type {?Node} */ (e.target);
@@ -448,10 +448,63 @@ class RegistryApp extends App {
 					this.gotoSibling(-1);
 					return true;
 				}
+				if (node instanceof HTMLAnchorElement) {
+					return this.maybeNavigateAnchor_(node, e);
+				}
 				return false;
 			},
 			true,
 		);
+	}
+
+	/**
+	 * Intercept a left-click on a same-origin <a href="/..."> and route via the
+	 * SPA router instead of letting the browser do a full page load. Keeping
+	 * the real href means right-click → "Open in new tab" still works: the
+	 * server's SPA fallback serves index.html for the new tab.
+	 *
+	 * @param {!HTMLAnchorElement} anchor
+	 * @param {!events.BrowserEvent} e
+	 * @return {boolean} true if the click was intercepted.
+	 * @private
+	 */
+	maybeNavigateAnchor_(anchor, e) {
+		if (e.defaultPrevented) return false;
+		if (e.button !== 0) return false;
+		if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return false;
+		const tgt = anchor.target;
+		if (tgt && tgt !== "_self") return false;
+		if (anchor.hasAttribute("download")) return false;
+		const rawHref = anchor.getAttribute("href");
+		if (!rawHref) return false;
+		if (
+			rawHref.startsWith("javascript:") ||
+			rawHref.startsWith("mailto:") ||
+			rawHref.startsWith("tel:")
+		) {
+			return false;
+		}
+		const url = new URL(anchor.href, window.location.href);
+		if (url.origin !== window.location.origin) return false;
+		// In-page hash navigation (e.g. <a href="#section">) — let the browser
+		// scroll without re-running the router.
+		if (
+			url.pathname === window.location.pathname &&
+			url.search === window.location.search &&
+			url.hash
+		) {
+			return false;
+		}
+		// Legacy `/#/foo` bookmarks: pull the path out of the hash.
+		let path = url.pathname;
+		if (path === "/" && url.hash.startsWith("#/")) {
+			path = url.hash.substring(1);
+		}
+		const segments = path.split("/").filter(Boolean);
+		if (segments.length === 0) return false;
+		e.preventDefault();
+		this.setLocation(segments);
+		return true;
 	}
 
 	/**

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -165,7 +165,7 @@ import {
 {template header}
 <div class="Header" style="background-color: unset">
   <div class="Header-item" style="max-width: 54px">
-    <a href="/#/home">{logo()}</a>
+    <a href="/home">{logo()}</a>
   </div>
   <div class="Header-item Header-item--full">
     <form class="FormControl col-12 width-full" style="margin-block-end: 0">
@@ -281,7 +281,7 @@ import {
           {let $pkg: $label?.getPkg() ?? '' /}
           {let $name: $label?.getName() ?? '' /}
           {let $filePath: $pkg ? $pkg + '/' + $name : $name /}
-          <a href="/#/modules/{$result.module.getName()}/{$result.version.getVersion()}/docs/{$filePath}/{$result.sym.getName()}"
+          <a href="/modules/{$result.module.getName()}/{$result.version.getVersion()}/docs/{$filePath}/{$result.sym.getName()}"
              class="Box-row d-flex flex-items-center"
              style="text-decoration: none;">
             {symbolTypeLabel(type: $result.sym.getType())}
@@ -325,32 +325,32 @@ import {
     The central registry of Bazel modules for the Bzlmod external dependency system.  
   </p>
 
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/modules">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/modules">
     <span class="color-fg-muted">Modules</span>
     <span class="dotted-leader"></span>
     <span class="text-bold">{$totalModules}</span>
   </a>
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/modules">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/modules">
     <span class="color-fg-muted">Module Versions</span>
     <span class="dotted-leader"></span>
     <span class="text-bold">{$totalModuleVersions}</span>
   </a>
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/maintainers">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/maintainers">
     <span class="color-fg-muted">Maintainers</span>
     <span class="dotted-leader"></span>
     <span class="text-bold">{$totalMaintainers}</span>
   </a>
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/docs">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/docs">
     <span class="color-fg-muted">Documented Symbols</span>
     <span class="dotted-leader"></span>
     <span class="text-bold js-symbols-count">{$totalSymbols}</span>
   </a>
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/bazel/versions">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/bazel/versions">
     <span class="color-fg-muted">Bazel Versions</span>
     <span class="dotted-leader"></span>
     <span class="text-bold">{$totalBazelVersions}</span>
   </a>
-  <a class="Link--primary d-flex flex-items-center mb-2" href="/#/bazel/flags">
+  <a class="Link--primary d-flex flex-items-center mb-2" href="/bazel/flags">
     <span class="color-fg-muted">Bazel Flags</span>
     <span class="dotted-leader"></span>
     <span class="text-bold js-bazel-flags-count">914</span>
@@ -679,7 +679,7 @@ import {
 
     <div class="PageLayout-content px-3">
       <div class="mb-2">
-        <a class="Link--muted f6" href="/#/bazel/versions">
+        <a class="Link--muted f6" href="/bazel/versions">
           {octiconChevronLeft16()}{sp}Back to all versions
         </a>
       </div>
@@ -745,7 +745,7 @@ import {
           <span>Bazel {$moduleVersion.getVersion()} release on GitHub</span>
         </a>
         <a class="Link--muted d-flex flex-items-center mb-2"
-           href="/#/modules/bazel_tools/{$moduleVersion.getVersion()}">
+           href="/modules/bazel_tools/{$moduleVersion.getVersion()}">
           <span class="mr-2">{octiconBook16()}</span>
           <span>Module record (bazel_tools@{$moduleVersion.getVersion()})</span>
         </a>
@@ -826,7 +826,7 @@ import {
   {if length($categories) > 0}
     <div class="Box Box--condensed">
       {for $cat in $categories}
-        <a href="/#/bazel/flags/category/{$cat.name |escapeUri}"
+        <a href="/bazel/flags/category/{$cat.name |escapeUri}"
            class="Box-row d-flex flex-items-center"
            style="text-decoration: none;">
           <span class="text-bold">{$cat.name}</span>
@@ -851,7 +851,7 @@ import {
   {if length($tags) > 0}
     <div class="Box Box--condensed">
       {for $tag in $tags}
-        <a href="/#/bazel/flags/tag/{$tag.name |escapeUri}"
+        <a href="/bazel/flags/tag/{$tag.name |escapeUri}"
            class="Box-row d-flex flex-items-center"
            style="text-decoration: none;">
           <span class="text-bold">{$tag.name}</span>
@@ -876,7 +876,7 @@ import {
   {if length($items) > 0}
     <div class="Box Box--condensed">
       {for $item in $items}
-        <a href="/#/bazel/flags/{$item.flag.getName()}"
+        <a href="/bazel/flags/{$item.flag.getName()}"
            class="Box-row d-flex flex-items-center{if !$item.current} color-fg-muted{/if}"
            {if !$item.current}style="text-decoration: none; opacity: 0.55;" title="Removed in the latest supported Bazel version"
            {else}style="text-decoration: none;"
@@ -937,7 +937,7 @@ import {
 
     <div class="PageLayout-content px-3">
       <div class="mb-2">
-        <a class="Link--muted f6" href="/#/bazel/flags/list">
+        <a class="Link--muted f6" href="/bazel/flags/list">
           {octiconChevronLeft16()}{sp}Back to all flags
         </a>
       </div>
@@ -986,7 +986,7 @@ import {
 
   <div class="PageLayout-content px-3">
     <div class="mb-2">
-      <a class="Link--muted f6" href="/#/bazel/flags/list">
+      <a class="Link--muted f6" href="/bazel/flags/list">
         {octiconChevronLeft16()}{sp}Back to all flags
       </a>
     </div>
@@ -1048,7 +1048,7 @@ import {
         {sectionHeader(title: 'Category')}
         <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
           <a class="Label Label--secondary"
-             href="/#/bazel/flags/category/{$flag.getCategory() |escapeUri}"
+             href="/bazel/flags/category/{$flag.getCategory() |escapeUri}"
              style="text-decoration: none;">
             {$flag.getCategory()}
           </a>
@@ -1063,7 +1063,7 @@ import {
         {sectionHeader(title: 'Tags')}
         <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
           {for $tag in $flag.getTagList()}
-            <a class="Label Label--secondary" href="/#/bazel/flags/tag/{$tag}" style="text-decoration: none;">
+            <a class="Label Label--secondary" href="/bazel/flags/tag/{$tag}" style="text-decoration: none;">
               {$tag}
             </a>
           {/for}
@@ -1079,7 +1079,7 @@ import {
         <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
           {for $cmd in $commands}
             <a class="Label {if $cmd.active}Label--accent{else}Label--secondary color-fg-subtle{/if}"
-               href="/#/bazel/command/{$cmd.name}"
+               href="/bazel/command/{$cmd.name}"
                style="text-decoration: none;{if !$cmd.active} opacity: 0.4;{/if}">
               {$cmd.name}
             </a>
@@ -1098,7 +1098,7 @@ import {
         <div class="mt-2 d-flex flex-wrap" style="gap: 6px">
           {for $v in $versions}
             {if $v.active}
-              <a class="Label Label--success" href="/#/bazel/{$v.name}" style="text-decoration: none;">
+              <a class="Label Label--success" href="/bazel/{$v.name}" style="text-decoration: none;">
                 {$v.name}
               </a>
             {else}
@@ -1234,7 +1234,7 @@ import {
     <div class="PageLayout-pane" style="border-right: none">
       <nav class="SideNav ml-3" style="background-color: transparent; border: none">
         {for $language in $languages}
-          <a href="/#/{$pathUrl}/{$language.sanitizedName}" class="SideNav-item d-flex flex-items-center p-1 rounded" style="border: none; box-shadow: none">
+          <a href="/{$pathUrl}/{$language.sanitizedName}" class="SideNav-item d-flex flex-items-center p-1 rounded" style="border: none; box-shadow: none">
             <div class="mr-2" style="width: 6px; min-height: 20px; align-self: stretch; background-color: var(--lang-{$language.sanitizedName}-bg)"></div>
             {$language.name}
           </a>
@@ -2895,7 +2895,7 @@ import {
     <div class="blankslate-heading">
       Module Not Found
     </div>
-    <p><code>{$moduleName}</code> is not in the set of known <a href="/#/modules">modules</a>.</p>
+    <p><code>{$moduleName}</code> is not in the set of known <a href="/modules">modules</a>.</p>
   </div>
 </div>
 {/template}
@@ -2909,7 +2909,7 @@ import {
     <div class="blankslate-heading">
       Module Version Not Found
     </div>
-    <p>Module <a href="/#/modules/{$module.getName()}">{$module.getName()}</a> has no known version <code>{$version}</code></p>
+    <p>Module <a href="/modules/{$module.getName()}">{$module.getName()}</a> has no known version <code>{$version}</code></p>
   </div>
 </div>
 {/template}

--- a/app/bcr/bazel.js
+++ b/app/bcr/bazel.js
@@ -362,7 +362,7 @@ function computeBazelVersions(registry) {
 			moduleVersion: v,
 			commitDate: formatRelativeShort(v.getCommit().getDate()),
 			isNew: false,
-			linkUrl: `/#/bazel/${v.getVersion()}`,
+			linkUrl: `/bazel/${v.getVersion()}`,
 			pullRequestUrl: pr
 				? `https://github.com/bazelbuild/bazel/pull/${pr}`
 				: "",

--- a/app/bcr/documentation.js
+++ b/app/bcr/documentation.js
@@ -206,7 +206,7 @@ const TabName = {
 };
 
 /**
- * Build the `/#/targets/...` URL that lists every BCR target using a given
+ * Build the `/targets/...` URL that lists every BCR target using a given
  * callable symbol. Returns "" when the symbol has no file label.
  *
  * @param {!File} file
@@ -216,7 +216,7 @@ const TabName = {
 function makeUsagesUrl(file, sym) {
 	const label = file.getLabel();
 	if (!label) return "";
-	return "/#/targets/" + loadLabelToUrlKey(label, sym.getName());
+	return "/targets/" + loadLabelToUrlKey(label, sym.getName());
 }
 
 class DocsSelect extends ContentSelect {

--- a/app/bcr/home.js
+++ b/app/bcr/home.js
@@ -247,7 +247,7 @@ function computeRecentlyUpdated(registry) {
 			moduleVersion: item.v,
 			commitDate: formatRelativeShort(item.v.getCommit().getDate()),
 			isNew: item.m.getVersionsList().length === 1,
-			linkUrl: `/#/modules/${item.v.getName()}/${item.v.getVersion()}`,
+			linkUrl: `/modules/${item.v.getName()}/${item.v.getVersion()}`,
 			pullRequestUrl: pr
 				? `https://github.com/bazelbuild/bazel-central-registry/pull/${pr}`
 				: "",
@@ -288,7 +288,7 @@ function computeRecentlyAdded(registry) {
 			moduleVersion: item.v,
 			commitDate: formatRelativeShort(item.v.getCommit().getDate()),
 			isNew: true,
-			linkUrl: `/#/modules/${item.v.getName()}/${item.v.getVersion()}`,
+			linkUrl: `/modules/${item.v.getName()}/${item.v.getVersion()}`,
 			pullRequestUrl: pr
 				? `https://github.com/bazelbuild/bazel-central-registry/pull/${pr}`
 				: "",

--- a/app/bcr/maintainers.js
+++ b/app/bcr/maintainers.js
@@ -301,7 +301,7 @@ function computeMaintainerActivity(registry, maintainer) {
 			moduleVersion: item.v,
 			commitDate: formatRelativeShort(item.v.getCommit().getDate()),
 			isNew: item.m.getVersionsList().length === 1,
-			linkUrl: `/#/modules/${item.v.getName()}/${item.v.getVersion()}`,
+			linkUrl: `/modules/${item.v.getName()}/${item.v.getVersion()}`,
 			pullRequestUrl: pr
 				? `https://github.com/bazelbuild/bazel-central-registry/pull/${pr}`
 				: "",

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -1257,7 +1257,7 @@ class ModuleVersionDependentsComponent extends ContentComponent {
 			const moduleLink = dom.createDom(
 				"a",
 				{
-					"href": `/#/modules/${moduleName}/${latestVersion}`,
+					"href": `/modules/${moduleName}/${latestVersion}`,
 					"class": "Box-row-link no-wrap",
 				},
 				[versionText, moduleNameText],

--- a/app/bcr/packages.soy
+++ b/app/bcr/packages.soy
@@ -253,7 +253,7 @@ ROOT
       <span style="flex-shrink: 0;">{octiconDotFill16(fill: $styleBg)}</span>
       {if $urlKey}
         <a class="ml-1 text-bold flex-shrink-0 Link--primary"
-            href="/#/targets/{$urlKey}"
+            href="/targets/{$urlKey}"
             title="See registry-wide usages of {$ruleKind}">
           {$ruleKind}
         </a>

--- a/app/bcr/selectnav.js
+++ b/app/bcr/selectnav.js
@@ -158,7 +158,7 @@ class SelectNav extends ContentSelect {
 			title,
 			count,
 		});
-		a.href = "/#/" + path;
+		a.href = "/" + path;
 		dataset.set(a, "name", name);
 		return a;
 	}

--- a/app/bcr/settings.soy
+++ b/app/bcr/settings.soy
@@ -16,7 +16,7 @@ import {
         {sectionHeader(title: 'Settings', style: 'font-size: var(--h1-size)')}
 
         <nav class="SideNav" style="background-color: transparent; border: none">
-          <a href="/#/{$pathUrl}/appearance" class="SideNav-item d-flex flex-items-center p-1 pl-2 m-1 rounded" style="border: none; box-shadow: none">
+          <a href="/{$pathUrl}/appearance" class="SideNav-item d-flex flex-items-center p-1 pl-2 m-1 rounded" style="border: none; box-shadow: none">
             {octiconPaintbrush16(class: 'mr-2', fill: 'var(--color-fg-emphasis)')}
             {sp}
             Appearance

--- a/app/bcr/targets.soy
+++ b/app/bcr/targets.soy
@@ -49,7 +49,7 @@ import {
 
 /**
  * Default LIST view: condensed Box of known load-coordinate keys with their
- * usage counts. Each row links to the detail view at /#/targets/<urlKey>.
+ * usage counts. Each row links to the detail view at /targets/<urlKey>.
  */
 {template targetsListComponent}
   {@param entries: list<[urlKey: string, displayLabel: string, count: int]>}
@@ -62,7 +62,7 @@ import {
       {for $e in $entries}
         <a class="Box-row d-flex flex-items-center"
             style="text-decoration: none;"
-            href="/#/targets/{$e.urlKey}">
+            href="/targets/{$e.urlKey}">
           <span class="text-mono">{$e.displayLabel}</span>
           <span class="ml-auto color-fg-muted text-small">{$e.count}</span>
         </a>

--- a/app/bcr/uri.soy
+++ b/app/bcr/uri.soy
@@ -19,7 +19,7 @@ import {
 // ====================================================================
 
 {template rootUrl kind="uri"}
-  /#/
+  /
 {/template}
 
 {template maintainersUrl kind="uri"}
@@ -133,7 +133,7 @@ import {
   {@param? label: Label}
   {let $pkg: $label?.getPkg() /}
   {let $name: $label?.getName() /}
-  /#/{$baseUrl}/{if $pkg}{$pkg}/{/if}{$name}
+  /{$baseUrl}/{if $pkg}{$pkg}/{/if}{$name}
 {/template}
 
 {template symbolInfoUrl kind="uri"}
@@ -193,7 +193,7 @@ import {
   {let $pkg: $label.getPkg() /}
   {let $name: $label.getName() /}
   {if $repo}
-    /#/modules/{$repo}/latest/docs/{if $pkg}{$pkg}/{/if}{$name}
+    /modules/{$repo}/latest/docs/{if $pkg}{$pkg}/{/if}{$name}
   {else}
     // {# Local file - no link #}
   {/if}
@@ -204,7 +204,7 @@ import {
   {@param repo: string}
   {@param pkg: string}
   {@param name: string}
-  /#/{$pathUrl}
+  /{$pathUrl}
   {if $repo.length > 1}/external/{$repo}{else}/@{/if}
   /package/
   {if $pkg}{$pkg}{else}:{/if}

--- a/language/bcr/lifecycle.go
+++ b/language/bcr/lifecycle.go
@@ -59,7 +59,7 @@ func (ext *bcrExtension) AfterResolvingDeps(ctx context.Context) {
 	binaryProtoHttpArchives := ext.prepareBinaryprotoRepositories()
 	availableBzlRepositories := ext.prepareBzlRepositories()
 
-	// Calculate MVS sets - this updates the rankings of
+	// Calculate MVS sets
 	ext.calculateMvs(availableBzlRepositories)
 
 	if err := mergeGeneratedModuleBazelFile(ext.repoRoot, binaryProtoHttpArchives, availableBzlRepositories); err != nil {


### PR DESCRIPTION
All internal links were generated as `href="/#/path"`. Chrome's right-click "Open in new tab" took the literal href, parsed `#/path` as a fragment on `/`, and the new tab loaded the home page instead of the deep link.

Rewrite every internal href to a clean path (`href="/path"`). The existing `app.js` route resolver already reads `pathname + hash`, so legacy `/#/...` bookmarks keep working. Cloudflare, the dev server, and GitHub Pages all already serve `index.html` for unknown paths via their SPA fallbacks, so deep links resolve on a fresh tab load.

Switching to real paths means a plain anchor click would now full- reload, since `stack.ui` only intercepts hash links. Add an interceptor in `handleElementClick` that catches same-origin, plain (no-modifier, no-target, no-download) anchor clicks, calls `setLocation` to route through the SPA, and `preventDefault`s the browser navigation. Modifier clicks, external links, `mailto:`/`tel:`/`javascript:` hrefs, downloads, and in-page `#anchor` jumps all fall through to default behavior.

Fixes #490