### PR TITLE
feat: scan packages for overlay-only module versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,3 +15,11 @@ build --tool_java_runtime_version=21
 # for malformed docs URL archives that contain no content.  Consider putting
 # this under a transistion.
 common --noincompatible_disallow_empty_glob
+
+# CI prerender tuning. Local defaults assume 16GB RAM / 10 CPU; CI runners
+# typically have ~96GB / 32 CPU and can sustain a much bigger tab pool
+# without OOM or steady-state CPU contention. Pass `--config=ci` on CI
+# build invocations (e.g. in .github/workflows/*) to apply.
+build:ci --//app/bcr:prerender_pool_size=24
+build:ci --//app/bcr:prerender_tab_max_pages=50
+build:ci --//app/bcr:prerender_warmup_concurrency=8

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -127,6 +127,7 @@ jobs:
           --bazelrc=.github/workflows/ci.bazelrc
           --bazelrc=.bazelrc
           run
+          --config=ci
           --//app/bcr:release_type=production
           --//app/bcr:prerender_modules=on
           //app/bcr:ghpages

--- a/app/bcr/BUILD.bazel
+++ b/app/bcr/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "int_flag", "string_flag")
 load("@rules_tsickle//rules:defs.bzl", "closure_ts_compile")
 load(
     "@stackb_rules_closure//closure:defs.bzl",
@@ -50,6 +50,28 @@ string_flag(
         "off",
         "on",
     ],
+    visibility = ["//visibility:public"],
+)
+
+# Prerender tab-pool sizing. Defaults are tuned for the local dev box
+# (16GB RAM / 10 CPU on Apple Silicon, where pool_size>8 OOMs mid-batch).
+# CI runners with more headroom (e.g. 96GB / 32 CPU) should set higher
+# values via `--config=ci` in .bazelrc — see the build:ci block there.
+int_flag(
+    name = "prerender_pool_size",
+    build_setting_default = 8,
+    visibility = ["//visibility:public"],
+)
+
+int_flag(
+    name = "prerender_tab_max_pages",
+    build_setting_default = 27,
+    visibility = ["//visibility:public"],
+)
+
+int_flag(
+    name = "prerender_warmup_concurrency",
+    build_setting_default = 4,
     visibility = ["//visibility:public"],
 )
 

--- a/data/generated.MODULE.bazel
+++ b/data/generated.MODULE.bazel
@@ -9,6 +9,7 @@ starlark_repository = use_extension("@build_stack_rules_proto//extensions:starla
 use_repo(
     starlark_repository,
     "bzl.abc---0.62-yosyshq",
+    "bzl.abc---0.64-yosyshq.bcr.1",
     "bzl.abseil-cpp---20210324.2",
     "bzl.abseil-cpp---20211102.0",
     "bzl.abseil-cpp---20230125.1",
@@ -18,6 +19,7 @@ use_repo(
     "bzl.abseil-cpp---20240116.1",
     "bzl.abseil-cpp---20240116.2",
     "bzl.abseil-cpp---20240722.0.bcr.2",
+    "bzl.abseil-cpp---20240722.2",
     "bzl.abseil-cpp---20250127.0",
     "bzl.abseil-cpp---20250127.1",
     "bzl.abseil-cpp---20250512.0",
@@ -29,9 +31,12 @@ use_repo(
     "bzl.abseil-cpp---20260107.1",
     "bzl.abseil-py---2.1.0",
     "bzl.abseil-py---2.4.0",
+    "bzl.ada-url---3.4.4",
     "bzl.aexml---4.7.0.1",
+    "bzl.alsa_lib---1.2.9.bcr.2",
     "bzl.alsa_lib---1.2.9.bcr.4",
-    "bzl.antlr4-cpp-runtime---4.13.1",
+    "bzl.amqp-cpp---4.3.27",
+    "bzl.antlr4-cpp-runtime---4.13.0",
     "bzl.aom---3.13.3",
     "bzl.ape---1.0.0-beta.12",
     "bzl.ape---1.0.1",
@@ -41,7 +46,9 @@ use_repo(
     "bzl.apple_support---1.15.1",
     "bzl.apple_support---1.16.0",
     "bzl.apple_support---1.17.1",
+    "bzl.apple_support---1.18.0",
     "bzl.apple_support---1.21.1",
+    "bzl.apple_support---1.22.0",
     "bzl.apple_support---1.22.1",
     "bzl.apple_support---1.23.0",
     "bzl.apple_support---1.23.1",
@@ -55,10 +62,17 @@ use_repo(
     "bzl.apple_support---2.3.0",
     "bzl.apple_support---2.4.0",
     "bzl.apple_support---2.5.4",
+    "bzl.apriltag---3.4.5",
+    "bzl.ar_hosek_sky_model---1.4.a",
+    "bzl.aravis---0.9.2-20251111063445-57983d013883",
     "bzl.argparse---3.2.0",
     "bzl.asc_swift---1.6.0",
     "bzl.asio---1.28.2",
     "bzl.asio---1.32.0",
+    "bzl.asio---1.34.2",
+    "bzl.asio---1.34.2.bcr.0",
+    "bzl.asio---1.34.2.bcr.1",
+    "bzl.asio-grpc---3.1.0.bcr.1",
     "bzl.aspect_bazel_lib---1.28.0",
     "bzl.aspect_bazel_lib---1.38.1",
     "bzl.aspect_bazel_lib---1.39.0",
@@ -123,14 +137,25 @@ use_repo(
     "bzl.aspect_rules_webpack---0.17.1",
     "bzl.aspect_tools_telemetry---0.2.8",
     "bzl.aspect_tools_telemetry---0.3.3",
+    "bzl.assimp---5.4.3.bcr.3",
     "bzl.assimp---5.4.3.bcr.6",
+    "bzl.assimp---6.0.3",
+    "bzl.at-spi2-core---2.58.2",
     "bzl.avro-cpp---1.12.0",
     "bzl.awk.bzl---0.2.3",
     "bzl.aws-in-a-box---0.0.69",
     "bzl.aws-lc---1.67.0.bcr.1",
     "bzl.aws_sdk---1.11.758",
+    "bzl.azure-core-cpp---1.14.1.bcr.1",
+    "bzl.azure-core-cpp---1.14.1.bcr.2",
+    "bzl.azure-core-test-cpp---1.14.1",
+    "bzl.azure-identity-cpp---1.10.1",
+    "bzl.azure-storage-blobs-cpp---12.13.0",
+    "bzl.azure-storage-common-cpp---12.9.0",
     "bzl.babylon---1.4.4",
+    "bzl.backward-cpp---1.6",
     "bzl.bant---0.2.9",
+    "bzl.basis_universal---2.0.3",
     "bzl.bazel-diff---24.0.0",
     "bzl.bazel_bats---0.38.23",
     "bzl.bazel_cc_meta---0.2.0",
@@ -146,6 +171,7 @@ use_repo(
     "bzl.bazel_features---1.19.0",
     "bzl.bazel_features---1.20.0",
     "bzl.bazel_features---1.24.0",
+    "bzl.bazel_features---1.27.0",
     "bzl.bazel_features---1.28.0",
     "bzl.bazel_features---1.3.0",
     "bzl.bazel_features---1.30.0",
@@ -200,74 +226,134 @@ use_repo(
     "bzl.bazelpods---1.12.5",
     "bzl.bazelrc-preset.bzl---1.6.0",
     "bzl.bazelrc-preset.bzl---1.9.2",
+    "bzl.behaviortree_cpp---4.7.0.bcr.2",
+    "bzl.behaviortree_cpp---4.7.0.bcr.3",
+    "bzl.behaviortree_ros2---0.0.0-20250313-7a6ace6.bcr.1",
+    "bzl.bison---3.8.2.bcr.4",
     "bzl.bison---3.8.2.bcr.5",
     "bzl.blake3---1.5.1.bcr.1",
+    "bzl.blake3---1.8.2.bcr.1",
     "bzl.bliss---0.73",
+    "bzl.boost.algorithm---1.83.0.bcr.1",
+    "bzl.boost.algorithm---1.83.0.bcr.4",
     "bzl.boost.algorithm---1.87.0",
+    "bzl.boost.algorithm---1.88.0.bcr.2",
+    "bzl.boost.algorithm---1.89.0.bcr.1",
     "bzl.boost.algorithm---1.89.0.bcr.2",
     "bzl.boost.algorithm---1.90.0.bcr.1",
+    "bzl.boost.align---1.83.0.bcr.1",
+    "bzl.boost.align---1.83.0.bcr.4",
     "bzl.boost.align---1.87.0",
+    "bzl.boost.align---1.88.0.bcr.2",
+    "bzl.boost.align---1.89.0.bcr.1",
     "bzl.boost.align---1.89.0.bcr.2",
     "bzl.boost.align---1.90.0.bcr.1",
+    "bzl.boost.any---1.83.0.bcr.2",
+    "bzl.boost.any---1.83.0.bcr.4",
     "bzl.boost.any---1.87.0",
+    "bzl.boost.any---1.88.0.bcr.2",
     "bzl.boost.any---1.89.0.bcr.2",
     "bzl.boost.any---1.90.0.bcr.1",
+    "bzl.boost.array---1.83.0.bcr.1",
+    "bzl.boost.array---1.83.0.bcr.4",
     "bzl.boost.array---1.87.0",
-    "bzl.boost.array---1.88.0.bcr.3",
+    "bzl.boost.array---1.88.0.bcr.2",
+    "bzl.boost.array---1.89.0.bcr.1",
     "bzl.boost.array---1.89.0.bcr.2",
     "bzl.boost.array---1.90.0.bcr.1",
+    "bzl.boost.asio---1.83.0.bcr.4",
     "bzl.boost.asio---1.87.0.bcr.1",
+    "bzl.boost.asio---1.89.0.bcr.1",
     "bzl.boost.asio---1.89.0.bcr.2",
     "bzl.boost.asio---1.90.0.bcr.1",
+    "bzl.boost.assert---1.83.0.bcr.4",
     "bzl.boost.assert---1.87.0",
+    "bzl.boost.assert---1.88.0.bcr.2",
+    "bzl.boost.assert---1.89.0.bcr.1",
     "bzl.boost.assert---1.89.0.bcr.2",
     "bzl.boost.assert---1.90.0.bcr.1",
+    "bzl.boost.assign---1.87.0",
     "bzl.boost.assign---1.89.0.bcr.2",
     "bzl.boost.assign---1.90.0.bcr.1",
+    "bzl.boost.atomic---1.83.0.bcr.1",
+    "bzl.boost.atomic---1.83.0.bcr.4",
     "bzl.boost.atomic---1.87.0",
+    "bzl.boost.atomic---1.88.0.bcr.2",
     "bzl.boost.atomic---1.89.0.bcr.2",
     "bzl.boost.atomic---1.90.0.bcr.1",
+    "bzl.boost.beast---1.83.0.bcr.4",
     "bzl.boost.beast---1.89.0.bcr.2",
     "bzl.boost.beast---1.90.0.bcr.1",
+    "bzl.boost.bimap---1.83.0.bcr.1",
+    "bzl.boost.bimap---1.83.0.bcr.4",
+    "bzl.boost.bimap---1.87.0",
     "bzl.boost.bimap---1.89.0.bcr.2",
     "bzl.boost.bimap---1.90.0.bcr.1",
+    "bzl.boost.bind---1.83.0.bcr.1",
     "bzl.boost.bind---1.83.0.bcr.4",
     "bzl.boost.bind---1.87.0",
+    "bzl.boost.bind---1.88.0.bcr.2",
+    "bzl.boost.bind---1.89.0.bcr.1",
     "bzl.boost.bind---1.89.0.bcr.2",
     "bzl.boost.bind---1.90.0.bcr.1",
     "bzl.boost.callable_traits---1.89.0.bcr.2",
     "bzl.boost.callable_traits---1.90.0.bcr.1",
     "bzl.boost.charconv---1.89.0.bcr.2",
     "bzl.boost.charconv---1.90.0.bcr.1",
+    "bzl.boost.chrono---1.83.0.bcr.1",
+    "bzl.boost.chrono---1.83.0.bcr.4",
     "bzl.boost.chrono---1.87.0",
+    "bzl.boost.chrono---1.88.0.bcr.2",
     "bzl.boost.chrono---1.89.0.bcr.2",
     "bzl.boost.chrono---1.90.0.bcr.1",
+    "bzl.boost.circular_buffer---1.83.0.bcr.4",
+    "bzl.boost.circular_buffer---1.87.0",
     "bzl.boost.circular_buffer---1.89.0.bcr.2",
     "bzl.boost.circular_buffer---1.90.0.bcr.1",
     "bzl.boost.compat---1.89.0.bcr.2",
     "bzl.boost.compat---1.90.0.bcr.1",
+    "bzl.boost.compatibility---1.83.0.bcr.4",
+    "bzl.boost.compute---1.89.0.bcr.2",
     "bzl.boost.compute---1.90.0.bcr.1",
+    "bzl.boost.concept_check---1.83.0.bcr.1",
+    "bzl.boost.concept_check---1.83.0.bcr.4",
     "bzl.boost.concept_check---1.87.0",
+    "bzl.boost.concept_check---1.88.0.bcr.2",
+    "bzl.boost.concept_check---1.89.0.bcr.1",
     "bzl.boost.concept_check---1.89.0.bcr.2",
     "bzl.boost.concept_check---1.90.0.bcr.1",
+    "bzl.boost.config---1.83.0.bcr.4",
     "bzl.boost.config---1.87.0",
     "bzl.boost.config---1.89.0.bcr.2",
     "bzl.boost.config---1.90.0.bcr.1",
-    "bzl.boost.container---1.87.0.bcr.2",
+    "bzl.boost.container---1.83.0.bcr.4",
     "bzl.boost.container---1.89.0.bcr.2",
     "bzl.boost.container---1.90.0.bcr.1",
+    "bzl.boost.container_hash---1.83.0.bcr.1",
+    "bzl.boost.container_hash---1.83.0.bcr.4",
     "bzl.boost.container_hash---1.87.0",
+    "bzl.boost.container_hash---1.88.0.bcr.2",
+    "bzl.boost.container_hash---1.89.0.bcr.1",
     "bzl.boost.container_hash---1.89.0.bcr.2",
     "bzl.boost.container_hash---1.90.0.bcr.1",
-    "bzl.boost.context---1.87.0.bcr.2",
+    "bzl.boost.context---1.83.0.bcr.4",
+    "bzl.boost.context---1.88.0.bcr.3",
     "bzl.boost.context---1.89.0.bcr.2",
     "bzl.boost.context---1.90.0.bcr.1",
+    "bzl.boost.conversion---1.83.0.bcr.1",
+    "bzl.boost.conversion---1.83.0.bcr.4",
     "bzl.boost.conversion---1.87.0",
+    "bzl.boost.conversion---1.88.0.bcr.2",
+    "bzl.boost.conversion---1.89.0.bcr.1",
     "bzl.boost.conversion---1.89.0.bcr.2",
     "bzl.boost.conversion---1.90.0.bcr.1",
+    "bzl.boost.core---1.83.0.bcr.4",
     "bzl.boost.core---1.87.0",
+    "bzl.boost.core---1.88.0.bcr.2",
+    "bzl.boost.core---1.89.0.bcr.1",
     "bzl.boost.core---1.89.0.bcr.2",
     "bzl.boost.core---1.90.0.bcr.1",
+    "bzl.boost.coroutine---1.83.0.bcr.4",
     "bzl.boost.coroutine---1.87.0",
     "bzl.boost.coroutine---1.89.0.bcr.2",
     "bzl.boost.coroutine---1.90.0.bcr.1",
@@ -276,274 +362,477 @@ use_repo(
     "bzl.boost.crc---1.87.0",
     "bzl.boost.crc---1.89.0.bcr.2",
     "bzl.boost.crc---1.90.0.bcr.1",
+    "bzl.boost.date_time---1.83.0.bcr.1",
+    "bzl.boost.date_time---1.83.0.bcr.4",
     "bzl.boost.date_time---1.87.0",
+    "bzl.boost.date_time---1.88.0.bcr.2",
+    "bzl.boost.date_time---1.89.0.bcr.1",
     "bzl.boost.date_time---1.89.0.bcr.2",
     "bzl.boost.date_time---1.90.0.bcr.1",
+    "bzl.boost.describe---1.83.0.bcr.1",
     "bzl.boost.describe---1.83.0.bcr.4",
     "bzl.boost.describe---1.87.0",
+    "bzl.boost.describe---1.88.0.bcr.2",
+    "bzl.boost.describe---1.89.0.bcr.1",
     "bzl.boost.describe---1.89.0.bcr.2",
     "bzl.boost.describe---1.90.0.bcr.1",
+    "bzl.boost.detail---1.83.0.bcr.3",
+    "bzl.boost.detail---1.83.0.bcr.4",
     "bzl.boost.detail---1.87.0",
+    "bzl.boost.detail---1.88.0.bcr.2",
+    "bzl.boost.detail---1.89.0.bcr.1",
     "bzl.boost.detail---1.89.0.bcr.2",
     "bzl.boost.detail---1.90.0.bcr.1",
+    "bzl.boost.dll---1.88.0.bcr.2",
     "bzl.boost.dll---1.89.0.bcr.2",
     "bzl.boost.dll---1.90.0.bcr.1",
+    "bzl.boost.dynamic_bitset---1.83.0.bcr.1",
+    "bzl.boost.dynamic_bitset---1.83.0.bcr.4",
     "bzl.boost.dynamic_bitset---1.87.0",
+    "bzl.boost.dynamic_bitset---1.88.0.bcr.2",
     "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
+    "bzl.boost.endian---1.83.0.bcr.1",
+    "bzl.boost.endian---1.83.0.bcr.2",
     "bzl.boost.endian---1.83.0.bcr.4",
     "bzl.boost.endian---1.87.0",
+    "bzl.boost.endian---1.88.0.bcr.2",
     "bzl.boost.endian---1.89.0.bcr.2",
     "bzl.boost.endian---1.90.0.bcr.1",
     "bzl.boost.exception---1.83.0.bcr.4",
     "bzl.boost.exception---1.87.0",
+    "bzl.boost.exception---1.88.0.bcr.3",
     "bzl.boost.exception---1.89.0.bcr.2",
     "bzl.boost.exception---1.90.0.bcr.1",
+    "bzl.boost.filesystem---1.83.0.bcr.4",
     "bzl.boost.filesystem---1.87.0",
+    "bzl.boost.filesystem---1.88.0.bcr.2",
     "bzl.boost.filesystem---1.89.0.bcr.2",
     "bzl.boost.filesystem---1.90.0.bcr.1",
+    "bzl.boost.foreach---1.83.0.bcr.1",
+    "bzl.boost.foreach---1.83.0.bcr.4",
+    "bzl.boost.foreach---1.87.0",
     "bzl.boost.foreach---1.89.0.bcr.2",
     "bzl.boost.foreach---1.90.0.bcr.1",
+    "bzl.boost.format---1.83.0.bcr.1",
+    "bzl.boost.format---1.83.0.bcr.4",
+    "bzl.boost.format---1.87.0",
     "bzl.boost.format---1.89.0.bcr.2",
     "bzl.boost.format---1.90.0.bcr.1",
+    "bzl.boost.function---1.83.0.bcr.1",
+    "bzl.boost.function---1.83.0.bcr.4",
     "bzl.boost.function---1.87.0",
+    "bzl.boost.function---1.88.0.bcr.2",
+    "bzl.boost.function---1.89.0.bcr.1",
     "bzl.boost.function---1.89.0.bcr.2",
     "bzl.boost.function---1.90.0.bcr.1",
+    "bzl.boost.function_types---1.83.0.bcr.1",
+    "bzl.boost.function_types---1.83.0.bcr.4",
     "bzl.boost.function_types---1.87.0",
+    "bzl.boost.function_types---1.88.0.bcr.2",
+    "bzl.boost.function_types---1.89.0.bcr.1",
     "bzl.boost.function_types---1.89.0.bcr.2",
     "bzl.boost.function_types---1.90.0.bcr.1",
+    "bzl.boost.functional---1.83.0.bcr.1",
     "bzl.boost.functional---1.83.0.bcr.4",
     "bzl.boost.functional---1.87.0",
+    "bzl.boost.functional---1.88.0.bcr.2",
+    "bzl.boost.functional---1.89.0.bcr.1",
     "bzl.boost.functional---1.89.0.bcr.2",
     "bzl.boost.functional---1.90.0.bcr.1",
+    "bzl.boost.fusion---1.83.0.bcr.1",
+    "bzl.boost.fusion---1.83.0.bcr.4",
     "bzl.boost.fusion---1.87.0",
+    "bzl.boost.fusion---1.88.0.bcr.2",
+    "bzl.boost.fusion---1.89.0.bcr.1",
     "bzl.boost.fusion---1.89.0.bcr.2",
     "bzl.boost.fusion---1.90.0.bcr.1",
+    "bzl.boost.geometry---1.83.0.bcr.4",
     "bzl.boost.geometry---1.89.0.bcr.2",
     "bzl.boost.geometry---1.90.0.bcr.1",
+    "bzl.boost.graph---1.83.0.bcr.4",
     "bzl.boost.graph---1.89.0.bcr.2",
     "bzl.boost.graph---1.90.0.bcr.1",
     "bzl.boost.hash2---1.89.0.bcr.2",
     "bzl.boost.hash2---1.90.0.bcr.1",
+    "bzl.boost.heap---1.83.0",
+    "bzl.boost.heap---1.83.0.bcr.4",
     "bzl.boost.heap---1.89.0.bcr.2",
     "bzl.boost.heap---1.90.0.bcr.1",
-    "bzl.boost.histogram---1.89.0.bcr.2",
     "bzl.boost.histogram---1.90.0.bcr.1",
     "bzl.boost.hof---1.89.0.bcr.2",
     "bzl.boost.hof---1.90.0.bcr.1",
+    "bzl.boost.icl---1.83.0.bcr.4",
     "bzl.boost.icl---1.89.0.bcr.2",
     "bzl.boost.icl---1.90.0.bcr.1",
+    "bzl.boost.integer---1.83.0.bcr.4",
     "bzl.boost.integer---1.87.0",
-    "bzl.boost.integer---1.88.0.bcr.3",
     "bzl.boost.integer---1.89.0.bcr.2",
     "bzl.boost.integer---1.90.0.bcr.1",
+    "bzl.boost.interprocess---1.83.0.bcr.4",
+    "bzl.boost.interprocess---1.88.0.bcr.2",
     "bzl.boost.interprocess---1.89.0.bcr.2",
     "bzl.boost.interprocess---1.90.0.bcr.1",
+    "bzl.boost.intrusive---1.83.0.bcr.4",
     "bzl.boost.intrusive---1.87.0",
     "bzl.boost.intrusive---1.89.0.bcr.2",
     "bzl.boost.intrusive---1.90.0.bcr.1",
-    "bzl.boost.io---1.88.0.bcr.1",
+    "bzl.boost.io---1.83.0.bcr.1",
+    "bzl.boost.io---1.83.0.bcr.4",
+    "bzl.boost.io---1.87.0",
+    "bzl.boost.io---1.88.0.bcr.2",
+    "bzl.boost.io---1.89.0.bcr.1",
     "bzl.boost.io---1.89.0.bcr.2",
     "bzl.boost.io---1.90.0.bcr.1",
-    "bzl.boost.iostreams---1.87.0.bcr.1",
+    "bzl.boost.iostreams---1.83.0.bcr.2",
+    "bzl.boost.iostreams---1.83.0.bcr.4",
+    "bzl.boost.iostreams---1.87.0",
+    "bzl.boost.iostreams---1.88.0.bcr.2",
+    "bzl.boost.iostreams---1.89.0.bcr.2",
+    "bzl.boost.iostreams---1.90.0.bcr.1",
+    "bzl.boost.iostreams---1.90.0.bcr.2",
+    "bzl.boost.iterator---1.83.0.bcr.1",
     "bzl.boost.iterator---1.83.0.bcr.4",
     "bzl.boost.iterator---1.87.0",
+    "bzl.boost.iterator---1.88.0.bcr.2",
+    "bzl.boost.iterator---1.89.0.bcr.1",
     "bzl.boost.iterator---1.89.0.bcr.2",
     "bzl.boost.iterator---1.90.0.bcr.1",
+    "bzl.boost.json---1.83.0.bcr.4",
     "bzl.boost.json---1.89.0.bcr.2",
     "bzl.boost.json---1.90.0.bcr.1",
+    "bzl.boost.lambda---1.83.0.bcr.1",
+    "bzl.boost.lambda---1.83.0.bcr.4",
+    "bzl.boost.lambda---1.87.0",
     "bzl.boost.lambda---1.89.0.bcr.2",
     "bzl.boost.lambda---1.90.0.bcr.1",
     "bzl.boost.lambda2---1.89.0.bcr.2",
     "bzl.boost.lambda2---1.90.0.bcr.1",
     "bzl.boost.leaf---1.89.0.bcr.2",
     "bzl.boost.leaf---1.90.0.bcr.1",
+    "bzl.boost.lexical_cast---1.83.0.bcr.1",
+    "bzl.boost.lexical_cast---1.83.0.bcr.4",
     "bzl.boost.lexical_cast---1.87.0",
+    "bzl.boost.lexical_cast---1.88.0.bcr.2",
+    "bzl.boost.lexical_cast---1.89.0.bcr.1",
     "bzl.boost.lexical_cast---1.89.0.bcr.2",
     "bzl.boost.lexical_cast---1.90.0.bcr.1",
-    "bzl.boost.locale---1.83.0",
     "bzl.boost.locale---1.90.0.bcr.1",
     "bzl.boost.lockfree---1.89.0.bcr.2",
     "bzl.boost.lockfree---1.90.0.bcr.1",
     "bzl.boost.log---1.89.0.bcr.2",
     "bzl.boost.log---1.90.0.bcr.1",
+    "bzl.boost.logic---1.83.0.bcr.4",
     "bzl.boost.logic---1.89.0.bcr.2",
     "bzl.boost.logic---1.90.0.bcr.1",
+    "bzl.boost.math---1.83.0.bcr.4",
     "bzl.boost.math---1.87.0",
     "bzl.boost.math---1.89.0.bcr.2",
     "bzl.boost.math---1.90.0.bcr.1",
     "bzl.boost.move---1.83.0.bcr.4",
     "bzl.boost.move---1.89.0.bcr.2",
     "bzl.boost.move---1.90.0.bcr.1",
+    "bzl.boost.mp11---1.83.0.bcr.1",
+    "bzl.boost.mp11---1.83.0.bcr.4",
     "bzl.boost.mp11---1.87.0",
-    "bzl.boost.mp11---1.88.0.bcr.3",
+    "bzl.boost.mp11---1.88.0.bcr.2",
+    "bzl.boost.mp11---1.89.0.bcr.1",
     "bzl.boost.mp11---1.89.0.bcr.2",
     "bzl.boost.mp11---1.90.0.bcr.1",
+    "bzl.boost.mpl---1.83.0.bcr.1",
+    "bzl.boost.mpl---1.83.0.bcr.4",
     "bzl.boost.mpl---1.87.0",
+    "bzl.boost.mpl---1.88.0.bcr.2",
+    "bzl.boost.mpl---1.89.0.bcr.1",
     "bzl.boost.mpl---1.89.0.bcr.2",
     "bzl.boost.mpl---1.90.0.bcr.1",
     "bzl.boost.mqtt5---1.89.0",
     "bzl.boost.mqtt5---1.90.0.bcr.1",
+    "bzl.boost.multi_array---1.83.0.bcr.4",
     "bzl.boost.multi_array---1.89.0.bcr.2",
     "bzl.boost.multi_array---1.90.0.bcr.1",
+    "bzl.boost.multi_index---1.83.0.bcr.1",
+    "bzl.boost.multi_index---1.83.0.bcr.4",
+    "bzl.boost.multi_index---1.87.0",
+    "bzl.boost.multi_index---1.88.0.bcr.2",
     "bzl.boost.multi_index---1.89.0.bcr.2",
     "bzl.boost.multi_index---1.90.0.bcr.1",
+    "bzl.boost.multiprecision---1.83.0.bcr.4",
     "bzl.boost.multiprecision---1.87.0",
     "bzl.boost.multiprecision---1.89.0.bcr.2",
     "bzl.boost.multiprecision---1.90.0.bcr.1",
     "bzl.boost.mysql---1.89.0.bcr.2",
     "bzl.boost.mysql---1.90.0.bcr.1",
+    "bzl.boost.numeric_conversion---1.83.0.bcr.1",
+    "bzl.boost.numeric_conversion---1.83.0.bcr.4",
     "bzl.boost.numeric_conversion---1.87.0",
+    "bzl.boost.numeric_conversion---1.88.0.bcr.2",
+    "bzl.boost.numeric_conversion---1.89.0.bcr.1",
     "bzl.boost.numeric_conversion---1.89.0.bcr.2",
     "bzl.boost.numeric_conversion---1.90.0.bcr.1",
     "bzl.boost.numeric_interval---1.89.0",
     "bzl.boost.numeric_interval---1.90.0.bcr.1",
     "bzl.boost.numeric_ublas---1.89.0.bcr.2",
+    "bzl.boost.optional---1.83.0.bcr.4",
     "bzl.boost.optional---1.87.0",
+    "bzl.boost.optional---1.88.0.bcr.3",
     "bzl.boost.optional---1.89.0.bcr.2",
     "bzl.boost.optional---1.90.0.bcr.1",
     "bzl.boost.outcome---1.89.0.bcr.2",
     "bzl.boost.outcome---1.90.0.bcr.1",
+    "bzl.boost.parameter---1.83.0.bcr.1",
+    "bzl.boost.parameter---1.83.0.bcr.4",
+    "bzl.boost.parameter---1.87.0",
     "bzl.boost.parameter---1.89.0.bcr.2",
     "bzl.boost.parameter---1.90.0.bcr.1",
+    "bzl.boost.pfr---1.83.0.bcr.4",
     "bzl.boost.pfr---1.89.0.bcr.2",
     "bzl.boost.pfr---1.90.0.bcr.1",
+    "bzl.boost.phoenix---1.83.0.bcr.4",
     "bzl.boost.phoenix---1.87.0",
-    "bzl.boost.phoenix---1.88.0.bcr.3",
     "bzl.boost.phoenix---1.89.0.bcr.2",
     "bzl.boost.phoenix---1.90.0.bcr.1",
     "bzl.boost.pin_version---1.89.0",
+    "bzl.boost.polygon---1.83.0.bcr.4",
     "bzl.boost.polygon---1.89.0.bcr.2",
     "bzl.boost.polygon---1.90.0.bcr.1",
+    "bzl.boost.pool---1.83.0.bcr.1",
+    "bzl.boost.pool---1.83.0.bcr.4",
     "bzl.boost.pool---1.87.0",
+    "bzl.boost.pool---1.88.0.bcr.2",
+    "bzl.boost.pool---1.89.0.bcr.1",
     "bzl.boost.pool---1.89.0.bcr.2",
     "bzl.boost.pool---1.90.0.bcr.1",
+    "bzl.boost.predef---1.83.0.bcr.1",
+    "bzl.boost.predef---1.83.0.bcr.4",
     "bzl.boost.predef---1.87.0",
+    "bzl.boost.predef---1.88.0.bcr.2",
+    "bzl.boost.predef---1.89.0.bcr.1",
     "bzl.boost.predef---1.89.0.bcr.2",
     "bzl.boost.predef---1.90.0.bcr.1",
+    "bzl.boost.preprocessor---1.83.0.bcr.4",
     "bzl.boost.preprocessor---1.87.0",
-    "bzl.boost.preprocessor---1.90.0",
     "bzl.boost.preprocessor---1.90.0.bcr.1",
+    "bzl.boost.process---1.83.0.bcr.4",
     "bzl.boost.process---1.89.0.bcr.2",
     "bzl.boost.process---1.90.0.bcr.1",
+    "bzl.boost.program_options---1.83.0.bcr.2",
+    "bzl.boost.program_options---1.83.0.bcr.4",
     "bzl.boost.program_options---1.87.0",
+    "bzl.boost.program_options---1.88.0.bcr.2",
     "bzl.boost.program_options---1.89.0.bcr.2",
     "bzl.boost.program_options---1.90.0.bcr.1",
+    "bzl.boost.property_map---1.83.0.bcr.1",
+    "bzl.boost.property_map---1.83.0.bcr.4",
+    "bzl.boost.property_map---1.87.0",
     "bzl.boost.property_map---1.89.0.bcr.2",
     "bzl.boost.property_map---1.90.0.bcr.1",
+    "bzl.boost.property_tree---1.83.0.bcr.4",
     "bzl.boost.property_tree---1.89.0.bcr.2",
     "bzl.boost.property_tree---1.90.0.bcr.1",
+    "bzl.boost.proto---1.83.0.bcr.1",
+    "bzl.boost.proto---1.83.0.bcr.2",
     "bzl.boost.proto---1.83.0.bcr.4",
     "bzl.boost.proto---1.87.0",
+    "bzl.boost.proto---1.88.0.bcr.2",
     "bzl.boost.proto---1.89.0.bcr.2",
     "bzl.boost.proto---1.90.0.bcr.1",
+    "bzl.boost.ptr_container---1.83.0.bcr.4",
+    "bzl.boost.ptr_container---1.87.0",
     "bzl.boost.ptr_container---1.89.0.bcr.2",
     "bzl.boost.ptr_container---1.90.0.bcr.1",
+    "bzl.boost.python---1.89.0.bcr.2",
     "bzl.boost.python---1.90.0.bcr.1",
+    "bzl.boost.qvm---1.83.0.bcr.4",
     "bzl.boost.qvm---1.89.0.bcr.2",
     "bzl.boost.qvm---1.90.0.bcr.1",
+    "bzl.boost.random---1.83.0.bcr.1",
+    "bzl.boost.random---1.83.0.bcr.4",
     "bzl.boost.random---1.87.0",
+    "bzl.boost.random---1.88.0.bcr.2",
     "bzl.boost.random---1.89.0.bcr.2",
     "bzl.boost.random---1.90.0.bcr.1",
+    "bzl.boost.range---1.83.0.bcr.1",
+    "bzl.boost.range---1.83.0.bcr.4",
     "bzl.boost.range---1.87.0",
+    "bzl.boost.range---1.88.0.bcr.2",
+    "bzl.boost.range---1.89.0.bcr.1",
     "bzl.boost.range---1.89.0.bcr.2",
     "bzl.boost.range---1.90.0.bcr.1",
+    "bzl.boost.ratio---1.83.0.bcr.1",
+    "bzl.boost.ratio---1.83.0.bcr.4",
     "bzl.boost.ratio---1.87.0",
+    "bzl.boost.ratio---1.88.0.bcr.2",
     "bzl.boost.ratio---1.89.0.bcr.2",
     "bzl.boost.ratio---1.90.0.bcr.1",
+    "bzl.boost.rational---1.83.0.bcr.1",
+    "bzl.boost.rational---1.83.0.bcr.4",
     "bzl.boost.rational---1.87.0",
     "bzl.boost.rational---1.89.0.bcr.2",
     "bzl.boost.rational---1.90.0.bcr.1",
+    "bzl.boost.regex---1.83.0.bcr.1",
     "bzl.boost.regex---1.83.0.bcr.4",
     "bzl.boost.regex---1.87.0",
+    "bzl.boost.regex---1.88.0.bcr.2",
+    "bzl.boost.regex---1.89.0.bcr.1",
     "bzl.boost.regex---1.89.0.bcr.2",
     "bzl.boost.regex---1.90.0.bcr.1",
     "bzl.boost.scope---1.87.0",
+    "bzl.boost.scope---1.88.0.bcr.2",
     "bzl.boost.scope---1.89.0.bcr.2",
     "bzl.boost.scope---1.90.0.bcr.1",
+    "bzl.boost.scope_exit---1.83.0.bcr.4",
     "bzl.boost.scope_exit---1.89.0.bcr.2",
     "bzl.boost.scope_exit---1.90.0.bcr.1",
-    "bzl.boost.serialization---1.87.0.bcr.1",
+    "bzl.boost.serialization---1.83.0.bcr.4",
+    "bzl.boost.serialization---1.88.0.bcr.3",
     "bzl.boost.serialization---1.89.0.bcr.2",
     "bzl.boost.serialization---1.90.0.bcr.1",
+    "bzl.boost.signals2---1.83.0.bcr.4",
     "bzl.boost.signals2---1.89.0.bcr.2",
     "bzl.boost.signals2---1.90.0.bcr.1",
+    "bzl.boost.smart_ptr---1.83.0.bcr.1",
+    "bzl.boost.smart_ptr---1.83.0.bcr.4",
     "bzl.boost.smart_ptr---1.87.0",
+    "bzl.boost.smart_ptr---1.88.0.bcr.2",
+    "bzl.boost.smart_ptr---1.89.0.bcr.1",
     "bzl.boost.smart_ptr---1.89.0.bcr.2",
     "bzl.boost.smart_ptr---1.90.0.bcr.1",
+    "bzl.boost.sort---1.83.0.bcr.4",
     "bzl.boost.sort---1.89.0.bcr.2",
     "bzl.boost.sort---1.90.0.bcr.1",
     "bzl.boost.spirit---1.83.0.bcr.4",
     "bzl.boost.spirit---1.89.0.bcr.3",
     "bzl.boost.spirit---1.90.0.bcr.1",
+    "bzl.boost.stacktrace---1.83.0.bcr.4",
     "bzl.boost.stacktrace---1.89.0.bcr.2",
     "bzl.boost.stacktrace---1.90.0.bcr.1",
+    "bzl.boost.static_assert---1.83.0.bcr.4",
     "bzl.boost.static_assert---1.87.0",
+    "bzl.boost.static_assert---1.88.0.bcr.2",
+    "bzl.boost.static_assert---1.89.0.bcr.1",
     "bzl.boost.static_assert---1.89.0.bcr.2",
     "bzl.boost.static_assert---1.90.0.bcr.1",
+    "bzl.boost.static_string---1.83.0.bcr.4",
     "bzl.boost.static_string---1.89.0.bcr.2",
     "bzl.boost.static_string---1.90.0.bcr.1",
+    "bzl.boost.system---1.83.0.bcr.1",
+    "bzl.boost.system---1.83.0.bcr.4",
     "bzl.boost.system---1.87.0",
+    "bzl.boost.system---1.88.0.bcr.2",
+    "bzl.boost.system---1.89.0.bcr.1",
     "bzl.boost.system---1.89.0.bcr.2",
     "bzl.boost.system---1.90.0.bcr.1",
-    "bzl.boost.test---1.87.0.bcr.2",
+    "bzl.boost.test---1.83.0.bcr.4",
+    "bzl.boost.test---1.87.0",
     "bzl.boost.test---1.89.0.bcr.2",
     "bzl.boost.test---1.90.0.bcr.1",
+    "bzl.boost.thread---1.83.0.bcr.1",
+    "bzl.boost.thread---1.83.0.bcr.2",
+    "bzl.boost.thread---1.83.0.bcr.4",
+    "bzl.boost.thread---1.87.0",
+    "bzl.boost.thread---1.88.0.bcr.2",
     "bzl.boost.thread---1.89.0.bcr.2",
     "bzl.boost.thread---1.90.0.bcr.1",
+    "bzl.boost.throw_exception---1.83.0.bcr.4",
     "bzl.boost.throw_exception---1.87.0",
+    "bzl.boost.throw_exception---1.88.0.bcr.2",
+    "bzl.boost.throw_exception---1.89.0.bcr.1",
     "bzl.boost.throw_exception---1.89.0.bcr.2",
     "bzl.boost.throw_exception---1.90.0.bcr.1",
+    "bzl.boost.timer---1.83.0.bcr.4",
     "bzl.boost.timer---1.87.0",
     "bzl.boost.timer---1.89.0.bcr.2",
     "bzl.boost.timer---1.90.0.bcr.1",
+    "bzl.boost.tokenizer---1.83.0.bcr.1",
+    "bzl.boost.tokenizer---1.83.0.bcr.4",
     "bzl.boost.tokenizer---1.87.0",
+    "bzl.boost.tokenizer---1.88.0.bcr.2",
+    "bzl.boost.tokenizer---1.89.0.bcr.1",
     "bzl.boost.tokenizer---1.89.0.bcr.2",
     "bzl.boost.tokenizer---1.90.0.bcr.1",
+    "bzl.boost.tti---1.83.0.bcr.4",
+    "bzl.boost.tti---1.87.0",
     "bzl.boost.tti---1.89.0.bcr.2",
     "bzl.boost.tti---1.90.0.bcr.1",
+    "bzl.boost.tuple---1.83.0.bcr.1",
     "bzl.boost.tuple---1.83.0.bcr.4",
     "bzl.boost.tuple---1.87.0",
+    "bzl.boost.tuple---1.88.0.bcr.2",
+    "bzl.boost.tuple---1.89.0.bcr.1",
     "bzl.boost.tuple---1.89.0.bcr.2",
     "bzl.boost.tuple---1.90.0.bcr.1",
+    "bzl.boost.type_index---1.83.0.bcr.1",
+    "bzl.boost.type_index---1.83.0.bcr.4",
     "bzl.boost.type_index---1.87.0",
-    "bzl.boost.type_index---1.88.0.bcr.3",
+    "bzl.boost.type_index---1.88.0.bcr.2",
     "bzl.boost.type_index---1.89.0.bcr.2",
     "bzl.boost.type_index---1.90.0.bcr.1",
+    "bzl.boost.type_traits---1.83.0.bcr.4",
     "bzl.boost.type_traits---1.87.0",
-    "bzl.boost.type_traits---1.88.0.bcr.3",
     "bzl.boost.type_traits---1.89.0.bcr.2",
     "bzl.boost.type_traits---1.90.0.bcr.1",
+    "bzl.boost.typeof---1.83.0.bcr.1",
+    "bzl.boost.typeof---1.83.0.bcr.4",
     "bzl.boost.typeof---1.87.0",
+    "bzl.boost.typeof---1.88.0.bcr.2",
+    "bzl.boost.typeof---1.89.0.bcr.1",
     "bzl.boost.typeof---1.89.0.bcr.2",
     "bzl.boost.typeof---1.90.0.bcr.1",
+    "bzl.boost.units---1.83.0.bcr.4",
     "bzl.boost.units---1.89.0.bcr.2",
     "bzl.boost.units---1.90.0.bcr.1",
+    "bzl.boost.unordered---1.83.0.bcr.1",
     "bzl.boost.unordered---1.83.0.bcr.4",
     "bzl.boost.unordered---1.87.0",
+    "bzl.boost.unordered---1.88.0.bcr.2",
+    "bzl.boost.unordered---1.89.0.bcr.1",
     "bzl.boost.unordered---1.89.0.bcr.2",
     "bzl.boost.unordered---1.90.0.bcr.1",
+    "bzl.boost.url---1.83.0.bcr.4",
     "bzl.boost.url---1.89.0.bcr.2",
     "bzl.boost.url---1.90.0.bcr.1",
+    "bzl.boost.utility---1.83.0.bcr.1",
+    "bzl.boost.utility---1.83.0.bcr.4",
     "bzl.boost.utility---1.87.0",
-    "bzl.boost.utility---1.88.0.bcr.3",
+    "bzl.boost.utility---1.88.0.bcr.2",
+    "bzl.boost.utility---1.89.0.bcr.1",
     "bzl.boost.utility---1.89.0.bcr.2",
     "bzl.boost.utility---1.90.0.bcr.1",
+    "bzl.boost.uuid---1.83.0.bcr.4",
     "bzl.boost.uuid---1.89.0.bcr.2",
     "bzl.boost.uuid---1.90.0.bcr.1",
+    "bzl.boost.variant---1.83.0.bcr.1",
+    "bzl.boost.variant---1.83.0.bcr.2",
+    "bzl.boost.variant---1.83.0.bcr.4",
     "bzl.boost.variant---1.87.0",
+    "bzl.boost.variant---1.88.0.bcr.2",
     "bzl.boost.variant---1.89.0.bcr.2",
     "bzl.boost.variant---1.90.0.bcr.1",
+    "bzl.boost.variant2---1.83.0.bcr.1",
+    "bzl.boost.variant2---1.83.0.bcr.4",
     "bzl.boost.variant2---1.87.0",
+    "bzl.boost.variant2---1.88.0.bcr.2",
+    "bzl.boost.variant2---1.89.0.bcr.1",
     "bzl.boost.variant2---1.89.0.bcr.2",
     "bzl.boost.variant2---1.90.0.bcr.1",
     "bzl.boost.vmd---1.89.0.bcr.2",
     "bzl.boost.vmd---1.90.0.bcr.1",
+    "bzl.boost.winapi---1.83.0.bcr.1",
+    "bzl.boost.winapi---1.83.0.bcr.4",
     "bzl.boost.winapi---1.87.0",
-    "bzl.boost.winapi---1.90.0",
+    "bzl.boost.winapi---1.88.0.bcr.2",
+    "bzl.boost.winapi---1.89.0.bcr.1",
+    "bzl.boost.winapi---1.89.0.bcr.2",
     "bzl.boost.winapi---1.90.0.bcr.1",
+    "bzl.boost.xpressive---1.83.0.bcr.1",
+    "bzl.boost.xpressive---1.83.0.bcr.4",
+    "bzl.boost.xpressive---1.87.0",
     "bzl.boost.xpressive---1.89.0.bcr.2",
     "bzl.boost.xpressive---1.90.0.bcr.1",
+    "bzl.boost---1.83.0.bcr.4",
+    "bzl.boost---1.89.0.bcr.2",
+    "bzl.boost---1.89.0.bcr.3",
     "bzl.boost---1.89.0.bcr.4",
     "bzl.boost---1.90.0.bcr.1",
     "bzl.boringssl---0.0.0-20211025-d4f1ab9",
@@ -554,15 +843,19 @@ use_repo(
     "bzl.boringssl---0.20241024.0",
     "bzl.boringssl---0.20241209.0",
     "bzl.boringssl---0.20250212.0",
+    "bzl.boringssl---0.20250311.0",
     "bzl.boringssl---0.20250514.0",
+    "bzl.boringssl---0.20250818.0",
     "bzl.boringssl---0.20251002.0",
     "bzl.boringssl---0.20251110.0",
     "bzl.boringssl---0.20251124.0",
     "bzl.boringssl---0.20260327.0",
     "bzl.boringssl---0.20260413.0",
     "bzl.boringssl---0.20260508.0",
+    "bzl.briansmith_ring---0.17.14.bcr.1",
     "bzl.brotli---1.1.0",
     "bzl.brotli_go---1.2.0",
+    "bzl.bubblewrap---0.11.0.bcr.1",
     "bzl.build_stack_rules_proto---4.1.1",
     "bzl.build_stack_rules_proto---4.2.0",
     "bzl.build_stack_scala_gazelle---0.1.1",
@@ -576,17 +869,25 @@ use_repo(
     "bzl.buildifier_prebuilt---8.2.1.1",
     "bzl.buildifier_prebuilt---8.5.1.2",
     "bzl.buildozer---8.5.1",
+    "bzl.bullet---3.26.0-rc0.bcr.1",
     "bzl.bullet---3.26.0-rc0.bcr.2",
+    "bzl.byte_track_eigen---2.1.0.bcr.2",
+    "bzl.bzip2---1.0.8.bcr.1",
     "bzl.bzip2---1.0.8.bcr.4",
     "bzl.bzlparty_rules_quickjs---0.1.0",
     "bzl.bzlparty_tools---0.4.0",
     "bzl.bzlws---0.2.0",
     "bzl.c-ares---1.15.0",
     "bzl.c-ares---1.16.1",
+    "bzl.c-ares---1.19.1",
     "bzl.c-ares---1.19.1.bcr.1",
+    "bzl.c-ares---1.34.5.bcr.1",
+    "bzl.c-ares---1.34.5.bcr.2",
+    "bzl.c-ares---1.34.6",
     "bzl.c-blosc2---2.22.0",
     "bzl.c4core---0.2.12",
     "bzl.c4core---0.2.6",
+    "bzl.cairo---1.18.4",
     "bzl.capnp-cpp---1.1.0",
     "bzl.cargo_env.bzl---0.2.5",
     "bzl.caseyduquettesc_rules_python_pytest---1.1.1",
@@ -601,28 +902,38 @@ use_repo(
     "bzl.cel-spec---0.23.0",
     "bzl.cel-spec---0.24.0",
     "bzl.cel-spec---0.25.1",
+    "bzl.cereal---1.3.2.bcr.1",
     "bzl.cereal---1.3.2.bcr.4",
     "bzl.ceres-solver---2.2.0",
     "bzl.cgrindel_bazel_starlib---0.27.0",
     "bzl.cgrindel_bazel_starlib---0.28.0",
     "bzl.cgrindel_bazel_starlib---0.30.0",
+    "bzl.check---0.15.2.bcr.2",
+    "bzl.chicory---1.1.0",
     "bzl.civetweb---1.16.bcr.4",
     "bzl.cjson---1.7.19-0.20240923110858-12c4bf1986c2.bcr.4",
     "bzl.claro-lang---0.1.409",
     "bzl.cli11---2.6.2",
+    "bzl.clipper2---1.5.3",
     "bzl.closure-templates---1.0.1",
+    "bzl.cmake_configure_file---0.1.1",
     "bzl.cmake_configure_file---0.1.2",
     "bzl.cmake_configure_file---0.1.3",
     "bzl.cmake_configure_file---0.1.4",
     "bzl.cmake_configure_file---0.1.5",
     "bzl.cmake_configure_file---0.1.6",
     "bzl.cmake_configure_file---0.1.7",
+    "bzl.coacd---1.0.11.bcr.2",
     "bzl.codspeed_google_benchmark_compat---2.1.0",
+    "bzl.coin-or-lemon---1.3.1",
     "bzl.colordiff---1.0.22",
     "bzl.com_clementguillot_rules_quarkus---0.1.0",
     "bzl.com_github_benchsci_rules_nodejs_gazelle---0.8.4",
+    "bzl.com_github_mvukov_rules_ros2---0.0.0-20250612-f0d04fe",
     "bzl.com_github_mvukov_rules_ros2---0.0.0-20260118-78d85ff",
     "bzl.com_github_rabbitmq_looking_glass---0.2.1",
+    "bzl.concurrentqueue---1.0.4",
+    "bzl.console_bridge---1.0.1",
     "bzl.container_structure_test---1.22.1",
     "bzl.contrib_rules_jvm---0.24.0",
     "bzl.contrib_rules_jvm---0.28.0",
@@ -630,50 +941,78 @@ use_repo(
     "bzl.copybara---0.0.0-20250728-6672ce2",
     "bzl.coroutines---3.3.2",
     "bzl.cpp-httplib---0.22.0",
+    "bzl.cpp-peglib---1.0.1",
+    "bzl.cpp-sqlite---0.0.0-20230222-7f931c4",
+    "bzl.cpp-sqlite---0.0.0-20241111-21be8b5",
     "bzl.cpp2sky---0.6.1-20251203-dfc5bd9",
+    "bzl.cpp_fpm---1.1.0",
     "bzl.cpp_toolbelt---2.1.2",
+    "bzl.cppcheck---2.20.0",
     "bzl.cppitertools---2.1",
     "bzl.cppitertools---2.2",
     "bzl.cppoptlib---2.0.0",
     "bzl.cpptoml---0.1.1",
     "bzl.cpptrace---1.0.4.bcr.1",
+    "bzl.cppunit---1.15.1",
     "bzl.cppzmq---4.10.0.bcr.1",
+    "bzl.cpr---1.14.2",
     "bzl.cpuinfo---0.0.0-20260312-7607ca5",
     "bzl.crc32c---1.1.0",
     "bzl.crispy-doom---7.1.0.bcr.beta.2",
     "bzl.crowcpp---1.3.0",
+    "bzl.csv-parser---2.3.0",
     "bzl.cucumber-cpp---0.8.0.bcr.1",
     "bzl.cuda_toolchain_types---0.0.1",
     "bzl.cuda_toolkit---0.0.2",
-    "bzl.curl---8.11.0.bcr.5",
+    "bzl.cudd---3.0.0.bcr.2",
+    "bzl.cunit---2.1.3",
+    "bzl.curl---8.11.0.bcr.1",
+    "bzl.curl---8.11.0.bcr.2",
+    "bzl.curl---8.11.0.bcr.4",
+    "bzl.curl---8.12.0.bcr.1",
     "bzl.curl---8.7.1",
+    "bzl.curl---8.8.0.bcr.3",
     "bzl.cxx.rs---1.0.194",
     "bzl.cxxopts---3.3.1",
+    "bzl.cxxtest---4.4.bcr.1",
+    "bzl.cxxurl---0.3",
+    "bzl.cyclonedds---11.0.1",
     "bzl.cython---3.0.11-1",
     "bzl.cython---3.2.4",
     "bzl.darts-clone---0.32",
     "bzl.dartsim---6.13.2.bcr.2",
     "bzl.debian_dependency_bazelizer---1.0.0",
+    "bzl.delaunator-cpp---0.0.0-20181007-c1521f6",
     "bzl.depend_on_what_you_use---0.16.0",
     "bzl.diff.bzl---0.5.1",
     "bzl.diff.bzl---0.5.5",
     "bzl.diffutils---3.12",
     "bzl.distributed_point_functions---0.0.0",
+    "bzl.divsufsort---2.0.1.bcr.1",
+    "bzl.dlpack---1.3",
+    "bzl.dnsmasq---2.92",
+    "bzl.doctest---2.4.11",
     "bzl.doctest---2.4.12.bcr.1",
     "bzl.double-conversion---3.3.1",
     "bzl.download_archives---0.1.0",
     "bzl.download_utils---1.0.0-beta.2",
     "bzl.download_utils---1.0.1",
+    "bzl.dtc---1.7.2.bcr.1",
+    "bzl.dumb-init---1.2.5",
+    "bzl.dylib---2.2.1",
     "bzl.effcee---0.0.0-20250222",
     "bzl.egl-registry---0.0.0-20250527",
     "bzl.eigen---3.4.0.bcr.3",
+    "bzl.eigen---3.4.1",
     "bzl.eigen---3.4.1.bcr.1",
+    "bzl.eigen---4.0.0-20241125.bcr.2",
+    "bzl.eigen---5.0.1",
     "bzl.eigen---5.0.1.bcr.1",
     "bzl.elemental2---1.3.2",
     "bzl.emboss---2026.0212.185041",
     "bzl.emsdk---4.0.13",
     "bzl.emsdk---5.0.7",
-    "bzl.engflowapis---2024.12.06-06.17.32",
+    "bzl.engflowapis---2024.10.16",
     "bzl.engflowapis-java---2025.07.24-06.20.24",
     "bzl.envoy_api---0.0.0-20241214-918efc9",
     "bzl.envoy_api---0.0.0-20250128-4de3c74",
@@ -681,42 +1020,63 @@ use_repo(
     "bzl.envoy_api---0.0.0-20251216-6ef568c",
     "bzl.envoy_api---0.0.0-20260130-84e8436",
     "bzl.envoy_toolshed---0.3.25",
+    "bzl.esaxx---20250106.1",
+    "bzl.etherlab-ethercat---1.6.7.bcr.1",
     "bzl.evidence_store_bazel---0.0.1",
     "bzl.exempi---2.6.6",
+    "bzl.exprtk---0.0.3.bcr.1",
     "bzl.extra_rules_java---1.3",
     "bzl.fast_double_parser---0.8.0",
     "bzl.fast_float---8.0.2",
     "bzl.fast_float---8.2.4",
+    "bzl.fastcdr---2.3.5.bcr.0",
+    "bzl.fastdds---3.4.2",
     "bzl.fastjson---0.0.0-20120701063936-485f994a61a6.bcr.1",
+    "bzl.fasttext---0.10.0-bcr.20240313-1142dc4.bcr.2",
     "bzl.fcl---0.7.0.bcr.2",
     "bzl.federated_language---0.5.2",
     "bzl.ffmpeg---7.1.1.bcr.beta.5",
+    "bzl.fftw---3.3.10",
     "bzl.fildesh---0.2.0",
     "bzl.fire---0.5.0",
     "bzl.fizz---2025.02.10.00.bcr.2",
+    "bzl.fkyaml---0.4.2",
+    "bzl.flann---1.9.2",
     "bzl.flatbuffers---25.12.19",
     "bzl.flatbuffers---25.2.10",
     "bzl.flatbuffers---25.9.23",
+    "bzl.flex---2.6.4.bcr.2",
     "bzl.flex---2.6.4.bcr.3",
     "bzl.flex---2.6.4.bcr.5",
     "bzl.flip---1.6",
     "bzl.fmt---10.1.1",
     "bzl.fmt---11.1.3",
     "bzl.fmt---11.1.4",
+    "bzl.fmt---11.2.0",
+    "bzl.fmt---12.0.0",
     "bzl.fmt---12.1.0",
     "bzl.fmt---8.1.1",
     "bzl.folly---2025.01.13.00.bcr.6",
+    "bzl.foonathan_memory---0.7.3.bcr.2",
+    "bzl.foxglove_schemas_protobuf---0.2.2.bcr.1",
+    "bzl.foxglove_websocket---1.3.0",
+    "bzl.foxglove_ws_protocol---0.8.1",
     "bzl.fp16---0.0.0-20210320-0a92994",
+    "bzl.freeimage---3.19.10.bcr.3",
+    "bzl.freeimage---3.19.10.bcr.4",
     "bzl.freeimage---3.19.10.bcr.5",
+    "bzl.freertos---11.1.0.bcr.3",
+    "bzl.freetype---2.13.3.bcr.2",
     "bzl.freetype---2.14.1",
-    "bzl.freetype---2.9",
     "bzl.fremtind_rules_vitest---0.2.1",
     "bzl.fshlib---0.2.0",
     "bzl.ftxui---6.1.9",
     "bzl.fuzztest---20260219.0",
     "bzl.fxdiv---0.0.0-20201209-63058ef",
+    "bzl.fzf---0.71.0",
     "bzl.gawk---5.3.2.bcr.1",
-    "bzl.gawk---5.3.2.bcr.5",
+    "bzl.gawk---5.3.2.bcr.2",
+    "bzl.gawk---5.3.2.bcr.3",
     "bzl.gawk---5.3.2.bcr.7",
     "bzl.gazelle---0.29.0",
     "bzl.gazelle---0.30.0",
@@ -743,16 +1103,32 @@ use_repo(
     "bzl.gazelle_rust---0.1.0",
     "bzl.gazelle_ts---0.4.18",
     "bzl.gcc_toolchain---0.9.3",
+    "bzl.gcem---1.18.0.bcr.1",
+    "bzl.gdk-pixbuf---2.44.4",
     "bzl.generate_export_header---0.1.0",
+    "bzl.geographiclib---2.4.0.bcr.2",
+    "bzl.geometry-central---1.0.0",
     "bzl.gflags---2.2.2.bcr.1",
+    "bzl.giflib---5.2.1.bcr.1",
     "bzl.git---2.54.0",
+    "bzl.glew---2.3.1",
+    "bzl.glfw---3.4.0.bcr.1",
+    "bzl.glfw---3.4.0.bcr.2",
+    "bzl.glib---2.82.2.bcr.4",
     "bzl.glib---2.82.2.bcr.5",
     "bzl.glib---2.82.2.bcr.6",
+    "bzl.glib---2.82.2.bcr.7",
     "bzl.glib---2.82.2.bcr.8",
+    "bzl.glm---1.0.1",
+    "bzl.glm---1.0.3",
+    "bzl.glog---0.5.0",
     "bzl.glog---0.6.0",
     "bzl.glog---0.7.0",
     "bzl.glog---0.7.1.bcr.1",
+    "bzl.glpk---5.0.bcr.4",
     "bzl.glpk---5.0.bcr.5",
+    "bzl.glu---9.0.3",
+    "bzl.gmp---6.2.0",
     "bzl.gmp---6.2.0.bcr.1",
     "bzl.gmp---6.3.0",
     "bzl.gmp---6.3.0.bcr.1",
@@ -772,7 +1148,6 @@ use_repo(
     "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
     "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
     "bzl.googleapis---0.0.0-20251003-2193a2bf",
-    "bzl.googleapis---0.0.0-20251104-53af3b72",
     "bzl.googleapis---0.0.0-20260130-c0fcb356",
     "bzl.googleapis---0.0.0-20260223-edfe7983",
     "bzl.googleapis---0.0.0-20260325-8b491c86",
@@ -787,8 +1162,12 @@ use_repo(
     "bzl.googletest---1.15.2",
     "bzl.googletest---1.17.0.bcr.2",
     "bzl.gotopt2---2.5.1",
+    "bzl.gperf---3.1",
     "bzl.gperf---3.1.bcr.1",
     "bzl.gperftools---2.18.1",
+    "bzl.graaf---1.1.1",
+    "bzl.graphite2---1.3.14",
+    "bzl.greatest---1.5.0",
     "bzl.grpc---1.41.0",
     "bzl.grpc---1.56.3.bcr.1",
     "bzl.grpc---1.68.0",
@@ -797,6 +1176,8 @@ use_repo(
     "bzl.grpc---1.71.0",
     "bzl.grpc---1.72.0",
     "bzl.grpc---1.73.1",
+    "bzl.grpc---1.74.0",
+    "bzl.grpc---1.74.0-pre2",
     "bzl.grpc---1.74.1",
     "bzl.grpc---1.76.0.bcr.1",
     "bzl.grpc---1.80.0",
@@ -812,6 +1193,9 @@ use_repo(
     "bzl.grpc_ecosystem_grpc_gateway---2.26.3",
     "bzl.grpc_ecosystem_grpc_gateway---2.29.0.bcr.3",
     "bzl.grpc_kotlin---1.5.0",
+    "bzl.gsl---4.2.1",
+    "bzl.gsl-lite---1.1.0",
+    "bzl.gtsam---4.2.0",
     "bzl.gutil---20260309.0.bcr.1",
     "bzl.gz-common---7.0.0",
     "bzl.gz-common---7.1.0",
@@ -830,9 +1214,12 @@ use_repo(
     "bzl.gz-sim---10.3.0",
     "bzl.gz-transport---15.0.0",
     "bzl.gz-transport---15.0.2",
+    "bzl.gz-utils---3.1.0",
     "bzl.gz-utils---4.0.0",
     "bzl.gzgz_rules_sass---1.0.4",
+    "bzl.happly---0.0.20240207",
     "bzl.harfbuzz---11.0.1.bcr.1",
+    "bzl.harfbuzz---14.1.0",
     "bzl.helly25_bashtest---0.1.0",
     "bzl.helly25_bashtest---0.2.0",
     "bzl.helly25_bzl---0.3.1",
@@ -843,22 +1230,37 @@ use_repo(
     "bzl.hermetic_launcher---0.0.3",
     "bzl.hermetic_launcher---0.0.5",
     "bzl.hermetic_launcher---0.0.8",
+    "bzl.hfsm2---2.10.0",
     "bzl.highs---1.11.0",
     "bzl.highs---1.14.0",
     "bzl.highway---1.2.0",
     "bzl.highway---1.3.0.bcr.1",
     "bzl.highwayhash---0.0.0-20240305-5ad3bf8.bcr.1",
+    "bzl.hiredis---1.3.0",
+    "bzl.howardhinnant_date---3.0.1",
     "bzl.hugooole_muda---1.0.0",
+    "bzl.hypothesis---0.0.0-20240425-3acfea6.bcr.1",
     "bzl.iceoryx---2.95.4",
     "bzl.iceoryx2---0.6.1",
+    "bzl.icestorm---1.1",
     "bzl.icu---76.1.bcr.3",
+    "bzl.icu---78.2",
     "bzl.imath---3.1.12.bcr.1",
     "bzl.imath---3.2.2.bcr.1",
+    "bzl.imgui---1.91.8",
+    "bzl.imgui---1.92.2",
+    "bzl.imgui---1.92.6-docking.bcr.1",
+    "bzl.implot---0.16",
+    "bzl.implot---0.17",
+    "bzl.implot3d---0.2",
+    "bzl.inno-lidar-sdk---3.103.4",
+    "bzl.iperf---3.18.0",
     "bzl.isl---0.27",
     "bzl.iverilog---13.0.bcr.1",
     "bzl.j2cl---20250630",
     "bzl.j2cl---20260402",
     "bzl.javacc---7.0.13.bcr.1",
+    "bzl.javaparser---3.26.2",
     "bzl.javaparser---3.27.0",
     "bzl.jeffmanzione_intern---1.0.2",
     "bzl.jeffmanzione_rzalloc---1.0.1",
@@ -870,6 +1272,8 @@ use_repo(
     "bzl.jsinterop_base---1.1.1",
     "bzl.jsinterop_base---1.2.0-RC1",
     "bzl.jsinterop_generator---20250910",
+    "bzl.json_spirit---4.0.8",
+    "bzl.jsoncons---1.0.0",
     "bzl.jsoncpp---1.9.5",
     "bzl.jsoncpp---1.9.6.bcr.2",
     "bzl.jsonnet---0.21.0",
@@ -878,64 +1282,127 @@ use_repo(
     "bzl.jsonnet_go---0.22.0",
     "bzl.jwt_verify_lib---0.0.0-20230517-b59e807",
     "bzl.kleidiai---0.0.0-20260506-d41219d3db",
+    "bzl.lanelet2---1.2.2.c20250822-f5fc98d.bcr.1",
     "bzl.lcm---1.5.2.bcr.1",
+    "bzl.lcov---2.3.2",
     "bzl.lexbor---2.4.0",
+    "bzl.lexy---2025.05.0",
     "bzl.libaio---0.3.113.bcr.0",
     "bzl.libarchive---3.8.1.bcr.2",
+    "bzl.libavif---1.4.1",
+    "bzl.libbacktrace---1.0.0-20250926-7939218",
     "bzl.libc_replacer---0.1.3",
+    "bzl.libcap---2.27.bcr.1",
+    "bzl.libcreate---3.1.0",
     "bzl.libde265---1.0.18",
     "bzl.libdeflate---1.23",
     "bzl.libdeflate---1.25",
     "bzl.libdwarf---0.12.0.bcr.1",
     "bzl.libdwarf---2.2.0",
+    "bzl.libedlib---1.2.7",
+    "bzl.libestr---0.1.11",
+    "bzl.libev---4.33",
     "bzl.libevent---2.1.12-stable.bcr.0",
+    "bzl.libexpat---2.7.1",
     "bzl.libexpat---2.7.1.bcr.1",
+    "bzl.libfastjson---1.2304.0",
+    "bzl.libffi---3.4.7.bcr.2",
     "bzl.libffi---3.4.7.bcr.3",
     "bzl.libffi---3.4.7.bcr.4",
+    "bzl.libfuse---3.16.2",
+    "bzl.libfuse---3.18.2",
+    "bzl.libgd---2.3.3",
+    "bzl.libgit2---1.9.2.bcr.1",
+    "bzl.libgpiod---1.6.3",
+    "bzl.libgps---3.27.5",
     "bzl.libheif---1.21.2",
+    "bzl.libigl---2.6.0",
+    "bzl.libjpeg_turbo---3.1.3.bcr.1",
+    "bzl.libjpeg_turbo---3.1.3.bcr.2",
     "bzl.libjpeg_turbo---3.1.3.bcr.4",
+    "bzl.libmagic---5.47",
+    "bzl.libmicrohttpd---1.0.2.bcr.1",
+    "bzl.libmodbus---3.1.12",
+    "bzl.libpaper---2.2.7",
+    "bzl.libpcap---1.10.5.bcr.1",
+    "bzl.libpcap---1.10.5.bcr.3",
     "bzl.libpfm---4.11.0",
     "bzl.libpng---1.6.41",
+    "bzl.libpng---1.6.44",
+    "bzl.libpng---1.6.50.bcr.1",
+    "bzl.libpng---1.6.53",
     "bzl.libpng---1.6.54",
     "bzl.libprotobuf-mutator---1.3",
-    "bzl.librdkafka---2.3.0.bcr.1",
+    "bzl.librdkafka---2.8.0.bcr.1",
+    "bzl.librdkafka---2.8.0.bcr.2",
     "bzl.libsodium---1.0.19",
+    "bzl.libssh2---1.11.1.bcr.1",
+    "bzl.libstemmer---2.2.0",
     "bzl.libtiff---4.7.1",
     "bzl.libunwind---1.8.1",
     "bzl.libunwind---1.8.3",
     "bzl.liburing---2.10",
+    "bzl.liburing---2.14",
     "bzl.liburing---2.5",
+    "bzl.libusb---1.0.28",
     "bzl.libuuid---2.39.3.bcr.1",
+    "bzl.libuuid---2.41.2",
+    "bzl.libuv---1.48.0.bcr.1",
     "bzl.libvpx---1.16.0.bcr.beta.1",
     "bzl.libwebm---1.0.0.32",
     "bzl.libwebp---1.5.0",
     "bzl.libwebp---1.6.0",
+    "bzl.libwebsockets---4.5.2",
+    "bzl.libx11---1.8.12.bcr.1",
+    "bzl.libx11---1.8.12.bcr.3",
+    "bzl.libx11---1.8.12.bcr.4",
     "bzl.libx11---1.8.12.bcr.5",
+    "bzl.libxau---1.0.12.bcr.1",
     "bzl.libxau---1.0.12.bcr.2",
+    "bzl.libxcb---1.17.0.bcr.1",
     "bzl.libxcb---1.17.0.bcr.2",
+    "bzl.libxcb-keysyms---0.4.1.bcr.1",
     "bzl.libxcrypt---4.4.36.bcr.1",
     "bzl.libxcursor---1.2.3",
+    "bzl.libxev---0.0.0-20251014.0-9f785d2",
     "bzl.libxext---1.3.6",
     "bzl.libxfixes---6.0.2",
     "bzl.libxi---1.8.2",
+    "bzl.libxinerama---1.1.5",
+    "bzl.libxml2---2.13.5",
+    "bzl.libxml2---2.14.4.bcr.1",
     "bzl.libxml2---2.15.1.bcr.1",
+    "bzl.libxml2---2.15.3",
+    "bzl.libxml2-go---0.0.0-20250331-c934e3f.bcr.1",
     "bzl.libxrandr---1.5.4",
     "bzl.libxrender---0.9.12",
+    "bzl.libxslt---1.1.43.bcr.1",
+    "bzl.libxtrans---1.5.2",
     "bzl.libxtrans---1.5.2.bcr.2",
     "bzl.libyaml---0.2.5",
     "bzl.libyuv---1787",
     "bzl.libzip---1.11.4.bcr.2",
     "bzl.libzmq---4.3.5.bcr.4",
+    "bzl.linenoise---2.0.0",
     "bzl.lit2md---1.0.1",
+    "bzl.livox_sdk2---1.2.5.bcr.2",
     "bzl.llvm---0.7.9",
     "bzl.llvm-project---17.0.3.bcr.4",
     "bzl.lobster---0.13.2",
+    "bzl.lttng-ust---2.14.0",
+    "bzl.lua---5.5.0",
+    "bzl.luajit---2.1.0-beta3",
+    "bzl.lunasvg---2.4.1.bcr.1",
+    "bzl.lz4---1.10.0",
     "bzl.lz4---1.10.0.bcr.1",
     "bzl.lz4---1.9.4.bcr.2",
     "bzl.lz4-erlang---1.9.2.5",
+    "bzl.lzo---2.10",
+    "bzl.m4---1.4.20.bcr.3",
     "bzl.m4---1.4.20.bcr.4",
     "bzl.m4---1.4.21",
     "bzl.m4---1.4.21.bcr.1",
+    "bzl.magic_enum---0.9.7",
     "bzl.magic_enum---0.9.8",
     "bzl.maliput---1.15.0",
     "bzl.maliput---1.16.0",
@@ -946,37 +1413,70 @@ use_repo(
     "bzl.masorange_rules_helm---1.7.1",
     "bzl.mbedtls---3.6.0.bcr.1",
     "bzl.mbedtls---3.6.5",
+    "bzl.mcap---2.1.3",
+    "bzl.mimalloc---2.2.4.bcr.2",
+    "bzl.mimick---0.9.0",
+    "bzl.minicoro---0.1.2",
+    "bzl.miniply---0.0.0-20220915-1a235c7",
+    "bzl.minitrace---0.0.0-20241021-242da50",
+    "bzl.miniz---3.1.1",
     "bzl.modern-cpp-kafka---2024.07.03.bcr.1",
+    "bzl.mold---2.40.4",
+    "bzl.mosquitto---2.1.2.bcr.2",
+    "bzl.mp-units---2.5.0.bcr.0",
+    "bzl.mpc---1.4.1.bcr.2",
     "bzl.mpfr---4.2.2",
+    "bzl.msgpack-c---7.0.0",
     "bzl.mvfst---2025.01.20.00.bcr.1",
     "bzl.nanobind---2.12.0.bcr.1",
     "bzl.nanobind_bazel---2.12.0",
+    "bzl.nanoflann---1.3.2",
+    "bzl.nanoflann---1.5.5",
     "bzl.nanopb---0.4.9.1.bcr.3",
-    "bzl.nasm---2.16.03",
+    "bzl.nasm---2.16.03.bcr.2",
     "bzl.nasm---2.16.03.bcr.3",
+    "bzl.ncurses---6.4.20221231.bcr.10",
     "bzl.ncurses---6.4.20221231.bcr.11",
+    "bzl.ncurses---6.4.20221231.bcr.3",
     "bzl.ncurses---6.4.20221231.bcr.4",
-    "bzl.ncurses---6.4.20221231.bcr.7",
+    "bzl.ncurses---6.4.20221231.bcr.8",
     "bzl.ncurses---6.4.20221231.bcr.9",
+    "bzl.nextpnr---0.9",
     "bzl.ng-log---0.8.0-rc1",
+    "bzl.nghttp2---1.65.0",
+    "bzl.ninjatracing---0.0.0-a669e3644cf2",
     "bzl.nlohmann_json---3.11.2",
     "bzl.nlohmann_json---3.11.3.bcr.1",
     "bzl.nlohmann_json---3.12.0.bcr.1",
     "bzl.nlohmann_json---3.6.1",
+    "bzl.nlopt---2.7.1",
+    "bzl.nmea---1.0",
     "bzl.nogo_analyzer_bzlmod---0.1.0",
+    "bzl.nonstd-span---0.11.0",
     "bzl.nsync---1.29.2",
+    "bzl.numactl---2.0.19.bcr.1",
+    "bzl.octomap---1.10.0",
     "bzl.octomap---1.9.7.bcr.1",
     "bzl.ode---0.16.6.bcr.1",
     "bzl.ofiuco---0.3.7",
     "bzl.ofiuco---0.9.0",
+    "bzl.ogg---1.3.5.bcr.1",
+    "bzl.ogre-next---2.3.3",
+    "bzl.ogre-next---2.3.3.bcr.2",
     "bzl.ogre-next---2.3.3.bcr.3",
+    "bzl.onednn---2.7.3",
+    "bzl.onetbb---2022.0.0",
     "bzl.onetbb---2022.2.0",
     "bzl.onetbb---2022.3.0",
+    "bzl.onnx---1.20.1",
+    "bzl.open-inference-protocol---0.0.0-20250512-d49cc23.bcr.1",
     "bzl.open62541---1.4.16",
+    "bzl.open62541pp---0.21.0",
     "bzl.openapi_tools_generator_bazel---0.2.3",
     "bzl.opencc---1.3.1",
     "bzl.opencensus-cpp---0.0.0-20230502-50eb5de.bcr.2",
     "bzl.opencensus-proto---0.4.1.bcr.2",
+    "bzl.opencl-sdk---2025.07.23",
     "bzl.openconfig_attestz---0.6.10",
     "bzl.openconfig_attestz---0.6.8",
     "bzl.openconfig_bootz---0.5.0",
@@ -993,7 +1493,11 @@ use_repo(
     "bzl.openfst---1.8.4.bcr.1",
     "bzl.opengl-registry---0.0.0-20250707",
     "bzl.openjph---0.26.3.bcr.1",
+    "bzl.openjph---0.27.3",
+    "bzl.openmp---21.1.5.bcr.2",
+    "bzl.openssh---9.9p1.bcr.2",
     "bzl.openssl---3.3.1.bcr.1",
+    "bzl.openssl---3.3.1.bcr.6",
     "bzl.openssl---3.3.1.bcr.9",
     "bzl.openssl---3.5.4.bcr.0",
     "bzl.openssl---3.5.4.bcr.1",
@@ -1001,6 +1505,7 @@ use_repo(
     "bzl.openssl---3.5.5.bcr.1",
     "bzl.openssl---3.5.5.bcr.3",
     "bzl.openssl---3.5.5.bcr.4",
+    "bzl.opentelemetry-cpp---1.14.2.bcr.1",
     "bzl.opentelemetry-cpp---1.16.0",
     "bzl.opentelemetry-cpp---1.19.0",
     "bzl.opentelemetry-cpp---1.24.0.bcr.1",
@@ -1012,18 +1517,31 @@ use_repo(
     "bzl.opentelemetry-proto---1.8.0",
     "bzl.opentracing-cpp---1.6.0",
     "bzl.openusd---25.11.bcr.3",
+    "bzl.openvdb---11.0.0.bcr.1",
     "bzl.opus---1.6.0",
     "bzl.or-tools---9.15",
+    "bzl.orocos-kdl---1.5.3",
+    "bzl.osqp---1.0.0",
     "bzl.osqp---1.0.0.bcr.2",
     "bzl.osqp-eigen---0.10.3",
     "bzl.p4_constraints---20260311.0",
     "bzl.p4c---1.2.5.11.bcr.1",
     "bzl.p4runtime---1.5.0.bcr.1",
+    "bzl.package_metadata---0.0.1",
     "bzl.package_metadata---0.0.2",
     "bzl.package_metadata---0.0.3",
+    "bzl.paho.mqtt.c---1.3.14",
+    "bzl.paho.mqtt.c---1.3.14.bcr.1",
+    "bzl.paho.mqtt.cpp---1.5.2",
+    "bzl.papilo---3.0.0",
+    "bzl.patch---2.8.bcr.1",
     "bzl.pathkit---1.0.1.1",
+    "bzl.pcg---0.98.1.bcr.1",
+    "bzl.pcl---1.15.1.bcr.3",
     "bzl.pcre2---10.43",
+    "bzl.pcre2---10.45",
     "bzl.pcre2---10.46-DEV",
+    "bzl.pegtl---3.2.8",
     "bzl.periphery---3.7.4",
     "bzl.phtree-cpp---1.7.0",
     "bzl.pico-sdk---2.1.0",
@@ -1031,9 +1549,13 @@ use_repo(
     "bzl.picotool---2.1.0",
     "bzl.picotool---2.2.0",
     "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
+    "bzl.pict---3.7.4",
+    "bzl.pinocchio---2.6.21.bcr.7",
     "bzl.pixelmatch-cpp17---1.0.3",
     "bzl.pixman---0.46.4",
+    "bzl.pkg-config---0.29.2.bcr.1",
     "bzl.platforms---0.0.10",
+    "bzl.platforms---0.0.11",
     "bzl.platforms---0.0.4",
     "bzl.platforms---0.0.5",
     "bzl.platforms---0.0.6",
@@ -1044,9 +1566,22 @@ use_repo(
     "bzl.platforms---1.1.0",
     "bzl.platforms_contrib---0.2.3",
     "bzl.plyodine---1.1.1",
+    "bzl.pocketfft---0.0.2",
+    "bzl.poco---1.14.2-20250528.bcr.1",
+    "bzl.polyscope---2.4.0-20250430",
+    "bzl.poppler---24.04.0",
+    "bzl.popt---1.19",
     "bzl.portable_cc_toolchain---2025.12.16",
+    "bzl.portaudio---19.7.0.bcr.3",
+    "bzl.postgres---16.2.bcr.3",
+    "bzl.pplib---2.2",
+    "bzl.ppp---2.5.2",
     "bzl.prismo---0.1.4",
+    "bzl.prjtrellis---1.4",
+    "bzl.prjtrellis-db---1.4",
+    "bzl.procps-ng---4.0.5",
     "bzl.prodrive_technologies_bazel_latex---1.2.2-20250401-c552d5b",
+    "bzl.proj---9.8.0",
     "bzl.prometheus-cpp---1.2.4",
     "bzl.prometheus-cpp---1.3.0.bcr.2",
     "bzl.proto-converter---0.0.0-20230607-d77ff30",
@@ -1068,12 +1603,14 @@ use_repo(
     "bzl.protobuf---33.4",
     "bzl.protobuf---33.5",
     "bzl.protobuf---34.0.bcr.1",
+    "bzl.protobuf---34.0-rc1",
     "bzl.protobuf---34.1",
     "bzl.protobuf---35.0",
     "bzl.protobuf-matchers---0.1.1",
     "bzl.protobuf-matchers---0.1.2",
     "bzl.protoc-gen-validate---1.0.4.bcr.2",
     "bzl.protoc-gen-validate---1.2.1.bcr.2",
+    "bzl.protoc-gen-validate---1.3.0",
     "bzl.protoc-gen-validate---1.3.3",
     "bzl.protothreads---0.1.6",
     "bzl.protovalidate---1.1.1",
@@ -1081,6 +1618,7 @@ use_repo(
     "bzl.protovalidate-cc---1.1.0",
     "bzl.proxy-wasm-cpp-sdk---0.0.0-20260123-894dd29",
     "bzl.proxy-wasm-rust-sdk---0.2.5",
+    "bzl.proxygen---2025.02.10.00.bcr.1",
     "bzl.psmisc---23.7",
     "bzl.pthreadpool---0.0.0-20260119-9003ee6",
     "bzl.pugixml---1.15",
@@ -1093,30 +1631,51 @@ use_repo(
     "bzl.pybind11_bazel---3.0.1",
     "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
-    "bzl.qdldl---0.1.7.bcr.1",
+    "bzl.pystring---1.1.4",
+    "bzl.qdldl---0.1.8",
+    "bzl.qdldl---0.1.8.bcr.1",
+    "bzl.qhull---8.0.2",
+    "bzl.qhull---8.0.2.bcr.1",
+    "bzl.quickjs-ng---0.13.0",
     "bzl.quill---11.1.0",
+    "bzl.ragel---26.04.0-20260414092900-8841e561489e",
     "bzl.range-v3---0.12.0",
     "bzl.range-v3---0.12.1-20260505-108f93c",
     "bzl.rapidjson---1.1.0.bcr.20241007",
     "bzl.rapidjson---1.1.0.bcr.20250205",
     "bzl.rapidyaml---0.12.1",
     "bzl.rapidyaml---0.9.0",
+    "bzl.rawrtc---0.5.2",
+    "bzl.rawrtc_common---0.1.3",
+    "bzl.rawrtc_data_channel---0.1.4",
+    "bzl.rawrtc_re---0.6.0-3",
+    "bzl.rawrtc_rew---0.6.0-3",
+    "bzl.rawrtc_usrsctp---1.0.0-td113",
     "bzl.re.bzl---0.3.1",
     "bzl.re2---2021-09-01",
     "bzl.re2---2023-09-01",
-    "bzl.re2---2024-07-01",
+    "bzl.re2---2024-06-01",
     "bzl.re2---2024-07-02.bcr.1",
     "bzl.re2---2025-08-12.bcr.1",
     "bzl.re2---2025-11-05.bcr.1",
     "bzl.readerwriterqueue---1.0.6",
     "bzl.readline---8.3",
+    "bzl.readline---8.3.bcr.1",
+    "bzl.redis---8.6.2",
+    "bzl.reflexxes-rmltype2---1.2.7",
     "bzl.remotery---1.0.0",
+    "bzl.reproc---14.2.5",
     "bzl.riegeli---0.0.0-20240927-cdfb25a",
     "bzl.riegeli---0.0.0-20250822-9f2744d",
+    "bzl.roaring---4.3.11",
     "bzl.robin-map---1.4.0",
+    "bzl.roboticslibrary.rl---0.0.0-20250723-5bbd773.bcr.4",
     "bzl.rocksdb---9.11.2",
+    "bzl.rply---1.1.4",
     "bzl.rpmpack---0.6.0",
     "bzl.rsync---3.4.2",
+    "bzl.rsyslog---8.2504.0",
+    "bzl.rtipc---1.0.4",
     "bzl.ruff_prebuilt---0.15.12.1",
     "bzl.rules_abs---0.1.0",
     "bzl.rules_android---0.1.1",
@@ -1145,7 +1704,9 @@ use_repo(
     "bzl.rules_apple_remote_xcframework---0.5.2",
     "bzl.rules_auto_dotnet---0.3.5",
     "bzl.rules_autoconf---0.0.14",
+    "bzl.rules_autoconf---0.0.15",
     "bzl.rules_autoconf---0.0.16",
+    "bzl.rules_autoconf---0.0.9",
     "bzl.rules_batch---0.0.1",
     "bzl.rules_bazel_integration_test---0.37.1",
     "bzl.rules_bison---0.3",
@@ -1159,13 +1720,16 @@ use_repo(
     "bzl.rules_build_error---0.11.0",
     "bzl.rules_c_proto---0.1.0",
     "bzl.rules_cc---0.0.1",
+    "bzl.rules_cc---0.0.11",
     "bzl.rules_cc---0.0.12",
     "bzl.rules_cc---0.0.2",
     "bzl.rules_cc---0.0.6",
     "bzl.rules_cc---0.0.8",
     "bzl.rules_cc---0.0.9",
+    "bzl.rules_cc---0.1.0",
     "bzl.rules_cc---0.1.1",
     "bzl.rules_cc---0.1.2",
+    "bzl.rules_cc---0.1.3",
     "bzl.rules_cc---0.1.4",
     "bzl.rules_cc---0.1.5",
     "bzl.rules_cc---0.2.0",
@@ -1183,11 +1747,16 @@ use_repo(
     "bzl.rules_cc---0.2.9",
     "bzl.rules_cc_autoconf---0.10.0",
     "bzl.rules_cc_autoconf---0.10.1",
+    "bzl.rules_cc_autoconf---0.10.2",
     "bzl.rules_cc_autoconf---0.10.3",
     "bzl.rules_cc_autoconf---0.11.0",
+    "bzl.rules_cc_autoconf---0.5.3",
+    "bzl.rules_cc_autoconf---0.5.4",
     "bzl.rules_cc_autoconf---0.5.5",
     "bzl.rules_cc_autoconf---0.5.6",
+    "bzl.rules_cc_autoconf---0.7.14",
     "bzl.rules_cc_autoconf---0.7.15",
+    "bzl.rules_cc_autoconf---0.8.0",
     "bzl.rules_cc_autoconf---0.9.0",
     "bzl.rules_cc_hdrs_map---0.31.1",
     "bzl.rules_cc_resources---0.3.0",
@@ -1203,6 +1772,7 @@ use_repo(
     "bzl.rules_cpan---1.1.0",
     "bzl.rules_cuda---0.2.4",
     "bzl.rules_cuda---0.3.0",
+    "bzl.rules_cuda---0.3.0-beta1",
     "bzl.rules_cue---0.18.0",
     "bzl.rules_d---0.10.0",
     "bzl.rules_dart---0.2.2",
@@ -1226,6 +1796,7 @@ use_repo(
     "bzl.rules_flex---0.4",
     "bzl.rules_flex---0.4.1",
     "bzl.rules_foreign_cc---0.12.0",
+    "bzl.rules_foreign_cc---0.13.0",
     "bzl.rules_foreign_cc---0.9.0",
     "bzl.rules_formatjs---0.6.0",
     "bzl.rules_fuzzing---0.5.2",
@@ -1273,6 +1844,7 @@ use_repo(
     "bzl.rules_java---4.0.0",
     "bzl.rules_java---5.3.5",
     "bzl.rules_java---5.5.0",
+    "bzl.rules_java---6.0.0",
     "bzl.rules_java---6.1.0",
     "bzl.rules_java---6.3.0",
     "bzl.rules_java---6.4.0",
@@ -1372,6 +1944,7 @@ use_repo(
     "bzl.rules_openscad---0.1",
     "bzl.rules_pact---1.1.9",
     "bzl.rules_perl---0.2.4",
+    "bzl.rules_perl---0.4.1",
     "bzl.rules_perl---0.5.0",
     "bzl.rules_perl---0.6.7",
     "bzl.rules_perl---1.0.0",
@@ -1397,7 +1970,6 @@ use_repo(
     "bzl.rules_proto---5.3.0-21.7",
     "bzl.rules_proto---6.0.0-rc1",
     "bzl.rules_proto---6.0.2",
-    "bzl.rules_proto---7.0.0",
     "bzl.rules_proto---7.0.2",
     "bzl.rules_proto---7.1.0",
     "bzl.rules_proto_grpc---5.0.0",
@@ -1416,14 +1988,14 @@ use_repo(
     "bzl.rules_proto_grpc_python---5.8.0",
     "bzl.rules_proto_grpc_scala---5.8.0",
     "bzl.rules_proto_grpc_swift---5.8.0",
+    "bzl.rules_pycross---0.8.1",
     "bzl.rules_pycross---0.8.2",
     "bzl.rules_pydeps---0.5.0",
     "bzl.rules_python---0.10.2",
-    "bzl.rules_python---0.32.0",
     "bzl.rules_python---0.4.0",
     "bzl.rules_python---1.7.0",
-    "bzl.rules_python_gazelle_plugin---1.5.0-rc0",
     "bzl.rules_python_gazelle_plugin---1.5.1",
+    "bzl.rules_python_gazelle_plugin---1.5.3",
     "bzl.rules_qemu---0.1.1",
     "bzl.rules_qt---0.0.6",
     "bzl.rules_req_compile---1.1.0",
@@ -1436,8 +2008,8 @@ use_repo(
     "bzl.rules_ruby---0.19.0",
     "bzl.rules_ruby---0.26.0",
     "bzl.rules_runfiles_group---0.0.1-rc.5",
+    "bzl.rules_rust---0.39.0",
     "bzl.rules_rust---0.45.1",
-    "bzl.rules_rust---0.46.0",
     "bzl.rules_rust---0.51.0",
     "bzl.rules_rust_mutants---0.69.1",
     "bzl.rules_rust_mutation---0.69.0",
@@ -1514,41 +2086,56 @@ use_repo(
     "bzl.rules_webtesting---0.4.1",
     "bzl.rules_xcodeproj---4.1.0",
     "bzl.rules_ytt---0.4.0",
+    "bzl.rules_zig---0.12.1",
     "bzl.rules_zig---0.15.1",
     "bzl.ruy---0.0.0-20200416-9f53ba4",
     "bzl.ryandraves_nlb---0.1.0",
     "bzl.s2geometry---0.14.0",
     "bzl.safedi---2.0.0",
+    "bzl.safeint---3.0.28",
     "bzl.sajson---0.0.0-20210905003841-ec644013e34f",
     "bzl.scip---9.2.3",
     "bzl.sdformat---16.0.0",
     "bzl.sdformat---16.0.1",
     "bzl.sdl2---2.32.0.bcr.beta.5",
     "bzl.sdl2_mixer---2.8.1.bcr.beta.2",
+    "bzl.seastar---26.03.0-20260302212502-e639df376395",
+    "bzl.sed---4.9.bcr.1",
     "bzl.sed---4.9.bcr.3",
     "bzl.sed---4.9.bcr.5",
     "bzl.sha256.bzl---0.0.1",
+    "bzl.simde---0.8.2",
+    "bzl.simdutf---7.7.0",
     "bzl.simplehttp---0.2.0",
     "bzl.skcms---20250916.0.bcr.1",
     "bzl.skywalking-data-collect-protocol---10.3.0",
     "bzl.snappy---1.2.0",
     "bzl.snappy---1.2.2.bcr.3",
-    "bzl.soplex---7.1.3",
+    "bzl.sockpp---1.0.0-20260101-b8e19c8",
+    "bzl.soplex---7.1.4.bcr.1",
+    "bzl.soplex---7.1.4.bcr.4",
     "bzl.sourcekit_bazel_bsp---0.8.3",
     "bzl.sourcekitten---0.37.2",
     "bzl.sourcekitten---0.37.3",
     "bzl.sparrowhawk---2.1.0",
     "bzl.spdlog---1.10.0",
     "bzl.spdlog---1.12.0",
+    "bzl.spdlog---1.15.2",
     "bzl.spdlog---1.15.3",
     "bzl.spdlog---1.17.0",
     "bzl.sphinxdocs---2.0.1",
     "bzl.spirv_headers---1.4.341.0",
     "bzl.spirv_tools---2026.1",
     "bzl.sqids_bazel---0.1.0",
+    "bzl.sqlite3---3.49.1",
+    "bzl.sqlite3---3.50.2",
     "bzl.sqlite3---3.50.3",
+    "bzl.sqlite3---3.51.2",
     "bzl.sqlite3---3.51.2.bcr.1",
+    "bzl.sqlite_orm---1.9.1.bcr.1",
     "bzl.squashfs-tools---4.7.4",
+    "bzl.squashfs-tools---4.7.5",
+    "bzl.squashfuse---0.5.2",
     "bzl.stardoc---0.5.0",
     "bzl.stardoc---0.5.1",
     "bzl.stardoc---0.5.3",
@@ -1560,10 +2147,14 @@ use_repo(
     "bzl.stardoc---0.7.2",
     "bzl.stardoc---0.8.0",
     "bzl.stardoc---0.8.1",
+    "bzl.stb---0.0.0-20241109-5c20573",
+    "bzl.stb---0.0.0-20251026-f1c79c0",
     "bzl.subspace---2.7.0",
+    "bzl.suitesparse---7.10.1.bcr.3",
     "bzl.supply-chain-go---0.0.10",
     "bzl.supply-chain-go---0.0.6",
     "bzl.supply_chain_tools---0.0.1",
+    "bzl.sv-lang---10.0.0",
     "bzl.swift-filename-matcher---2.0.1",
     "bzl.swift-index-store---1.10.0",
     "bzl.swift-indexstore---0.5.0",
@@ -1572,7 +2163,6 @@ use_repo(
     "bzl.swift-system---1.6.4.bcr.1",
     "bzl.swift-tomldecoder---0.4.4",
     "bzl.swift_argument_parser---1.3.1.2",
-    "bzl.swift_argument_parser---1.5.0",
     "bzl.swift_argument_parser---1.7.0",
     "bzl.swift_bep_parser---0.0.6",
     "bzl.swift_gazelle_plugin---0.2.2",
@@ -1580,6 +2170,8 @@ use_repo(
     "bzl.swig---4.2.0",
     "bzl.swig---4.3.0.bcr.2",
     "bzl.swxmlhash---7.0.2.2",
+    "bzl.symengine---0.12.0",
+    "bzl.systemc---3.0.2",
     "bzl.systemc---3.0.2.bcr.1",
     "bzl.systemd---260.1",
     "bzl.tar.bzl---0.10.1",
@@ -1590,19 +2182,30 @@ use_repo(
     "bzl.tar.bzl---0.6.0",
     "bzl.tar.bzl---0.7.0",
     "bzl.tar.bzl---0.9.0",
+    "bzl.tcl_lang---8.6.16",
     "bzl.tcl_lang---8.6.16.bcr.1",
     "bzl.tcl_lang---9.0.2.bcr.1",
     "bzl.tclap---1.2.5.bcr.1",
+    "bzl.tclreadline---2.4.1",
     "bzl.tcmalloc---0.0.0-20250927-12f2552",
+    "bzl.tcpdump---4.99.6",
+    "bzl.teckit---2.5.12",
     "bzl.textforge---1.0.0",
+    "bzl.tftp-hpa---5.2",
+    "bzl.thorvg---1.0.3",
     "bzl.thrax---1.3.9.bcr.1",
     "bzl.tink_cc---2.3.0",
     "bzl.tink_cc---2.7.0",
+    "bzl.tinygltf---2.9.6",
     "bzl.tinyobjloader---2.0.0-rc1.bcr.2",
     "bzl.tinyply---3.0",
     "bzl.tinyxml---2.6.2",
+    "bzl.tinyxml---2.6.2.bcr.1",
     "bzl.tinyxml2---10.0.0",
+    "bzl.tinyxml2---11.0.0",
     "bzl.tinyxml2---9.0.0",
+    "bzl.tl-expected---1.3.1",
+    "bzl.tl-optional---1.1.0",
     "bzl.toml.bzl---0.3.0",
     "bzl.toml.bzl---0.4.1",
     "bzl.toolchain_utils---1.0.0-beta.9",
@@ -1611,7 +2214,7 @@ use_repo(
     "bzl.toolchains_avr---0.1.2",
     "bzl.toolchains_buildbuddy---0.0.4",
     "bzl.toolchains_llvm---1.7.0",
-    "bzl.toolchains_llvm_bootstrapped---0.2.3",
+    "bzl.toolchains_llvm_bootstrapped---0.5.6",
     "bzl.toolchains_musl---0.1.27.bcr.1",
     "bzl.toolchains_protoc---0.2.1",
     "bzl.toolchains_protoc---0.3.1",
@@ -1619,24 +2222,39 @@ use_repo(
     "bzl.toolchains_protoc---0.6.1",
     "bzl.toolchains_riscv_gnu---1.0.0",
     "bzl.tools_android---0.3.2",
+    "bzl.toybox---0.8.12.bcr.1",
     "bzl.tree-sitter-bazel---0.24.4",
     "bzl.tree-sitter-bazel---0.26.5",
     "bzl.tree-sitter-c-bazel---0.23.4",
+    "bzl.triton-inference-server-common---0.0.0-20251104-c09e98a",
     "bzl.trlc---2.0.4",
+    "bzl.trompeloeil---49",
     "bzl.tweag-credential-helper---0.0.9",
     "bzl.ultrajson---5.10.0",
+    "bzl.uncrustify---0.82.0",
+    "bzl.universal-robots-client-library---2.4.0",
     "bzl.upb---0.0.0-20220923-a547704",
     "bzl.upb---0.0.0-20230516-61a97ef",
     "bzl.upb---0.0.0-20230907-e7430e6",
+    "bzl.urdfdom---2.3.4.bcr.1",
+    "bzl.urdfdom_headers---1.0.5",
+    "bzl.userspace_rcu---0.15.4",
+    "bzl.uthash---2.3.0",
     "bzl.verible---0.0.3933",
     "bzl.verilator---5.036.bcr.3",
     "bzl.verilator---5.046.bcr.3",
     "bzl.verilator---5.046.bcr.4",
     "bzl.version_utils---0.1.0",
     "bzl.vhdl_ls_gen---0.3.0",
+    "bzl.videoproto---2.3.3",
+    "bzl.vulkan_headers---1.4.349",
+    "bzl.vulkan_utility_libraries---1.4.349",
     "bzl.wabt---1.0.37",
     "bzl.wangle---2025.02.10.00.bcr.2",
     "bzl.wayland---1.24.0.bcr.1",
+    "bzl.webgpu_headers---0.0.0-20260319-7d3186c",
+    "bzl.websocketpp---0.8.2.bcr.3",
+    "bzl.websocketpp---0.8.2.bcr.5",
     "bzl.websocketpp---0.8.2.bcr.6",
     "bzl.wheelos_common_msgs---0.1.2",
     "bzl.windows_support---0.1.7",
@@ -1645,13 +2263,21 @@ use_repo(
     "bzl.with_cfg.bzl---0.14.6",
     "bzl.wolfd_bazel_compile_commands---0.5.2",
     "bzl.x264---2023.10.1.bcr.2",
+    "bzl.x265---4.1",
     "bzl.xcb-proto---1.17.0",
     "bzl.xcodeproj---9.10.1",
     "bzl.xds---0.0.0-20240423-555b57e",
     "bzl.xds---0.0.0-20251210-ee656c7",
+    "bzl.xilinx_bootgen---2025.2",
     "bzl.xkbcommon---1.9.2.bcr.beta.1",
     "bzl.xml.bzl---0.2.3",
     "bzl.xorgproto---2024.1.bcr.1",
+    "bzl.xpdf---4.06",
+    "bzl.xtensor---0.27.1",
+    "bzl.xtl---0.8.0",
+    "bzl.xtl---0.8.1",
+    "bzl.xxd---9.1.0917",
+    "bzl.xxd---9.1.0917.bcr.1",
     "bzl.xxhash---0.8.3.bcr.1",
     "bzl.xz---5.4.5.bcr.5",
     "bzl.xz---5.4.5.bcr.6",
@@ -1662,14 +2288,19 @@ use_repo(
     "bzl.yaml-cpp---0.9.0",
     "bzl.yams---6.2.0",
     "bzl.yams---6.2.1",
+    "bzl.yoga---2.0.1",
     "bzl.yosys---0.63",
     "bzl.yq.bzl---0.1.1",
     "bzl.yq.bzl---0.3.1",
     "bzl.yq.bzl---0.3.2",
     "bzl.yq.bzl---0.3.4",
     "bzl.yq.bzl---0.3.6",
+    "bzl.yyjson---0.10.0",
     "bzl.z3---4.15.2",
     "bzl.zenoh-c---1.7.2.bcr.1",
+    "bzl.zenoh-cpp---1.7.2.bcr.1",
+    "bzl.zenoh-pico---1.7.2",
+    "bzl.zip---3.0",
     "bzl.zipkin-api---1.0.0.bcr.1",
     "bzl.zlib---1.2.11",
     "bzl.zlib---1.2.12",
@@ -1677,11 +2308,14 @@ use_repo(
     "bzl.zlib---1.3.1.bcr.8",
     "bzl.zlib---1.3.2",
     "bzl.zlib-ng---2.0.7",
+    "bzl.zlib-ng---2.3.3",
     "bzl.zstd---1.5.6",
     "bzl.zstd---1.5.7.bcr.1",
     "bzl.zstd-jni---1.5.6-9",
     "bzl.zstr---1.0.7",
+    "bzl.zstr---1.1.0",
     "bzl.zsync3---0.0.3",
+    "bzl.zziplib---0.13.72",
 )
 
 http_archive(
@@ -19474,23 +20108,55 @@ http_file(
     urls = ["https://github.com/yuyawk/rules_build_error/releases/download/0.11.0/source.json.intoto.jsonl"],
 )
 
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.abc---0.64-yosyshq.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/abc/0.64-yosyshq.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.abc---0.62-yosyshq",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abc-0.62",
-    type = "zip",
-    urls = ["https://github.com/YosysHQ/abc/archive/refs/tags/v0.62.zip"],
+    path = "data/bazel-central-registry/modules/abc/0.62-yosyshq/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    name = "bzl.abseil-cpp---20250814.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240722.0",
+    strip_prefix = "abseil-cpp-20250814.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20230802.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20230802.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20230125.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20230125.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250127.0",
@@ -19502,31 +20168,40 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250512.0",
+    name = "bzl.abseil-cpp---20240116.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250512.0",
+    strip_prefix = "abseil-cpp-20240116.2",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.0/abseil-cpp-20250512.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250127.1",
+    name = "bzl.abseil-cpp---20250814.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250127.1",
+    strip_prefix = "abseil-cpp-20250814.2",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230125.1",
+    name = "bzl.abseil-cpp---20260107.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230125.1",
+    strip_prefix = "abseil-cpp-20260107.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20260107.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20260107.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20210324.2",
@@ -19547,13 +20222,13 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.2",
+    name = "bzl.abseil-cpp---20250512.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.2",
+    strip_prefix = "abseil-cpp-20250512.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.0/abseil-cpp-20250512.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250814.1",
@@ -19565,15 +20240,6 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20260107.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20260107.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.abseil-cpp---20230802.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -19581,51 +20247,6 @@ starlark_repository.archive(
     strip_prefix = "abseil-cpp-20230802.1",
     type = "tar.gz",
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.2",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20211102.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20211102.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20260107.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20260107.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250512.1",
@@ -19637,13 +20258,40 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.0",
+    name = "bzl.abseil-cpp---20250127.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.0",
+    strip_prefix = "abseil-cpp-20250127.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20211102.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20211102.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240722.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240722.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240722.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240722.2",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240722.2/abseil-cpp-20240722.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-py---2.1.0",
@@ -19663,6 +20311,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.4.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.ada-url---3.4.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ada-url/3.4.4/overlay",
+)
 starlark_repository.archive(
     name = "bzl.aexml---4.7.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -19672,23 +20327,35 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/tadija/AEXML/archive/refs/tags/4.7.0.zip"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.alsa_lib---1.2.9.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "alsa-lib-1.2.9",
-    type = "tar.bz2",
-    urls = ["https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.9.tar.bz2"],
+    path = "data/bazel-central-registry/modules/alsa_lib/1.2.9.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.antlr4-cpp-runtime---4.13.1",
+starlark_repository.local(
+    name = "bzl.alsa_lib---1.2.9.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "antlr4-4.13.1/runtime/Cpp",
+    path = "data/bazel-central-registry/modules/alsa_lib/1.2.9.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.amqp-cpp---4.3.27",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/amqp-cpp/4.3.27/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.antlr4-cpp-runtime---4.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "antlr4-4.13.0/runtime/Cpp",
     type = "tar.gz",
-    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.1.tar.gz"],
+    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.aom---3.13.3",
@@ -19696,15 +20363,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/aom/3.13.3/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.ape---1.0.0-beta.12",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ape-v1.0.0-beta.12",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-beta.12/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ape---1.0.1",
@@ -19716,13 +20374,13 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_rules_lint---0.3.2",
+    name = "bzl.ape---1.0.0-beta.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "apple_rules_lint-0.3.2",
+    strip_prefix = "ape-v1.0.0-beta.12",
     type = "tar.gz",
-    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
+    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-beta.12/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_rules_lint---0.4.0",
@@ -19734,12 +20392,149 @@ starlark_repository.archive(
     urls = ["https://github.com/apple/apple_rules_lint/releases/download/0.4.0/apple_rules_lint-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.apple_rules_lint---0.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "apple_rules_lint-0.3.2",
+    type = "tar.gz",
+    urls = ["https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.15.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.18.0/apple_support.1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.22.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.21.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.22.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.0/apple_support.1.22.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.apple_support---2.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.17.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.23.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---2.4.0",
@@ -19758,46 +20553,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.21.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.15.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.23.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.apple_support---1.23.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -19805,77 +20560,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.0/apple_support.1.23.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.apple_support---1.17.1",
+starlark_repository.local(
+    name = "bzl.apriltag---3.4.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/apriltag/3.4.5/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.apple_support---1.8.1",
+starlark_repository.local(
+    name = "bzl.ar_hosek_sky_model---1.4.a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/ar_hosek_sky_model/1.4.a/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.5",
+starlark_repository.local(
+    name = "bzl.aravis---0.9.2-20251111063445-57983d013883",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.22.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/aravis/0.9.2-20251111063445-57983d013883/overlay",
 )
 starlark_repository.archive(
     name = "bzl.argparse---3.2.0",
@@ -19896,15 +20600,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aaronsky/asc-swift/releases/download/1.6.0/asc_swift-1.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.asio---1.32.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "asio-asio-1-32-0",
-    type = "tar.gz",
-    urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-32-0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.asio---1.28.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -19912,6 +20607,41 @@ starlark_repository.archive(
     strip_prefix = "asio-asio-1-28-2/asio/include",
     type = "zip",
     urls = ["https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-28-2.zip"],
+)
+starlark_repository.local(
+    name = "bzl.asio---1.32.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/asio/1.32.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.asio---1.34.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/asio/1.34.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.asio---1.34.2.bcr.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/asio/1.34.2.bcr.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.asio---1.34.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/asio/1.34.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.asio-grpc---3.1.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/asio-grpc/3.1.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.3.0",
@@ -19923,24 +20653,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.16.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -19948,24 +20660,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.13.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.9.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.9.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.38.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.38.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.11.0",
@@ -19977,24 +20671,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.9.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20002,60 +20678,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.9.3",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.14.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.14.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.7",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---1.42.3",
@@ -20067,6 +20689,78 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.16.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.9.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.9.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20074,6 +20768,42 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-2.8.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.7",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.38.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.38.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.14.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.14.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_gazelle_prebuilt---0.0.11",
@@ -20103,15 +20833,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_cypress/releases/download/v0.7.2/rules_cypress-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_esbuild---0.26.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_esbuild-0.26.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.26.0/rules_esbuild-v0.26.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_esbuild---0.21.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20119,6 +20840,15 @@ starlark_repository.archive(
     strip_prefix = "rules_esbuild-0.21.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_esbuild---0.26.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_esbuild-0.26.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.26.0/rules_esbuild-v0.26.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_jasmine---2.0.4",
@@ -20139,31 +20869,58 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_jest/releases/download/v0.25.2/rules_jest-v0.25.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.42.0",
+    name = "bzl.aspect_rules_js---1.34.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.42.0",
+    strip_prefix = "rules_js-1.34.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.39.0",
+    name = "bzl.aspect_rules_js---2.3.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.39.0",
+    strip_prefix = "rules_js-2.3.8",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---3.0.3",
+    name = "bzl.aspect_rules_js---1.34.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-3.0.3",
+    strip_prefix = "rules_js-1.34.1",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.3/rules_js-v3.0.3.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.9.2",
@@ -20173,15 +20930,6 @@ starlark_repository.archive(
     strip_prefix = "rules_js-2.9.2",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.9.2/rules_js-v2.9.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.1.3",
@@ -20202,31 +20950,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.1.2/rules_js-v3.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.0.0",
+    name = "bzl.aspect_rules_js---1.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.0.0",
+    strip_prefix = "rules_js-1.40.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.2",
+    name = "bzl.aspect_rules_js---1.39.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.2",
+    strip_prefix = "rules_js-1.39.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.39.0/rules_js-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.7.0",
@@ -20238,13 +20977,31 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---3.0.1",
+    name = "bzl.aspect_rules_js---2.6.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-3.0.1",
+    strip_prefix = "rules_js-2.6.2",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---3.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-3.0.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.3/rules_js-v3.0.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.42.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.42.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.42.0/rules_js-v1.42.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.3.5",
@@ -20256,13 +21013,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.1.2",
+    name = "bzl.aspect_rules_js---2.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.1.2",
+    strip_prefix = "rules_js-2.0.2",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.3.3",
@@ -20274,58 +21040,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.3/rules_js-v2.3.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.0.2",
+    name = "bzl.aspect_rules_js---3.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.0.2",
+    strip_prefix = "rules_js-3.0.1",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.3.8",
+    name = "bzl.aspect_rules_js---2.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.3.8",
+    strip_prefix = "rules_js-2.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.40.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js_rust_wasm_bindgen---0.0.2",
@@ -20345,15 +21075,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_lint---1.0.0-rc4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_lint-1.0.0-rc4",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v1.0.0-rc4/rules_lint-v1.0.0-rc4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_lint---2.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20363,13 +21084,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_lint/releases/download/v2.5.2/rules_lint-v2.5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_py---1.8.4",
+    name = "bzl.aspect_rules_lint---1.0.0-rc4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_py-1.8.4",
+    strip_prefix = "rules_lint-1.0.0-rc4",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.8.4/rules_py-v1.8.4.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v1.0.0-rc4/rules_lint-v1.0.0-rc4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.11.5",
@@ -20379,6 +21100,15 @@ starlark_repository.archive(
     strip_prefix = "rules_py-1.11.5",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.11.5/rules_py-v1.11.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_py---1.8.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_py-1.8.4",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_py/releases/download/v1.8.4/rules_py-v1.8.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.0.0",
@@ -20417,15 +21147,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_terser/releases/download/v2.1.0/rules_terser-v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.6.0/rules_ts-v3.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20453,6 +21174,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_ts---3.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ts-3.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.6.0/rules_ts-v3.6.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20471,15 +21201,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_webpack/releases/download/v0.17.1/rules_webpack-v0.17.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_tools_telemetry---0.2.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tools_telemetry-0.2.8",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_tools_telemetry---0.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20489,13 +21210,41 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.3.3/tools_telemetry-v0.3.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_tools_telemetry---0.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tools_telemetry-0.2.8",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.assimp---6.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/assimp/6.0.3/overlay",
+)
+starlark_repository.local(
     name = "bzl.assimp---5.4.3.bcr.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assimp-5.4.3",
-    type = "tar.gz",
-    urls = ["https://github.com/assimp/assimp/archive/refs/tags/v5.4.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/assimp/5.4.3.bcr.6/overlay",
+)
+starlark_repository.local(
+    name = "bzl.assimp---5.4.3.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/assimp/5.4.3.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.at-spi2-core---2.58.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/at-spi2-core/2.58.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.avro-cpp---1.12.0",
@@ -20536,6 +21285,48 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/aws_sdk/1.11.758/overlay",
 )
+starlark_repository.local(
+    name = "bzl.azure-core-cpp---1.14.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-core-cpp/1.14.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.azure-core-cpp---1.14.1.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-core-cpp/1.14.1.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.azure-core-test-cpp---1.14.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-core-test-cpp/1.14.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.azure-identity-cpp---1.10.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-identity-cpp/1.10.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.azure-storage-blobs-cpp---12.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-storage-blobs-cpp/12.13.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.azure-storage-common-cpp---12.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/azure-storage-common-cpp/12.9.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.babylon---1.4.4",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -20545,6 +21336,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/baidu/babylon/releases/download/v1.4.4/v1.4.4.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.backward-cpp---1.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/backward-cpp/1.6/overlay",
+)
 starlark_repository.archive(
     name = "bzl.bant---0.2.9",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -20553,6 +21351,13 @@ starlark_repository.archive(
     strip_prefix = "bant-v0.2.9",
     type = "tar.gz",
     urls = ["https://github.com/hzeller/bant/releases/download/v0.2.9/bant-v0.2.9.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.basis_universal---2.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/basis_universal/2.0.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.bazel-diff---24.0.0",
@@ -20598,94 +21403,13 @@ starlark_repository.archive(
     urls = ["https://github.com/buildbuddy-io/bazel_env.bzl/releases/download/v0.7.2/bazel_env.bzl-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.0",
+    name = "bzl.bazel_features---1.9.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.0",
+    strip_prefix = "bazel_features-1.9.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---0.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-0.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.39.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.30.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.47.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.47.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.1/bazel_features-v1.47.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.47.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.47.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.0/bazel_features-v1.47.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.18.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.46.0",
@@ -20697,13 +21421,58 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.3.0",
+    name = "bzl.bazel_features---1.18.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.3.0",
+    strip_prefix = "bazel_features-1.18.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.47.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.47.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.1/bazel_features-v1.47.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.19.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.30.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.38.0",
@@ -20724,49 +21493,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.11.0",
+    name = "bzl.bazel_features---1.39.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.11.0",
+    strip_prefix = "bazel_features-1.39.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.43.0",
+    name = "bzl.bazel_features---1.27.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.43.0",
+    strip_prefix = "bazel_features-1.27.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.27.0/bazel_features-v1.27.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.32.0",
+    name = "bzl.bazel_features---1.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.32.0",
+    strip_prefix = "bazel_features-1.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.19.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.13.0",
@@ -20778,13 +21529,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.13.0/bazel_features-v1.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.44.0",
+    name = "bzl.bazel_features---1.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.44.0",
+    strip_prefix = "bazel_features-1.11.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.28.0",
@@ -20796,13 +21547,40 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.4.1",
+    name = "bzl.bazel_features---1.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.4.1",
+    strip_prefix = "bazel_features-1.43.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.44.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.24.0",
@@ -20814,6 +21592,51 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.bazel_features---1.47.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.47.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.0/bazel_features-v1.47.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.32.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.32.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.bazel_features---1.20.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20823,30 +21646,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_gomock---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/uber-go/mock/releases/download/bazel_rule_v0.2.0/bazel_gomock-v0.2.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_jar_jar---0.1.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_jar_jar-0.1.7",
-    type = "tar.gz",
-    urls = ["https://github.com/bazeltools/bazel_jar_jar/releases/download/v0.1.7/bazel_jar_jar-v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_jar_jar---0.1.15",
@@ -20858,13 +21663,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazeltools/bazel_jar_jar/releases/download/v0.1.15/bazel_jar_jar-v0.1.15.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.2",
+    name = "bzl.bazel_jar_jar---0.1.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.2",
+    strip_prefix = "bazel_jar_jar-0.1.7",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
+    urls = ["https://github.com/bazeltools/bazel_jar_jar/releases/download/v0.1.7/bazel_jar_jar-v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_lib---3.2.0",
@@ -20876,15 +21681,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_lib---3.0.0-beta.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20892,15 +21688,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-3.0.0-beta.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0-rc.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0-rc.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_lib---3.1.0",
@@ -20912,6 +21699,24 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.1.0/bazel-lib-v3.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.bazel_lib---3.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0-rc.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0-rc.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.bazel_lib---3.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20919,6 +21724,15 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-3.0.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_linux_packages---0.3.1",
@@ -20939,84 +21753,12 @@ starlark_repository.archive(
     urls = ["https://github.com/gregl83/bazel-paq/releases/download/v1.4.1/bazel-paq-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_skylib---1.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.7.1",
@@ -21035,12 +21777,84 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.2/bazel-skylib-1.8.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.bazel_skylib---1.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.8.0",
@@ -21051,12 +21865,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.0/bazel-skylib-1.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.9.0",
+    name = "bzl.bazel_skylib---1.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib_gazelle_plugin---1.9.0",
@@ -21102,15 +21916,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.5/java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_worker_java---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21118,6 +21923,15 @@ starlark_repository.archive(
     strip_prefix = "bazel-worker-api-0.0.8/java",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.5/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazeldnf---v0.99.2-rc1",
@@ -21137,15 +21951,6 @@ starlark_repository.archive(
     urls = ["https://github.com/sergeykhliustin/BazelPods/releases/download/1.12.5/release.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazelrc-preset.bzl---1.9.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazelrc-preset.bzl-1.9.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.9.2/bazelrc-preset.bzl-v1.9.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazelrc-preset.bzl---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21154,12 +21959,49 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.6.0/bazelrc-preset.bzl-v1.6.0.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.bazelrc-preset.bzl---1.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazelrc-preset.bzl-1.9.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazelrc-preset.bzl/releases/download/v1.9.2/bazelrc-preset.bzl-v1.9.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.behaviortree_cpp---4.7.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/behaviortree_cpp/4.7.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.behaviortree_cpp---4.7.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/behaviortree_cpp/4.7.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.behaviortree_ros2---0.0.0-20250313-7a6ace6.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/behaviortree_ros2/0.0.0-20250313-7a6ace6.bcr.1/overlay",
+)
 starlark_repository.local(
     name = "bzl.bison---3.8.2.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/bison/3.8.2.bcr.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.bison---3.8.2.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/bison/3.8.2.bcr.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.blake3---1.5.1.bcr.1",
@@ -21169,6 +22011,13 @@ starlark_repository.archive(
     strip_prefix = "BLAKE3-1.5.1",
     type = "tar.gz",
     urls = ["https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.5.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.blake3---1.8.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/blake3/1.8.2.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.bliss---0.73",
@@ -21180,248 +22029,369 @@ starlark_repository.archive(
     type = "zip",
     urls = ["http://www.tcs.hut.fi/Software/bliss/bliss-0.73.zip"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost---1.89.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boost-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost/1.89.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boost-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/boost/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.algorithm---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost---1.89.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "algorithm-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost/1.89.0.bcr.3/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.algorithm---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "algorithm-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.algorithm---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "algorithm-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/algorithm/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.align---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.align/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.align---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.align---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.align/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.align---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "align-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/align/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.align/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.any---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.align---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "any-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.align/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.any---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.align---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "any-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.align/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.align---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.any---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "any-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/any/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.any/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.array---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.any---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.any/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.any---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.any/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.any---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.any/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.any---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.any/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.any---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.any/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.array---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.array/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.array---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.array/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.array---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.array/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.array---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.array/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.array---1.88.0.bcr.3",
+starlark_repository.local(
+    name = "bzl.boost.array---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "array-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/array/archive/refs/tags/boost-1.88.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.array/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.asio---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.array---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "asio-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.array/1.89.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.array---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.array/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.asio---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.asio---1.87.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "asio-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.87.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.asio---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "asio-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/asio/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.assert---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.asio---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assert-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.asio---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.assert---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assert-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.assert---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assert-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assert/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.assign---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.assert---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assign-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.assert---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.assert---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.assert---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.assign---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "assign-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/assign/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assign/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.atomic---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.assign---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "atomic-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assign/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.atomic---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.assign---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "atomic-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.assign/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.atomic---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "atomic-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/atomic/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.beast---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "beast-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.83.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.beast---1.89.0.bcr.2",
@@ -21433,193 +22403,297 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.bimap---1.89.0.bcr.2",
+    name = "bzl.boost.beast---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bimap-boost-1.89.0",
+    strip_prefix = "beast-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/bimap/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.beast---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "beast-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/beast/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.boost.bimap---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bimap-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bimap/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bimap/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.bind---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.bimap---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bimap/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.bind---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.bimap---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bimap/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.bind---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.bimap---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bimap/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.bimap---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bimap/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.bind---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bind-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/bind/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.callable_traits---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.bind---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "callable_traits-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.bind---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.callable_traits---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "callable_traits-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/callable_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.callable_traits/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.callable_traits---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.callable_traits/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.charconv---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "charconv-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.charconv/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.charconv---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "charconv-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/charconv/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.charconv/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.chrono---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "chrono-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.chrono---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "chrono-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.chrono---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "chrono-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/chrono/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.chrono---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.chrono---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.chrono---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.chrono---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.circular_buffer---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "circular_buffer-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/circular_buffer/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.circular_buffer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "circular_buffer-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/circular_buffer/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.circular_buffer---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.circular_buffer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.compat---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "compat-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/compat/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.compat/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.compat---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "compat-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/compat/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.compat/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.compatibility---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.compatibility/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.compute---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.compute/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.compute---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "compute-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/compute/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.compute/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.concept_check---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.concept_check---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.concept_check---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "concept_check-boost-1.90.0",
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.config---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "config-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/concept_check/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.config---1.89.0.bcr.2",
@@ -21631,15 +22705,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.config---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "config-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.config---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21649,13 +22714,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container---1.89.0.bcr.2",
+    name = "bzl.boost.config---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "container-boost-1.89.0",
+    strip_prefix = "config-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/config/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.container---1.90.0.bcr.1",
@@ -21667,40 +22732,80 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container---1.87.0.bcr.2",
+    name = "bzl.boost.container---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "container-boost-1.87.0",
+    strip_prefix = "container-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.container_hash---1.87.0",
+    name = "bzl.boost.container---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.87.0",
+    strip_prefix = "container-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/container/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.container_hash---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.container_hash---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "container_hash-boost-1.90.0",
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.88.0.bcr.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.context---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "context-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/container_hash/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.context---1.90.0.bcr.1",
@@ -21721,103 +22826,132 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.context---1.87.0.bcr.2",
+    name = "bzl.boost.context---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "context-boost-1.87.0",
+    strip_prefix = "context-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/context/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.conversion---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.conversion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "conversion-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.core---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.core---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.core---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.core/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.core---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "core-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/core/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.core/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.core---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.core/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.coroutine---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.core---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.core/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.core---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.core/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.core---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.core/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.coroutine---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.coroutine/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.coroutine2---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.coroutine---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "coroutine2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.coroutine/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.coroutine---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.coroutine/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.coroutine---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.coroutine/1.90.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.coroutine2---1.89.0.bcr.2",
@@ -21829,220 +22963,293 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.crc---1.89.0.bcr.2",
+    name = "bzl.boost.coroutine2---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "crc-boost-1.89.0",
+    strip_prefix = "coroutine2-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/crc/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/coroutine2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.crc---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "crc-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/crc/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.crc---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "crc-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/crc/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.crc/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.date_time---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.crc---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "date_time-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.crc/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.crc---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.crc/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.date_time---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "date_time-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.date_time---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "date_time-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/date_time/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.describe---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.describe---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.describe---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.describe---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.describe---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "describe-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/describe/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.detail---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.describe---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "detail-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.89.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.detail---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.describe---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "detail-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.describe---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.detail---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.detail---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "detail-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/detail/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.dll---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.detail---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "dll-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dll/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.detail---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.detail---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.detail---1.83.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.83.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.detail---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.dll---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "dll-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dll/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.dll/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.dll---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.dll/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.dynamic_bitset---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.dll---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.dll/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "dynamic_bitset-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/dynamic_bitset/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.endian---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.endian---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.endian---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.endian---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "endian-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/endian/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.exception---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.endian---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "exception-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.exception---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.endian---1.83.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "exception-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.endian---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.83.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.exception---1.89.0.bcr.2",
@@ -22063,31 +23270,80 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.exception---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.exception---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.87.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.exception---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "exception-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/exception/archive/refs/tags/boost-1.88.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.boost.filesystem---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "filesystem-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.filesystem---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.filesystem---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "filesystem-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.filesystem---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "filesystem-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/filesystem/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.filesystem---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.foreach---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.foreach/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.foreach---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.foreach/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.foreach---1.89.0.bcr.2",
@@ -22097,164 +23353,270 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.foreach/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.foreach---1.90.0.bcr.1",
+    name = "bzl.boost.foreach---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.foreach/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.foreach/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.foreach---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.foreach/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.format---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.format/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.format---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.format/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.format---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "format-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.format/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.format---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "format-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/format/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.format/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.format---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.format/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.function---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.function---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.function---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.function---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.function_types---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.function---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function/1.89.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.function---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.function---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.function_types---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.function_types---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "function_types-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/function_types/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.functional---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.functional---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.89.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.functional---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.functional---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "functional-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/functional/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.fusion---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.functional---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.functional---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.fusion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.fusion---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fusion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/fusion/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.geometry---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "geometry-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.geometry---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "geometry-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/geometry/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.geometry/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.geometry---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.geometry/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.geometry---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.geometry/1.89.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.graph---1.90.0.bcr.1",
@@ -22275,22 +23637,34 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/graph/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.hash2---1.89.0.bcr.2",
+    name = "bzl.boost.graph---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "hash2-boost-1.89.0",
+    strip_prefix = "graph-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/hash2/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/graph/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.hash2---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "hash2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/hash2/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.hash2/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.hash2---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.hash2/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.heap---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.heap/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.heap---1.90.0.bcr.1",
@@ -22300,29 +23674,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.heap/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.heap---1.89.0.bcr.2",
+    name = "bzl.boost.heap---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.heap/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.heap/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.heap---1.83.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.heap/1.83.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.histogram---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "histogram-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/histogram/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.histogram---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "histogram-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/histogram/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.histogram/1.90.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.hof---1.89.0.bcr.2",
@@ -22343,15 +23713,6 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/hof/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.icl---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "icl-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boost.icl---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22359,6 +23720,24 @@ starlark_repository.archive(
     strip_prefix = "icl-boost-1.90.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.icl---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "icl-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.icl---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "icl-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/icl/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.integer---1.89.0.bcr.2",
@@ -22379,6 +23758,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.integer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "integer-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.integer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22387,41 +23775,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.integer---1.88.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "integer-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/integer/archive/refs/tags/boost-1.88.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.interprocess---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "interprocess-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.interprocess---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "interprocess-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/interprocess/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.intrusive---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.interprocess---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "intrusive-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.interprocess---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.interprocess---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.88.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.intrusive---1.87.0",
@@ -22433,6 +23813,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.intrusive---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "intrusive-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.intrusive---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22442,76 +23831,160 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.intrusive---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "intrusive-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/intrusive/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.boost.io---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "io-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.io---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "io-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.io---1.88.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.io---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "io-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/io/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.iostreams---1.87.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.io---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "iostreams-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iostreams/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.89.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.iterator---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.io---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.iterator---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.io---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.io---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.io/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.90.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.90.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iostreams---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.iterator---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.iterator---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.iterator---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "iterator-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/iterator/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iterator---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iterator---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iterator---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.iterator---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.iterator/1.89.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.json---1.90.0.bcr.1",
@@ -22532,85 +24005,125 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.lambda---1.90.0.bcr.1",
+    name = "bzl.boost.json---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lambda-boost-1.90.0",
+    strip_prefix = "json-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/json/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.lambda---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lambda-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lambda/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.lambda2---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.lambda---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lambda2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lambda/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.lambda---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lambda/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lambda---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lambda/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lambda---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lambda/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.lambda2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lambda2-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lambda2/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lambda2/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.leaf---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.lambda2---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "leaf-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lambda2/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.leaf---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "leaf-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/leaf/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.leaf/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.lexical_cast---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.leaf---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lexical_cast-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.leaf/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.lexical_cast---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lexical_cast-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.lexical_cast---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lexical_cast-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lexical_cast/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.89.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.locale---1.90.0.bcr.1",
@@ -22621,77 +24134,63 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/locale/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.locale---1.83.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "locale-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/locale/archive/refs/tags/boost-1.83.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.lockfree---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lockfree-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lockfree/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lockfree/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.lockfree---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lockfree-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/lockfree/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.lockfree/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.log---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "log-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/log/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.log---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "log-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/log/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.log/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.logic---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.log---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "logic-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.log/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.logic---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "logic-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/logic/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.logic/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.math---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.logic---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "math-boost-1.90.0",
+    path = "data/bazel-central-registry/modules/boost.logic/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.logic---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.logic/1.89.0.bcr.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.math---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "math-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.math---1.89.0.bcr.2",
@@ -22701,6 +24200,15 @@ starlark_repository.archive(
     strip_prefix = "math-boost-1.89.0",
     type = "tar.gz",
     urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.math---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "math-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/math/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.math---1.87.0",
@@ -22738,131 +24246,180 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/move/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.mp11---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.mp11---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.mp11---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.mp11---1.88.0.bcr.3",
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mp11-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mp11/archive/refs/tags/boost-1.88.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.mpl---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mpl-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.mpl---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mpl-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.mpl---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mpl-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mpl/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.mqtt5---1.89.0",
+starlark_repository.local(
+    name = "bzl.boost.mpl---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mqtt5-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mqtt5/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.mpl---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mpl---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mpl---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mpl---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mpl/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.mqtt5---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mqtt5-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/mqtt5/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mqtt5/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.multi_array---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.mqtt5---1.89.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "multi_array-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.mqtt5/1.89.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.multi_array---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_array/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.multi_array---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "multi_array-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_array/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.multi_array/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.multi_index---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.multi_array---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "multi_index-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.multi_array/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.multi_index---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "multi_index-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multi_index/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.multiprecision---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "multiprecision-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.88.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.multiprecision---1.87.0",
@@ -22874,6 +24431,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.multiprecision---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "multiprecision-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.multiprecision---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22883,13 +24449,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.mysql---1.90.0.bcr.1",
+    name = "bzl.boost.multiprecision---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mysql-boost-1.90.0",
+    strip_prefix = "multiprecision-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/multiprecision/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.mysql---1.89.0.bcr.2",
@@ -22901,58 +24467,101 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.mysql---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "mysql-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/mysql/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.boost.numeric_conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.numeric_conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.numeric_conversion---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "numeric_conversion-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/numeric_conversion/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.numeric_interval---1.89.0",
+starlark_repository.local(
+    name = "bzl.boost.numeric_conversion---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "interval-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/interval/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.numeric_conversion---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.numeric_conversion---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.numeric_conversion---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.numeric_conversion---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.numeric_interval---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "interval-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/interval/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.numeric_interval/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.numeric_interval---1.89.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_interval/1.89.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.numeric_ublas---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ublas-boost-1.89.0",
+    path = "data/bazel-central-registry/modules/boost.numeric_ublas/1.89.0.bcr.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.optional---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "optional-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/ublas/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.optional---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "optional-boost-1.89.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.optional---1.90.0.bcr.1",
@@ -22973,13 +24582,13 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.optional---1.89.0.bcr.2",
+    name = "bzl.boost.optional---1.88.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "optional-boost-1.89.0",
+    strip_prefix = "optional-boost-1.88.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/optional/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.outcome---1.90.0.bcr.1",
@@ -22999,50 +24608,61 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/outcome/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.parameter---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "parameter-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/parameter/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.parameter---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "parameter-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/parameter/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.pfr---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.parameter---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pfr-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.parameter---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.parameter---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.parameter---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.pfr---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pfr/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.pfr---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pfr-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pfr/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.pfr/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.phoenix---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.pfr---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "phoenix-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.pfr/1.89.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.phoenix---1.87.0",
@@ -23063,13 +24683,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.phoenix---1.88.0.bcr.3",
+    name = "bzl.boost.phoenix---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "phoenix-boost-1.88.0",
+    strip_prefix = "phoenix-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.89.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.phoenix---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "phoenix-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/phoenix/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.boost.pin_version---1.89.0",
@@ -23078,77 +24707,124 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.pin_version/1.89.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.polygon---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "polygon-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.polygon/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.polygon---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.polygon/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.polygon---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "polygon-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/polygon/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.polygon/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.pool---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.pool---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.pool---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.pool---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pool-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/pool/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.pool---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.pool---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.pool---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.predef---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.predef---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.predef---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.predef---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "predef-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/predef/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.89.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.preprocessor---1.90.0.bcr.1",
@@ -23169,22 +24845,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.preprocessor---1.90.0",
+    name = "bzl.boost.preprocessor---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "preprocessor-boost-1.89.0",
+    strip_prefix = "preprocessor-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/preprocessor/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.process---1.89.0.bcr.2",
+    name = "bzl.boost.process---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "process-boost-1.89.0",
+    strip_prefix = "process-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.process---1.90.0.bcr.1",
@@ -23196,49 +24872,99 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.program_options---1.89.0.bcr.2",
+    name = "bzl.boost.process---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "program_options-boost-1.89.0",
+    strip_prefix = "process-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/program_options/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/process/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.program_options---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "program_options-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/program_options/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.program_options---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "program_options-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/program_options/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.property_map---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "property_map-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.property_map---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "property_map-boost-1.89.0",
+    path = "data/bazel-central-registry/modules/boost.property_map/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_map---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_map---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_map---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_map---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.83.0.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.property_tree---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "property_tree-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/property_map/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.property_tree---1.89.0.bcr.2",
@@ -23258,275 +24984,383 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/property_tree/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.proto---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.proto---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.proto---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.proto---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "proto-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/proto/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.proto---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.ptr_container---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ptr_container-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ptr_container/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ptr_container/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.ptr_container---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ptr_container/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.ptr_container---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ptr_container-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ptr_container/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ptr_container/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.ptr_container---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ptr_container/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.python---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "python-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/python/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.python/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.python---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.python/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.qvm---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "qvm-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.qvm/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.qvm---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.qvm/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.qvm---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "qvm-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/qvm/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.qvm/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.random---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.random---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "random-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.random/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.random---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "random-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.random---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "random-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/random/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.random/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.random---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.random/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.random---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.random/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.random---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.random/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.random---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.random/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.range---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.range/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.range---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.range---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.range---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/range/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.range/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.range---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.range---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.range---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.ratio---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.ratio---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.ratio---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.ratio---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ratio-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/ratio/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.rational---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.ratio---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.ratio---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.rational---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.rational---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.rational---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.rational---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rational-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/rational/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.regex---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.rational---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.regex---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.regex---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.regex---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "regex-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/regex/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.scope---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.regex---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scope-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.scope---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.regex---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scope-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.regex---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.regex---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.regex---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.regex---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.scope---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scope-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.scope/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.scope---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.scope/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.scope---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.scope/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.scope---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.scope/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.scope_exit---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scope_exit-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.scope_exit/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.scope_exit---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.scope_exit/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.scope_exit---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scope_exit-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/scope_exit/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.scope_exit/1.89.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.serialization---1.89.0.bcr.2",
@@ -23547,13 +25381,22 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.serialization---1.87.0.bcr.1",
+    name = "bzl.boost.serialization---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "serialization-boost-1.87.0",
+    strip_prefix = "serialization-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boost.serialization---1.88.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "serialization-boost-1.88.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/serialization/archive/refs/tags/boost-1.88.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.signals2---1.89.0.bcr.2",
@@ -23565,6 +25408,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/signals2/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.signals2---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "signals2-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/signals2/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.signals2---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23573,32 +25425,63 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/signals2/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.smart_ptr---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.smart_ptr---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "smart_ptr-boost-1.89.0",
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.83.0.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.sort---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "sort-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/smart_ptr/archive/refs/tags/boost-1.89.0.tar.gz"],
+    urls = ["https://github.com/boostorg/sort/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.sort---1.89.0.bcr.2",
@@ -23645,59 +25528,68 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/spirit/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.stacktrace---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "stacktrace-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.stacktrace/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.stacktrace---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "stacktrace-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/stacktrace/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.stacktrace/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.static_assert---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.stacktrace---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.stacktrace/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.static_assert---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.static_assert---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.static_string---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "static_string-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.89.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.static_string---1.90.0.bcr.1",
@@ -23709,166 +25601,276 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.system---1.90.0.bcr.1",
+    name = "bzl.boost.static_string---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.90.0",
+    strip_prefix = "static_string-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.system---1.87.0",
+    name = "bzl.boost.static_string---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.87.0",
+    strip_prefix = "static_string-boost-1.89.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/static_string/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.system---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "system-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/system/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.system/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.system---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.test---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "test-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.test/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.test---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "test-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.test/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.test---1.87.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.test---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "test-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/test/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.test/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.thread---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.test---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "thread-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.test/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.thread---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "thread-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/thread/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.throw_exception---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.thread---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.thread---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.throw_exception---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.throw_exception---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.throw_exception---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.throw_exception---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "throw_exception-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/throw_exception/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.throw_exception---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.throw_exception---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.timer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.timer/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.timer---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "timer-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.timer/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.timer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "timer-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.timer/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.timer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "timer-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/timer/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.timer/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.tokenizer---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tokenizer-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.tokenizer---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tokenizer-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.tokenizer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tokenizer-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tokenizer/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.tti---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tti-boost-1.90.0",
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.89.0.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.boost.tti---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tti-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boost.tti---1.89.0.bcr.2",
@@ -23880,94 +25882,113 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.tuple---1.87.0",
+    name = "bzl.boost.tti---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.87.0",
+    strip_prefix = "tti-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.tti---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tti-boost-1.90.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/tti/archive/refs/tags/boost-1.90.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.boost.tuple---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.tuple---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.89.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.tuple---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tuple-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/tuple/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.type_index---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.type_index---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.type_index---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.type_index---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.type_index---1.88.0.bcr.3",
+starlark_repository.local(
+    name = "bzl.boost.type_index---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_index-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_index/archive/refs/tags/boost-1.88.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.type_index---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.88.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.type_index---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.83.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.type_traits---1.89.0.bcr.2",
@@ -23979,94 +26000,150 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.type_traits---1.88.0.bcr.3",
+    name = "bzl.boost.type_traits---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "type_traits-boost-1.88.0",
+    strip_prefix = "type_traits-boost-1.83.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.88.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.83.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.typeof---1.90.0.bcr.1",
+    name = "bzl.boost.type_traits---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "typeof-boost-1.90.0",
+    strip_prefix = "type_traits-boost-1.90.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.90.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boost.typeof---1.87.0",
+    name = "bzl.boost.type_traits---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "typeof-boost-1.87.0",
+    strip_prefix = "type_traits-boost-1.87.0",
     type = "tar.gz",
-    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.87.0.tar.gz"],
+    urls = ["https://github.com/boostorg/type_traits/archive/refs/tags/boost-1.87.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.typeof---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "typeof-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/typeof/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.typeof---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.typeof/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.units---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.units/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.units---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "units-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.units/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.units---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "units-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/units/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.units/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.unordered---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.90.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boost.unordered---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.unordered---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.unordered---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "unordered-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/unordered/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.88.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.url---1.90.0.bcr.1",
@@ -24078,6 +26155,15 @@ starlark_repository.archive(
     urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boost.url---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "url-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boost.url---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24086,113 +26172,173 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/url/archive/refs/tags/boost-1.89.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.boost.utility---1.89.0.bcr.2",
+starlark_repository.local(
+    name = "bzl.boost.utility---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.utility---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.87.0.tar.gz"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.utility---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.utility---1.88.0.bcr.3",
+starlark_repository.local(
+    name = "bzl.boost.utility---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "utility-boost-1.88.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/utility/archive/refs/tags/boost-1.88.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.utility---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.utility---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.utility---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.utility---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.uuid---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "uuid-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.uuid/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.uuid---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "uuid-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/uuid/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.uuid/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.variant---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.uuid---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.uuid/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.variant---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.variant---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.90.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.boost.variant---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.variant2---1.87.0",
+starlark_repository.local(
+    name = "bzl.boost.variant---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.87.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.variant---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.variant2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "variant2-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/variant2/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant2---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.88.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.vmd---1.89.0.bcr.2",
@@ -24212,95 +26358,89 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/boostorg/vmd/archive/refs/tags/boost-1.90.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.winapi---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.winapi---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.87.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.87.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.87.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boost.winapi---1.90.0",
+starlark_repository.local(
+    name = "bzl.boost.winapi---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "winapi-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/winapi/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.83.0.bcr.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.boost.winapi---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.winapi---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.winapi---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.winapi---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.xpressive---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.xpressive---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "xpressive-boost-1.90.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/xpressive/archive/refs/tags/boost-1.90.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.90.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.boost.xpressive---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "xpressive-boost-1.89.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/xpressive/archive/refs/tags/boost-1.89.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.89.0.bcr.2/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260327.0",
+starlark_repository.local(
+    name = "bzl.boost.xpressive---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260327.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.83.0.bcr.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20240930.0",
+starlark_repository.local(
+    name = "bzl.boost.xpressive---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20240930.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20250514.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250514.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250514.0/boringssl-0.20250514.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20241209.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241209.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20251124.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20251124.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.87.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20240913.0",
@@ -24312,31 +26452,22 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20241024.0",
+    name = "bzl.boringssl---0.20250514.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241024.0/",
+    strip_prefix = "boringssl-0.20250514.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250514.0/boringssl-0.20250514.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20260413.0",
+    name = "bzl.boringssl---0.20250818.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260413.0/",
+    strip_prefix = "boringssl-0.20250818.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250818.0/boringssl-0.20250818.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.0.0-20240530-2db0eb3",
@@ -24357,6 +26488,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20251110.0/boringssl-0.20251110.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.boringssl---0.20260413.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20260413.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.boringssl---0.20260508.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24364,6 +26504,51 @@ starlark_repository.archive(
     strip_prefix = "boringssl-0.20260508.0/",
     type = "tar.gz",
     urls = ["https://github.com/google/boringssl/releases/download/0.20260508.0/boringssl-0.20260508.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20260327.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20260327.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20240930.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20240930.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20230215-5c22014",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
+    type = "zip",
+    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241209.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241209.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241024.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241024.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20250212.0",
@@ -24384,13 +26569,38 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20251002.0/boringssl-0.20251002.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20230215-5c22014",
+    name = "bzl.boringssl---0.20250311.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
-    type = "zip",
-    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
+    strip_prefix = "boringssl-0.20250311.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250311.0/boringssl-0.20250311.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20251124.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20251124.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.briansmith_ring---0.17.14.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/briansmith_ring/0.17.14.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.brotli---1.1.0",
@@ -24409,6 +26619,13 @@ starlark_repository.archive(
     strip_prefix = "brotli-1.2.0/go",
     type = "tar.gz",
     urls = ["https://github.com/google/brotli/archive/refs/tags/v1.2.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.bubblewrap---0.11.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/bubblewrap/0.11.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.build_stack_rules_proto---4.1.1",
@@ -24438,6 +26655,15 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/scala-gazelle/releases/download/v0.1.1/scala-gazelle-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-6.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---6.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24445,50 +26671,6 @@ starlark_repository.archive(
     strip_prefix = "buildifier-prebuilt-6.1.2",
     type = "tar.gz",
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---7.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-7.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.5.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.0",
@@ -24500,13 +26682,21 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---6.4.0",
+    name = "bzl.buildifier_prebuilt---8.5.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---7.3.1",
@@ -24518,6 +26708,33 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---7.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-7.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.buildozer---8.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24526,23 +26743,42 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/fmeum/buildozer/releases/download/v8.5.1/buildozer-v8.5.1.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.bullet---3.26.0-rc0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bullet3-d1a4256b3a019117f2bb6cb8c63d6367aaf512e2",
-    type = "tar.gz",
-    urls = ["https://github.com/bulletphysics/bullet3/archive/d1a4256b3a019117f2bb6cb8c63d6367aaf512e2.tar.gz"],
+    path = "data/bazel-central-registry/modules/bullet/3.26.0-rc0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.bullet---3.26.0-rc0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/bullet/3.26.0-rc0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.byte_track_eigen---2.1.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/byte_track_eigen/2.1.0.bcr.2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.bzip2---1.0.8.bcr.4",
+    name = "bzl.bzip2---1.0.8.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     strip_prefix = "bzip2-1.0.8",
     type = "tar.gz",
-    urls = ["https://mirror.bazel.build/sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
+    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.bzip2---1.0.8.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/bzip2/1.0.8.bcr.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.bzlparty_rules_quickjs---0.1.0",
@@ -24570,6 +26806,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/zaucy/bzlws/releases/download/0.2.0/bzlws-0.2.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.c-ares---1.34.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c-ares/1.34.6/overlay",
+)
 starlark_repository.archive(
     name = "bzl.c-ares---1.16.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -24588,14 +26831,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.c-ares---1.19.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "c-ares-1.19.1",
-    type = "tar.gz",
-    urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_19_1/c-ares-1.19.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/c-ares/1.19.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.c-ares---1.34.5.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.c-ares---1.34.5.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.c-ares---1.19.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c-ares/1.19.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.c-blosc2---2.22.0",
@@ -24607,15 +26869,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Blosc/c-blosc2/archive/refs/tags/v2.22.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.c4core---0.2.12",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "c4core-0.2.12-src",
-    type = "tgz",
-    urls = ["https://github.com/biojppm/c4core/releases/download/v0.2.12/c4core-0.2.12-src.tgz"],
-)
-starlark_repository.archive(
     name = "bzl.c4core---0.2.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24623,6 +26876,20 @@ starlark_repository.archive(
     strip_prefix = "c4core-0.2.6-src",
     type = "tgz",
     urls = ["https://github.com/biojppm/c4core/releases/download/v0.2.6/c4core-0.2.6-src.tgz"],
+)
+starlark_repository.local(
+    name = "bzl.c4core---0.2.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c4core/0.2.12/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cairo---1.18.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cairo/1.18.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.capnp-cpp---1.1.0",
@@ -24652,15 +26919,6 @@ starlark_repository.archive(
     urls = ["https://github.com/caseyduquettesc/rules_python_pytest/releases/download/v1.1.1/rules_python_pytest-v1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.catch2---3.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Catch2-3.8.0",
-    type = "tar.gz",
-    urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.catch2---3.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24670,13 +26928,20 @@ starlark_repository.archive(
     urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.13.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.catch2---3.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Catch2-3.8.0",
+    type = "tar.gz",
+    urls = ["https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.ccd---2.1.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libccd-2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/danfis/libccd/archive/refs/tags/v2.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/ccd/2.1.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cctz---2.4",
@@ -24715,13 +26980,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-cpp/archive/refs/tags/v0.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-spec---0.23.0",
+    name = "bzl.cel-spec---0.24.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.23.0",
+    strip_prefix = "cel-spec-0.24.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cel-spec---0.15.0",
@@ -24733,15 +26998,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cel-spec---0.24.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.24.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.24.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.cel-spec---0.25.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24751,13 +27007,27 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.cel-spec---0.23.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cel-spec-0.23.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.cereal---1.3.2.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cereal-1.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/USCiLab/cereal/archive/refs/tags/v1.3.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/cereal/1.3.2.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cereal---1.3.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cereal/1.3.2.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.ceres-solver---2.2.0",
@@ -24767,6 +27037,14 @@ starlark_repository.archive(
     strip_prefix = "ceres-solver-2.2.0",
     type = "tar.gz",
     urls = ["https://github.com/ceres-solver/ceres-solver/archive/refs/tags/2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cgrindel_bazel_starlib---0.27.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.27.0/bazel-starlib.v0.27.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cgrindel_bazel_starlib---0.28.0",
@@ -24784,22 +27062,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.30.0/bazel-starlib.v0.30.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.cgrindel_bazel_starlib---0.27.0",
+starlark_repository.local(
+    name = "bzl.check---0.15.2.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/cgrindel/bazel-starlib/releases/download/v0.27.0/bazel-starlib.v0.27.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/check/0.15.2.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.chicory---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/chicory/1.1.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.civetweb---1.16.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "civetweb-1.16",
-    type = "tar.gz",
-    urls = ["https://github.com/civetweb/civetweb/archive/v1.16.tar.gz"],
+    path = "data/bazel-central-registry/modules/civetweb/1.16.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.cjson---1.7.19-0.20240923110858-12c4bf1986c2.bcr.4",
@@ -24825,6 +27107,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.6.2.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.clipper2---1.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/clipper2/1.5.3/overlay",
+)
 starlark_repository.archive(
     name = "bzl.closure-templates---1.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -24835,13 +27124,13 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/closure-templates/releases/download/v1.0.1/closure-templates-v1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.6",
+    name = "bzl.cmake_configure_file---0.1.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.6",
+    strip_prefix = "cmake_configure_file-0.1.4",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.6/cmake_configure_file-v0.1.6.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.4/cmake_configure_file-v0.1.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.2",
@@ -24871,13 +27160,13 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.5/cmake_configure_file-v0.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.4",
+    name = "bzl.cmake_configure_file---0.1.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.4",
+    strip_prefix = "cmake_configure_file-0.1.6",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.4/cmake_configure_file-v0.1.4.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.6/cmake_configure_file-v0.1.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.7",
@@ -24889,6 +27178,22 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.cmake_configure_file---0.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cmake_configure_file-0.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.1/cmake_configure_file-0.1.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.coacd---1.0.11.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/coacd/1.0.11.bcr.2/overlay",
+)
+starlark_repository.archive(
     name = "bzl.codspeed_google_benchmark_compat---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24896,6 +27201,13 @@ starlark_repository.archive(
     strip_prefix = "codspeed-cpp-v2.1.0/google_benchmark",
     type = "tar.gz",
     urls = ["https://github.com/CodSpeedHQ/codspeed-cpp/releases/download/v2.1.0/codspeed-cpp-v2.1.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.coin-or-lemon---1.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/coin-or-lemon/1.3.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.colordiff---1.0.22",
@@ -24932,6 +27244,15 @@ starlark_repository.archive(
     urls = ["https://github.com/mvukov/rules_ros2/archive/78d85ff784d999bcd4dc288b6fd48e41e7710204.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.com_github_mvukov_rules_ros2---0.0.0-20250612-f0d04fe",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ros2-f0d04fe57e5174b708ee7256814a627e934aacf4",
+    type = "tar.gz",
+    urls = ["https://github.com/mvukov/rules_ros2/archive/f0d04fe57e5174b708ee7256814a627e934aacf4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.com_github_rabbitmq_looking_glass---0.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24939,6 +27260,20 @@ starlark_repository.archive(
     strip_prefix = "looking_glass-0.2.1",
     type = "tar.gz",
     urls = ["https://github.com/rabbitmq/looking_glass/releases/download/0.2.1/looking_glass-0.2.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.concurrentqueue---1.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/concurrentqueue/1.0.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.console_bridge---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/console_bridge/1.0.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.container_structure_test---1.22.1",
@@ -24948,15 +27283,6 @@ starlark_repository.archive(
     strip_prefix = "container-structure-test-1.22.1",
     type = "tar.gz",
     urls = ["https://github.com/GoogleContainerTools/container-structure-test/archive/refs/tags/v1.22.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.contrib_rules_jvm---0.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm-0.33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.33.0/rules_jvm-v0.33.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.contrib_rules_jvm---0.28.0",
@@ -24977,6 +27303,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.24.0/rules_jvm-v0.24.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.contrib_rules_jvm---0.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm-0.33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm/releases/download/v0.33.0/rules_jvm-v0.33.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.copybara---0.0.0-20250728-6672ce2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24994,14 +27329,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/dallison/co/releases/download/3.3.2/co-3.3.2.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.cpp-httplib---0.22.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cpp-httplib-0.22.0",
-    type = "tar.gz",
-    urls = ["https://github.com/yhirose/cpp-httplib/archive/refs/tags/v0.22.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/cpp-httplib/0.22.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cpp-peglib---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpp-peglib/1.0.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cpp-sqlite---0.0.0-20230222-7f931c4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpp-sqlite/0.0.0-20230222-7f931c4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cpp-sqlite---0.0.0-20241111-21be8b5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpp-sqlite/0.0.0-20241111-21be8b5/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cpp2sky---0.6.1-20251203-dfc5bd9",
@@ -25012,6 +27366,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/SkyAPM/cpp2sky/archive/dfc5bd9a9561a5f9f5b031311cb01f547c939207.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.cpp_fpm---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpp_fpm/1.1.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.cpp_toolbelt---2.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25021,14 +27382,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/dallison/cpp_toolbelt/releases/download/2.1.2/cpp_toolbelt-2.1.2.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.cppitertools---2.1",
+starlark_repository.local(
+    name = "bzl.cppcheck---2.20.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cppitertools-2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/cppcheck/2.20.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cppitertools---2.2",
@@ -25038,6 +27397,15 @@ starlark_repository.archive(
     strip_prefix = "cppitertools-2.2",
     type = "tar.gz",
     urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.cppitertools---2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cppitertools-2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/ryanhaining/cppitertools/archive/refs/tags/v2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cppoptlib---2.0.0",
@@ -25066,6 +27434,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v1.0.4.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.cppunit---1.15.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cppunit/1.15.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.cppzmq---4.10.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25074,6 +27449,13 @@ starlark_repository.archive(
     strip_prefix = "cppzmq-4.10.0",
     type = "tar.gz",
     urls = ["https://github.com/zeromq/cppzmq/archive/refs/tags/v4.10.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.cpr---1.14.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpr/1.14.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cpuinfo---0.0.0-20260312-7607ca5",
@@ -25109,14 +27491,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/CrowCpp/Crow/archive/refs/tags/v1.3.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.csv-parser---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/csv-parser/2.3.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.cucumber-cpp---0.8.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cucumber-cpp-0.8.0",
-    type = "tar.gz",
-    urls = ["https://github.com/cucumber/cucumber-cpp/archive/refs/tags/v0.8.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/cucumber-cpp/0.8.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cuda_toolchain_types---0.0.1",
@@ -25136,6 +27523,27 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/hermeticbuild/cuda-toolkit/releases/download/v0.0.2/cuda-toolkit-v0.0.2.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.cudd---3.0.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cudd/3.0.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cunit---2.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cunit/2.1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.curl---8.12.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/curl/8.12.0.bcr.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.curl---8.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25145,14 +27553,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.curl---8.11.0.bcr.5",
+starlark_repository.local(
+    name = "bzl.curl---8.8.0.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "curl-8.11.0",
-    type = "tar.gz",
-    urls = ["https://github.com/curl/curl/releases/download/curl-8_11_0/curl-8.11.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/curl/8.8.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.curl---8.11.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/curl/8.11.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.curl---8.11.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/curl/8.11.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.curl---8.11.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/curl/8.11.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cxx.rs---1.0.194",
@@ -25171,6 +27598,27 @@ starlark_repository.archive(
     strip_prefix = "cxxopts-3.3.1",
     type = "tar.gz",
     urls = ["https://github.com/jarro2783/cxxopts/archive/refs/tags/v3.3.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.cxxtest---4.4.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cxxtest/4.4.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cxxurl---0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cxxurl/0.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cyclonedds---11.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cyclonedds/11.0.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cython---3.0.11-1",
@@ -25215,6 +27663,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/shabanzd/debian_dependency_bazelizer/releases/download/1.0.0/debian_dependency_bazelizer-1.0.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.delaunator-cpp---0.0.0-20181007-c1521f6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/delaunator-cpp/0.0.0-20181007-c1521f6/overlay",
+)
 starlark_repository.archive(
     name = "bzl.depend_on_what_you_use---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25258,6 +27713,27 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/distributed_point_functions/releases/download/v0.0.0/distributed_point_functions-0.0.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.divsufsort---2.0.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/divsufsort/2.0.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.dlpack---1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/dlpack/1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.dnsmasq---2.92",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/dnsmasq/2.92/overlay",
+)
 starlark_repository.archive(
     name = "bzl.doctest---2.4.12.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25266,6 +27742,15 @@ starlark_repository.archive(
     strip_prefix = "doctest-2.4.12",
     type = "tar.gz",
     urls = ["https://github.com/doctest/doctest/archive/refs/tags/v2.4.12.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.doctest---2.4.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "doctest-2.4.11",
+    type = "tar.gz",
+    urls = ["https://github.com/doctest/doctest/archive/refs/tags/v2.4.11.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.double-conversion---3.3.1",
@@ -25286,6 +27771,15 @@ starlark_repository.archive(
     urls = ["https://github.com/jjmaestro/bazel_download_archives/releases/download/v0.1.0/bazel_download_archives-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.download_utils---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "download_utils-v1.0.1",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.1/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.download_utils---1.0.0-beta.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25294,14 +27788,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.0-beta.2/downloads/src.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.download_utils---1.0.1",
+starlark_repository.local(
+    name = "bzl.dtc---1.7.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "download_utils-v1.0.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.1/downloads/src.tar.gz"],
+    path = "data/bazel-central-registry/modules/dtc/1.7.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.dumb-init---1.2.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/dumb-init/1.2.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.dylib---2.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/dylib/2.2.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.effcee---0.0.0-20250222",
@@ -25312,41 +27818,54 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/google/effcee/archive/874b47102c57a8979c0f154cf8e0eab53c0a0502.zip"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.egl-registry---0.0.0-20250527",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "EGL-Registry-3ae2b7c48690d2ce13cc6db3db02dfc0572be65e",
-    type = "tar.gz",
-    urls = ["https://github.com/KhronosGroup/EGL-Registry/archive/3ae2b7c48690d2ce13cc6db3db02dfc0572be65e.tar.gz"],
+    path = "data/bazel-central-registry/modules/egl-registry/0.0.0-20250527/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.eigen---3.4.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "eigen-3.4.0",
-    type = "zip",
-    urls = ["https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.eigen---5.0.1.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "eigen-5.0.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.com/libeigen/eigen/-/package_files/246179253/download"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.eigen---3.4.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "eigen-3.4.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.com/libeigen/eigen/-/package_files/233618439/download"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---3.4.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---5.0.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/5.0.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---3.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---5.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/5.0.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---4.0.0-20241125.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/4.0.0-20241125.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.elemental2---1.3.2",
@@ -25384,12 +27903,12 @@ starlark_repository.archive(
     urls = ["https://github.com/emscripten-core/emsdk/archive/refs/tags/4.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.engflowapis---2024.12.06-06.17.32",
+    name = "bzl.engflowapis---2024.10.16",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.12.06-06.17.32/engflowapis-2024.12.06-06.17.32.tar.gz"],
+    type = "tgz",
+    urls = ["https://github.com/EngFlow/engflowapis/releases/download/2024.10.16/engflowapis-2024.10.16.tgz"],
 )
 starlark_repository.archive(
     name = "bzl.engflowapis-java---2025.07.24-06.20.24",
@@ -25401,13 +27920,13 @@ starlark_repository.archive(
     urls = ["https://github.com/EngFlow/engflowapis/releases/download/2025.07.24-06.20.24/engflowapis-2025.07.24-06.20.24.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20251216-6ef568c",
+    name = "bzl.envoy_api---0.0.0-20251105-4a2b9a3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-6ef568cf4a67362849911d1d2a546fd9f35db2ff",
+    strip_prefix = "data-plane-api-4a2b9a30628e95e0cfe985c45c10adc8a6b1643b",
     type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz"],
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4a2b9a30628e95e0cfe985c45c10adc8a6b1643b.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20260130-84e8436",
@@ -25428,13 +27947,13 @@ starlark_repository.archive(
     urls = ["https://github.com/envoyproxy/data-plane-api/archive/4de3c74cf21a9958c1cf26d8993c55c6e0d28b49.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20251105-4a2b9a3",
+    name = "bzl.envoy_api---0.0.0-20251216-6ef568c",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-4a2b9a30628e95e0cfe985c45c10adc8a6b1643b",
+    strip_prefix = "data-plane-api-6ef568cf4a67362849911d1d2a546fd9f35db2ff",
     type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4a2b9a30628e95e0cfe985c45c10adc8a6b1643b.tar.gz"],
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20241214-918efc9",
@@ -25454,6 +27973,20 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/envoyproxy/toolshed/releases/download/bazel-v0.3.25/toolshed-bazel-v0.3.25.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.esaxx---20250106.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/esaxx/20250106.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.etherlab-ethercat---1.6.7.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/etherlab-ethercat/1.6.7.bcr.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.evidence_store_bazel---0.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25469,6 +28002,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/exempi/2.6.6/overlay",
+)
+starlark_repository.local(
+    name = "bzl.exprtk---0.0.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/exprtk/0.0.3.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.extra_rules_java---1.3",
@@ -25488,15 +28028,6 @@ starlark_repository.archive(
     urls = ["https://github.com/lemire/fast_double_parser/archive/refs/tags/v0.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.fast_float---8.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fast_float-8.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.0.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.fast_float---8.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25505,6 +28036,29 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.2.4.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.fast_float---8.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fast_float-8.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/fastfloat/fast_float/archive/refs/tags/v8.0.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.fastcdr---2.3.5.bcr.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fastcdr/2.3.5.bcr.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.fastdds---3.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fastdds/3.4.2/overlay",
+)
 starlark_repository.local(
     name = "bzl.fastjson---0.0.0-20120701063936-485f994a61a6.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25512,14 +28066,19 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/fastjson/0.0.0-20120701063936-485f994a61a6.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.fasttext---0.10.0-bcr.20240313-1142dc4.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fasttext/0.10.0-bcr.20240313-1142dc4.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.fcl---0.7.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fcl-0.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/flexible-collision-library/fcl/archive/refs/tags/0.7.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/fcl/0.7.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.federated_language---0.5.2",
@@ -25536,6 +28095,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/ffmpeg/7.1.1.bcr.beta.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.fftw---3.3.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fftw/3.3.10/overlay",
 )
 starlark_repository.archive(
     name = "bzl.fildesh---0.2.0",
@@ -25563,14 +28129,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/facebookincubator/fizz/releases/download/v2025.02.10.00/fizz-v2025.02.10.00.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.flatbuffers---25.2.10",
+starlark_repository.local(
+    name = "bzl.fkyaml---0.4.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "flatbuffers-25.2.10",
-    type = "tar.gz",
-    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
+    path = "data/bazel-central-registry/modules/fkyaml/0.4.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.flann---1.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/flann/1.9.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.flatbuffers---25.9.23",
@@ -25580,6 +28151,15 @@ starlark_repository.archive(
     strip_prefix = "flatbuffers-25.9.23",
     type = "tar.gz",
     urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.flatbuffers---25.2.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "flatbuffers-25.2.10",
+    type = "tar.gz",
+    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.flatbuffers---25.12.19",
@@ -25604,6 +28184,13 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/flex/2.6.4.bcr.3/overlay",
 )
+starlark_repository.local(
+    name = "bzl.flex---2.6.4.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/flex/2.6.4.bcr.2/overlay",
+)
 starlark_repository.archive(
     name = "bzl.flip---1.6",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25613,41 +28200,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/NVlabs/flip/archive/79675788aa642fbb4732effe2b45b082ff4c4d52.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.fmt---11.1.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-11.1.4",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip"],
+    path = "data/bazel-central-registry/modules/fmt/11.1.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.fmt---11.1.3",
+starlark_repository.local(
+    name = "bzl.fmt---12.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-11.1.3",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/11.1.3/fmt-11.1.3.zip"],
+    path = "data/bazel-central-registry/modules/fmt/12.0.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.fmt---10.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-10.1.1",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.fmt---12.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-12.1.0",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/12.1.0/fmt-12.1.0.zip"],
+    path = "data/bazel-central-registry/modules/fmt/12.1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.fmt---8.1.1",
@@ -25659,12 +28231,65 @@ starlark_repository.archive(
     urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.fmt---10.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-10.1.1",
+    type = "zip",
+    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
+)
+starlark_repository.local(
+    name = "bzl.fmt---11.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fmt/11.1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.fmt---11.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fmt/11.2.0/overlay",
+)
+starlark_repository.archive(
     name = "bzl.folly---2025.01.13.00.bcr.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/facebook/folly/releases/download/v2025.01.13.00/folly-v2025.01.13.00.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.foonathan_memory---0.7.3.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "memory-0.7-3",
+    type = "tar.gz",
+    urls = ["https://github.com/foonathan/memory/archive/refs/tags/v0.7-3.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.foxglove_schemas_protobuf---0.2.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/foxglove_schemas_protobuf/0.2.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.foxglove_websocket---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/foxglove_websocket/1.3.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.foxglove_ws_protocol---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/foxglove_ws_protocol/0.8.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.fp16---0.0.0-20210320-0a92994",
@@ -25675,32 +28300,47 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.freeimage---3.19.10.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "FreeImage-3.19.10",
-    type = "tar.gz",
-    urls = ["https://github.com/danoli3/FreeImage/archive/refs/tags/3.19.10.tar.gz"],
+    path = "data/bazel-central-registry/modules/freeimage/3.19.10.bcr.5/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.freeimage---3.19.10.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/freeimage/3.19.10.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.freeimage---3.19.10.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/freeimage/3.19.10.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.freertos---11.1.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/freertos/11.1.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.freetype---2.13.3.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/freetype/2.13.3.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.freetype---2.14.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "freetype-2.14.1",
-    type = "tar.gz",
-    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.freetype---2.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "freetype-2.9",
-    type = "tar.gz",
-    urls = ["https://download.savannah.gnu.org/releases/freetype/freetype-2.9.tar.gz"],
+    path = "data/bazel-central-registry/modules/freetype/2.14.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.fremtind_rules_vitest---0.2.1",
@@ -25746,35 +28386,55 @@ starlark_repository.archive(
     urls = ["https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.fzf---0.71.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fzf/0.71.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gawk---5.3.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.gawk---5.3.2.bcr.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.7/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.gawk---5.3.2.bcr.1",
+starlark_repository.local(
+    name = "bzl.gawk---5.3.2.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "gawk-5.3.2",
-    type = "tar.xz",
-    urls = ["https://ftp.gnu.org/gnu/gawk/gawk-5.3.2.tar.xz"],
+    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.3/overlay",
 )
 starlark_repository.local(
-    name = "bzl.gawk---5.3.2.bcr.5",
+    name = "bzl.gawk---5.3.2.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.5/overlay",
+    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.46.0",
+    name = "bzl.gazelle---0.45.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.42.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.29.0",
@@ -25786,28 +28446,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.30.0",
+    name = "bzl.gazelle---0.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.51.0",
+    name = "bzl.gazelle---0.46.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.51.0/bazel-gazelle-v0.51.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.38.0",
@@ -25816,6 +28468,30 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.37.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.41.0",
@@ -25842,44 +28518,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.47.0/bazel-gazelle-v0.47.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.50.0",
+    name = "bzl.gazelle---0.40.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.37.0",
+    name = "bzl.gazelle---0.30.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.42.0",
+    name = "bzl.gazelle---0.44.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.43.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.33.0",
@@ -25890,36 +28550,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.39.1",
+    name = "bzl.gazelle---0.51.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.51.0/bazel-gazelle-v0.51.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.45.0",
+    name = "bzl.gazelle---0.35.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.34.0",
+    name = "bzl.gazelle---0.50.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle_cc---0.5.0",
@@ -25974,6 +28626,20 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/f0rmiga/gcc-toolchain/releases/download/0.9.3/gcc-toolchain-0.9.3.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.gcem---1.18.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gcem/1.18.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gdk-pixbuf---2.44.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gdk-pixbuf/2.44.4/overlay",
+)
 starlark_repository.archive(
     name = "bzl.generate_export_header---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -25982,6 +28648,20 @@ starlark_repository.archive(
     strip_prefix = "generate_export_header-0.1.0",
     type = "tar.gz",
     urls = ["https://github.com/Wito-1/generate_export_header/archive/refs/tags/0.1.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.geographiclib---2.4.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/geographiclib/2.4.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.geometry-central---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/geometry-central/1.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.gflags---2.2.2.bcr.1",
@@ -25993,6 +28673,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.giflib---5.2.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/giflib/5.2.1.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.git---2.54.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26000,11 +28687,39 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/git/2.54.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.glew---2.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glew/2.3.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glfw---3.4.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glfw/3.4.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glfw---3.4.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glfw/3.4.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.glib---2.82.2.bcr.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/glib/2.82.2.bcr.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glib---2.82.2.bcr.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glib/2.82.2.bcr.7/overlay",
 )
 starlark_repository.local(
     name = "bzl.glib---2.82.2.bcr.6",
@@ -26019,6 +28734,27 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/glib/2.82.2.bcr.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glib---2.82.2.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glib/2.82.2.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glm---1.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glm/1.0.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glm---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glm/1.0.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.glog---0.7.1.bcr.1",
@@ -26048,20 +28784,34 @@ starlark_repository.archive(
     urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.glog---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "glog-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/glog/archive/refs/tags/v0.5.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.glpk---5.0.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "glpk-5.0",
-    type = "tar.gz",
-    urls = ["https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/glpk/5.0.bcr.5/overlay",
 )
 starlark_repository.local(
-    name = "bzl.gmp---6.3.0.bcr.1",
+    name = "bzl.glpk---5.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gmp/6.3.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/glpk/5.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.glu---9.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/glu/9.0.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.gmp---6.2.0.bcr.1",
@@ -26071,11 +28821,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/gmp/6.2.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.gmp---6.3.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gmp/6.3.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.gmp---6.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/gmp/6.3.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gmp---6.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gmp/6.2.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.gonzojive_protobuf_javascript---3.21.5.esm",
@@ -26096,6 +28860,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/bazel-common/releases/download/0.0.1/bazel-common-0.0.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.google_benchmark---1.9.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.9.5",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26105,31 +28878,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.4",
+    name = "bzl.google_benchmark---1.9.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.4",
+    strip_prefix = "benchmark-1.9.4",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.5",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.5",
@@ -26141,6 +28896,24 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.google_benchmark---1.9.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.9.2",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.google_benchmark---1.8.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.8.4",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26148,15 +28921,6 @@ starlark_repository.archive(
     strip_prefix = "benchmark-1.8.2",
     type = "tar.gz",
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.4",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_cloud_cpp---3.0.0-rc1",
@@ -26177,40 +28941,22 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    name = "bzl.googleapis---0.0.0-20240819-fe8ba054a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260223-edfe7983",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-edfe7983b9d99d6244b4d7636d25fa6e752a2041",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/edfe7983b9d99d6244b4d7636d25fa6e752a2041.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20240326-1c8d509c5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
+    strip_prefix = "googleapis-fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0",
     type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz"],
+    urls = ["https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260514-1dbb1a14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-1dbb1a14e079f78d9214f8e48bf083f32e3ddb96",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/1dbb1a14e079f78d9214f8e48bf083f32e3ddb96.zip"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20260325-8b491c86",
@@ -26240,31 +28986,40 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/googleapis/archive/20ac242a6b3a723cb10c1a0201209261addaf7d8.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20260514-1dbb1a14",
+    name = "bzl.googleapis---0.0.0-20260223-edfe7983",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-1dbb1a14e079f78d9214f8e48bf083f32e3ddb96",
+    strip_prefix = "googleapis-edfe7983b9d99d6244b4d7636d25fa6e752a2041",
     type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/1dbb1a14e079f78d9214f8e48bf083f32e3ddb96.zip"],
+    urls = ["https://github.com/googleapis/googleapis/archive/edfe7983b9d99d6244b4d7636d25fa6e752a2041.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20240819-fe8ba054a",
+    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0",
-    type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz"],
+    strip_prefix = "googleapis-f9d6fe4a6ad9ed89dfc315f284124d2104377940",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/f9d6fe4a6ad9ed89dfc315f284124d2104377940.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
+    name = "bzl.googleapis---0.0.0-20240326-1c8d509c5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
+    strip_prefix = "googleapis-1c8d509c574aeab7478be1bfd4f2e8f0931cfead",
     type = "tar.gz",
-    urls = ["https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz"],
+    urls = ["https://github.com/googleapis/googleapis/archive/1c8d509c574aeab7478be1bfd4f2e8f0931cfead.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9",
+    type = "zip",
+    urls = ["https://github.com/googleapis/googleapis/archive/c8ca5bce5cbabac76b8619bd8d63ac10bb0561a9.zip"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20260130-c0fcb356",
@@ -26276,13 +29031,13 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/googleapis/archive/c0fcb35628690e9eb15dcefae41c651c67cd050b.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis---0.0.0-20251104-53af3b72",
+    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-53af3b727f84acc34e31c23f3b6e7b8aa4b7e837",
-    type = "zip",
-    urls = ["https://github.com/googleapis/googleapis/archive/53af3b727f84acc34e31c23f3b6e7b8aa4b7e837.zip"],
+    strip_prefix = "googleapis-5e258e334154da04dcd0a567a61ac21518cac81b",
+    type = "tar.gz",
+    urls = ["https://github.com/googleapis/googleapis/archive/5e258e334154da04dcd0a567a61ac21518cac81b.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis-rules-registry---1.0.0",
@@ -26303,13 +29058,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.17.0.bcr.2",
+    name = "bzl.googletest---1.15.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.17.0",
+    strip_prefix = "googletest-1.15.2",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.11.0",
@@ -26321,15 +29076,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.15.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.googletest---1.14.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26337,6 +29083,15 @@ starlark_repository.archive(
     strip_prefix = "googletest-1.14.0",
     type = "tar.gz",
     urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googletest---1.17.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googletest-1.17.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.12.1",
@@ -26365,6 +29120,16 @@ starlark_repository.archive(
     urls = ["https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gperf---3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    sha256 = "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2",
+    strip_prefix = "gperf-3.1",
+    type = "tar.gz",
+    urls = ["http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gperftools---2.18.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26372,6 +29137,27 @@ starlark_repository.archive(
     strip_prefix = "gperftools-2.18.1",
     type = "tar.gz",
     urls = ["https://github.com/gperftools/gperftools/releases/download/gperftools-2.18.1/gperftools-2.18.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.graaf---1.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/graaf/1.1.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.graphite2---1.3.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/graphite2/1.3.14/overlay",
+)
+starlark_repository.local(
+    name = "bzl.greatest---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/greatest/1.5.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.68.0",
@@ -26401,6 +29187,33 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.71.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc---1.74.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.74.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.56.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.56.3",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.73.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.73.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc---1.80.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26408,6 +29221,15 @@ starlark_repository.archive(
     strip_prefix = "grpc-1.80.0",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.80.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.41.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.41.0",
+    type = "zip",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.69.0",
@@ -26428,13 +29250,13 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.81.0-pre1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.41.0",
+    name = "bzl.grpc---1.74.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.41.0",
-    type = "zip",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
+    strip_prefix = "grpc-1.74.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.72.0",
@@ -26455,31 +29277,13 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.73.1",
+    name = "bzl.grpc---1.74.0-pre2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.73.1",
+    strip_prefix = "grpc-1.74.0-pre2",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.74.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.74.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.56.3.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.56.3",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.0-pre2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
@@ -26489,33 +29293,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-httpjson-transcoding-ff41eb3fc9209e6197595b54f7addfa244c0bdb6",
     type = "tar.gz",
     urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/ff41eb3fc9209e6197595b54f7addfa244c0bdb6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.69.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.66.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.66.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.71.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.71.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.71.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-java---1.67.1",
@@ -26543,6 +29320,33 @@ starlark_repository.archive(
     strip_prefix = "grpc-java-1.62.2",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.62.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.66.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.66.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.71.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.71.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.71.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.69.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.69.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-proto---0.0.0-20240627-ec30f58.bcr.1",
@@ -26579,6 +29383,27 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc-kotlin/archive/refs/tags/v1.5.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.gsl---4.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gsl/4.2.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gsl-lite---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gsl-lite/1.1.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gtsam---4.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gtsam/4.2.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.gutil---20260309.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -26587,15 +29412,6 @@ starlark_repository.archive(
     strip_prefix = "gutil-release-20260309",
     type = "zip",
     urls = ["https://github.com/google/gutil/releases/download/20260309.0/gutil-release-20260309.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.gz-common---7.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-common-gz-common7_7.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-common---7.1.0",
@@ -26614,6 +29430,15 @@ starlark_repository.archive(
     strip_prefix = "gz-common-gz-common7_7.2.0-pre1",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.2.0-pre1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-common---7.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-common-gz-common7_7.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-common/archive/refs/tags/gz-common7_7.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-fuel-tools---11.0.0",
@@ -26643,15 +29468,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-msgs---12.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-msgs-gz-msgs12_12.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-msgs---12.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26659,6 +29475,15 @@ starlark_repository.archive(
     strip_prefix = "gz-msgs-gz-msgs12_12.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-msgs---12.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-msgs-gz-msgs12_12.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-msgs/archive/refs/tags/gz-msgs12_12.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-physics---9.3.0",
@@ -26679,15 +29504,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-plugin/archive/refs/tags/gz-plugin4_4.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-rendering---10.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-rendering-gz-rendering10_10.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-rendering---10.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26695,6 +29511,15 @@ starlark_repository.archive(
     strip_prefix = "gz-rendering-gz-rendering10_10.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-rendering---10.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-rendering-gz-rendering10_10.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-sensors---10.0.1",
@@ -26724,6 +29549,15 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-sim/archive/refs/tags/gz-sim10_10.3.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.gz-transport---15.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-transport-gz-transport15_15.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.gz-transport---15.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26733,13 +29567,13 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-transport---15.0.2",
+    name = "bzl.gz-utils---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "gz-transport-gz-transport15_15.0.2",
+    strip_prefix = "gz-utils-gz-utils3_3.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.2.tar.gz"],
+    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/tags/gz-utils3_3.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-utils---4.0.0",
@@ -26759,14 +29593,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/GZGavinZhao/gzgz_rules_sass/releases/download/v1.0.4/gzgz_rules_sass-v1.0.4.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.happly---0.0.20240207",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/happly/0.0.20240207/overlay",
+)
+starlark_repository.local(
     name = "bzl.harfbuzz---11.0.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "harfbuzz-11.0.1",
-    type = "tar.xz",
-    urls = ["https://github.com/harfbuzz/harfbuzz/releases/download/11.0.1/harfbuzz-11.0.1.tar.xz"],
+    path = "data/bazel-central-registry/modules/harfbuzz/11.0.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.harfbuzz---14.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/harfbuzz/14.1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.helly25_bashtest---0.2.0",
@@ -26854,6 +29700,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.8/hermetic_launcher-v0.0.8.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.hfsm2---2.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/hfsm2/2.10.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.highs---1.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -26873,15 +29726,6 @@ starlark_repository.archive(
     urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.14.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.highway---1.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "highway-1.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.highway---1.3.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26889,6 +29733,15 @@ starlark_repository.archive(
     strip_prefix = "highway-1.3.0",
     type = "tar.gz",
     urls = ["https://github.com/google/highway/releases/download/1.3.0/highway-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.highway---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "highway-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highwayhash---0.0.0-20240305-5ad3bf8.bcr.1",
@@ -26899,6 +29752,20 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/highwayhash/archive/5ad3bf8444cfc663b11bf367baaa31f36e7ff7c8.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.hiredis---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/hiredis/1.3.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.howardhinnant_date---3.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/howardhinnant_date/3.0.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.hugooole_muda---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -26907,6 +29774,13 @@ starlark_repository.archive(
     strip_prefix = "muda-1.0.0",
     type = "tar.gz",
     urls = ["https://github.com/hugooole/muda/releases/download/v1.0.0/muda-1.0.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.hypothesis---0.0.0-20240425-3acfea6.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/hypothesis/0.0.0-20240425-3acfea6.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.iceoryx---2.95.4",
@@ -26926,32 +29800,96 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/eclipse-iceoryx/iceoryx2/archive/refs/tags/v0.6.1.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.icestorm---1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/icestorm/1.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.icu---76.1.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "icu-release-76-1",
-    type = "tar.gz",
-    urls = ["https://github.com/unicode-org/icu/archive/refs/tags/release-76-1.tar.gz"],
+    path = "data/bazel-central-registry/modules/icu/76.1.bcr.3/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.imath---3.2.2.bcr.1",
+starlark_repository.local(
+    name = "bzl.icu---78.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "Imath-3.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.2.2/Imath-3.2.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/icu/78.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.imath---3.1.12.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "Imath-3.1.12",
-    type = "tar.gz",
-    urls = ["https://github.com/AcademySoftwareFoundation/Imath/releases/download/v3.1.12/Imath-3.1.12.tar.gz"],
+    path = "data/bazel-central-registry/modules/imath/3.1.12.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.imath---3.2.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/imath/3.2.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.imgui---1.92.6-docking.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/imgui/1.92.6-docking.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.imgui---1.92.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/imgui/1.92.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.imgui---1.91.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/imgui/1.91.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.implot---0.17",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/implot/0.17/overlay",
+)
+starlark_repository.local(
+    name = "bzl.implot---0.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/implot/0.16/overlay",
+)
+starlark_repository.local(
+    name = "bzl.implot3d---0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/implot3d/0.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.inno-lidar-sdk---3.103.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/inno-lidar-sdk/3.103.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.iperf---3.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/iperf/3.18.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.isl---0.27",
@@ -27002,6 +29940,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/javaparser/3.27.0/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.javaparser---3.26.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "javaparser-javaparser-parent-3.26.2",
+    type = "tar.gz",
+    urls = ["https://github.com/javaparser/javaparser/archive/refs/tags/javaparser-parent-3.26.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jeffmanzione_intern---1.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27029,13 +29976,13 @@ starlark_repository.archive(
     urls = ["https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"],
 )
 starlark_repository.archive(
-    name = "bzl.jq.bzl---0.1.0",
+    name = "bzl.jq.bzl---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.1.0",
+    strip_prefix = "jq.bzl-0.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.1.0/jq.bzl-v0.1.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.4.0/jq.bzl-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jq.bzl---0.6.1",
@@ -27047,6 +29994,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.jq.bzl---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jq.bzl-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.1.0/jq.bzl-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jq.bzl---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27054,24 +30010,6 @@ starlark_repository.archive(
     strip_prefix = "jq.bzl-0.6.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.0/jq.bzl-v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.jq.bzl---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.4.0/jq.bzl-v0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.jsinterop_base---1.2.0-RC1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jsinterop-base-1.2.0-RC1",
-    type = "tar.gz",
-    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsinterop_base---1.1.1",
@@ -27083,6 +30021,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/jsinterop-base/releases/download/1.1.1/jsinterop-base-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.jsinterop_base---1.2.0-RC1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jsinterop-base-1.2.0-RC1",
+    type = "tar.gz",
+    urls = ["https://github.com/google/jsinterop-base/releases/download/1.2.0-RC1/jsinterop-base-1.2.0-RC1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jsinterop_generator---20250910",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27091,14 +30038,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/jsinterop-generator/releases/download/v20250910/jsinterop-generator-v20250910.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.jsoncpp---1.9.6.bcr.2",
+starlark_repository.local(
+    name = "bzl.json_spirit---4.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "jsoncpp-1.9.6",
-    type = "tar.gz",
-    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.6.tar.gz"],
+    path = "data/bazel-central-registry/modules/json_spirit/4.0.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.jsoncons---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/jsoncons/1.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.jsoncpp---1.9.5",
@@ -27108,6 +30060,15 @@ starlark_repository.archive(
     strip_prefix = "jsoncpp-1.9.5",
     type = "tar.gz",
     urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.jsoncpp---1.9.6.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jsoncpp-1.9.6",
+    type = "tar.gz",
+    urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsonnet---0.22.0",
@@ -27163,6 +30124,13 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/ARM-software/kleidiai/archive/d41219d3db13758074a6440d7b55a87487334c8b.zip"],
 )
+starlark_repository.local(
+    name = "bzl.lanelet2---1.2.2.c20250822-f5fc98d.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lanelet2/1.2.2.c20250822-f5fc98d.bcr.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.lcm---1.5.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27173,20 +30141,32 @@ starlark_repository.archive(
     urls = ["https://github.com/lcm-proj/lcm/releases/download/v1.5.2/lcm-1.5.2.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.lcov---2.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lcov/2.3.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.lexbor---2.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/lexbor/2.4.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.lexy---2025.05.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lexy/2025.05.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.libaio---0.3.113.bcr.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libaio-0.3.113",
-    type = "tar.gz",
-    urls = ["https://pagure.io/libaio/archive/libaio-0.3.113/libaio-0.3.113.tar.gz"],
+    path = "data/bazel-central-registry/modules/libaio/0.3.113.bcr.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.libarchive---3.8.1.bcr.2",
@@ -27194,6 +30174,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libarchive/3.8.1.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libavif---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libavif/1.4.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libbacktrace---1.0.0-20250926-7939218",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libbacktrace/1.0.0-20250926-7939218/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libc_replacer---0.1.3",
@@ -27204,32 +30198,40 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/yuyawk/libc_replacer/releases/download/0.1.3/libc_replacer-0.1.3.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libcap---2.27.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libcap/2.27.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libcreate---3.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libcreate/3.1.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.libde265---1.0.18",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libde265-1.0.18",
-    type = "tar.gz",
-    urls = ["https://github.com/strukturag/libde265/releases/download/v1.0.18/libde265-1.0.18.tar.gz"],
+    path = "data/bazel-central-registry/modules/libde265/1.0.18/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libdeflate---1.23",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libdeflate-1.23",
-    type = "tar.gz",
-    urls = ["https://github.com/ebiggers/libdeflate/releases/download/v1.23/libdeflate-1.23.tar.gz"],
+    path = "data/bazel-central-registry/modules/libdeflate/1.23/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libdeflate---1.25",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libdeflate-1.25",
-    type = "tar.gz",
-    urls = ["https://github.com/ebiggers/libdeflate/releases/download/v1.25/libdeflate-1.25.tar.gz"],
+    path = "data/bazel-central-registry/modules/libdeflate/1.25/overlay",
 )
 starlark_repository.local(
     name = "bzl.libdwarf---0.12.0.bcr.1",
@@ -27245,23 +30247,54 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libdwarf/2.2.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libedlib---1.2.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libedlib/1.2.7/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libestr---0.1.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libestr/0.1.11/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libev---4.33",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libev/4.33/overlay",
+)
+starlark_repository.local(
     name = "bzl.libevent---2.1.12-stable.bcr.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libevent-2.1.12-stable",
-    type = "tar.gz",
-    urls = ["https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz"],
+    path = "data/bazel-central-registry/modules/libevent/2.1.12-stable.bcr.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libexpat---2.7.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libexpat-R_2_7_1",
-    type = "tar.gz",
-    urls = ["https://github.com/libexpat/libexpat/archive/refs/tags/R_2_7_1.tar.gz"],
+    path = "data/bazel-central-registry/modules/libexpat/2.7.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libexpat---2.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libexpat/2.7.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libfastjson---1.2304.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libfastjson/1.2304.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.libffi---3.4.7.bcr.4",
@@ -27278,20 +30311,130 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libffi/3.4.7.bcr.3/overlay",
 )
 starlark_repository.local(
+    name = "bzl.libffi---3.4.7.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libffi/3.4.7.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libfuse---3.16.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libfuse/3.16.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libfuse---3.18.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libfuse/3.18.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libgd---2.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libgd/2.3.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libgit2---1.9.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libgit2/1.9.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libgpiod---1.6.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libgpiod/1.6.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libgps---3.27.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libgps/3.27.5/overlay",
+)
+starlark_repository.local(
     name = "bzl.libheif---1.21.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libheif/1.21.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libigl---2.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libigl/2.6.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.libjpeg_turbo---3.1.3.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libjpeg-turbo-3.1.3",
-    type = "tar.gz",
-    urls = ["https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.3/libjpeg-turbo-3.1.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/libjpeg_turbo/3.1.3.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libjpeg_turbo---3.1.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libjpeg_turbo/3.1.3.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libjpeg_turbo---3.1.3.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libjpeg_turbo/3.1.3.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libmagic---5.47",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libmagic/5.47/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libmicrohttpd---1.0.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libmicrohttpd/1.0.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libmodbus---3.1.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libmodbus/3.1.12/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libpaper---2.2.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpaper/2.2.7/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libpcap---1.10.5.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpcap/1.10.5.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libpcap---1.10.5.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpcap/1.10.5.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libpfm---4.11.0",
@@ -27302,6 +30445,27 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.libpng---1.6.53",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpng/1.6.53/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libpng---1.6.54",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpng/1.6.54/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libpng---1.6.44",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpng/1.6.44/overlay",
+)
 starlark_repository.archive(
     name = "bzl.libpng---1.6.41",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27311,14 +30475,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.41.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.libpng---1.6.54",
+starlark_repository.local(
+    name = "bzl.libpng---1.6.50.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libpng-1.6.54",
-    type = "tar.gz",
-    urls = ["https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.54.tar.gz"],
+    path = "data/bazel-central-registry/modules/libpng/1.6.50.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libprotobuf-mutator---1.3",
@@ -27329,14 +30491,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.3.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.librdkafka---2.3.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.librdkafka---2.8.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "librdkafka-2.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.3.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/librdkafka/2.8.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.librdkafka---2.8.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/librdkafka/2.8.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.libsodium---1.0.19",
@@ -27345,41 +30512,47 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libsodium/1.0.19/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libssh2---1.11.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libssh2/1.11.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libstemmer---2.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libstemmer/2.2.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.libtiff---4.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libtiff-4.7.1",
-    type = "tar.gz",
-    urls = ["https://github.com/libsdl-org/libtiff/archive/refs/tags/v4.7.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/libtiff/4.7.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libunwind---1.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libunwind-1.8.3",
-    type = "tar.gz",
-    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.8.3/libunwind-1.8.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/libunwind/1.8.3/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libunwind---1.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libunwind-1.8.1",
-    type = "tar.gz",
-    urls = ["https://github.com/libunwind/libunwind/releases/download/v1.8.1/libunwind-1.8.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/libunwind/1.8.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.liburing---2.10",
+starlark_repository.local(
+    name = "bzl.liburing---2.14",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "liburing-liburing-2.10",
-    type = "tar.gz",
-    urls = ["https://github.com/axboe/liburing/archive/refs/tags/liburing-2.10.tar.gz"],
+    path = "data/bazel-central-registry/modules/liburing/2.14/overlay",
 )
 starlark_repository.archive(
     name = "bzl.liburing---2.5",
@@ -27389,6 +30562,27 @@ starlark_repository.archive(
     strip_prefix = "liburing-liburing-2.5",
     type = "tar.gz",
     urls = ["https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.liburing---2.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/liburing/2.10/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libusb---1.0.28",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libusb/1.0.28/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libuuid---2.41.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libuuid/2.41.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libuuid---2.39.3.bcr.1",
@@ -27400,65 +30594,109 @@ starlark_repository.archive(
     urls = ["https://github.com/util-linux/util-linux/archive/refs/tags/v2.39.3.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.libuv---1.48.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libuv/1.48.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.libvpx---1.16.0.bcr.beta.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libvpx/1.16.0.bcr.beta.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libwebm---1.0.0.32",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libwebm-libwebm-1.0.0.32",
-    type = "tar.gz",
-    urls = ["https://github.com/webmproject/libwebm/archive/libwebm-1.0.0.32.tar.gz"],
+    path = "data/bazel-central-registry/modules/libwebm/1.0.0.32/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libwebp---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libwebp-1.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/webmproject/libwebp/archive/refs/tags/v1.6.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/libwebp/1.6.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libwebp---1.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libwebp-1.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/webmproject/libwebp/archive/refs/tags/v1.5.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/libwebp/1.5.0/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libwebsockets---4.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libwebsockets/4.5.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.libx11---1.8.12.bcr.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libx11-libX11-1.8.12",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libx11/archive/refs/tags/libX11-1.8.12.tar.gz"],
+    path = "data/bazel-central-registry/modules/libx11/1.8.12.bcr.5/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libx11---1.8.12.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libx11/1.8.12.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libx11---1.8.12.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libx11/1.8.12.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libx11---1.8.12.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libx11/1.8.12.bcr.3/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxau---1.0.12.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxau-libXau-1.0.12",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxau/archive/refs/tags/libXau-1.0.12.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxau/1.0.12.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libxau---1.0.12.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxau/1.0.12.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxcb---1.17.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxcb-libxcb-1.17.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gitlab-freedesktop-mirrors/libxcb/archive/refs/tags/libxcb-1.17.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxcb/1.17.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxcb---1.17.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxcb/1.17.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxcb-keysyms---0.4.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxcb-keysyms/0.4.1.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.libxcrypt---4.4.36.bcr.1",
@@ -27467,77 +30705,119 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libxcrypt/4.4.36.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libxcursor---1.2.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxcursor-libXcursor-1.2.3",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxcursor/archive/refs/tags/libXcursor-1.2.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxcursor/1.2.3/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libxev---0.0.0-20251014.0-9f785d2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxev/0.0.0-20251014.0-9f785d2/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxext---1.3.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxext-libXext-1.3.6",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxext/archive/refs/tags/libXext-1.3.6.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxext/1.3.6/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libxfixes---6.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxfixes-libXfixes-6.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxfixes/archive/refs/tags/libXfixes-6.0.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxfixes/6.0.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libxi---1.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxi-libXi-1.8.2",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxi/archive/refs/tags/libXi-1.8.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxi/1.8.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libxinerama---1.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxinerama/1.1.5/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxml2---2.15.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxml2-2.15.1",
-    type = "tar.xz",
-    urls = ["https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz"],
+    path = "data/bazel-central-registry/modules/libxml2/2.15.1.bcr.1/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.libxml2---2.13.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "libxml2-2.13.5",
+    type = "tar.xz",
+    urls = ["https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.tar.xz"],
+)
+starlark_repository.local(
+    name = "bzl.libxml2---2.14.4.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxml2/2.14.4.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxml2---2.15.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxml2/2.15.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxml2-go---0.0.0-20250331-c934e3f.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxml2-go/0.0.0-20250331-c934e3f.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxrandr---1.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxrandr-libXrandr-1.5.4",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxrandr/archive/refs/tags/libXrandr-1.5.4.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxrandr/1.5.4/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libxrender---0.9.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxrender-libXrender-0.9.12",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/libxrender/archive/refs/tags/libXrender-0.9.12.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxrender/0.9.12/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.libxslt---1.1.43.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxslt/1.1.43.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.libxtrans---1.5.2.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libxtrans-xtrans-1.5.2",
-    type = "tar.gz",
-    urls = ["https://gitlab.freedesktop.org/xorg/lib/libxtrans/-/archive/xtrans-1.5.2/libxtrans-xtrans-1.5.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/libxtrans/1.5.2.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxtrans---1.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxtrans/1.5.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libyaml---0.2.5",
@@ -27548,13 +30828,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.libyuv---1787",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://mirror.bazel.build/chromium.googlesource.com/libyuv/libyuv/+archive/eb6e7bb63738e29efd82ea3cf2a115238a89fa51.tar.gz"],
+    path = "data/bazel-central-registry/modules/libyuv/1787/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libzip---1.11.4.bcr.2",
@@ -27574,6 +30853,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.linenoise---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/linenoise/2.0.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.lit2md---1.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27581,6 +30867,13 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/filmil/lit2md/releases/download/v1.0.1/lit2md-v1.0.1.zip"],
+)
+starlark_repository.local(
+    name = "bzl.livox_sdk2---1.2.5.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/livox_sdk2/1.2.5.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.llvm---0.7.9",
@@ -27609,6 +30902,41 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/bmw-software-engineering/lobster/archive/refs/tags/lobster-1.0.2.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.lttng-ust---2.14.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lttng-ust/2.14.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.lua---5.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lua/5.5.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.luajit---2.1.0-beta3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/luajit/2.1.0-beta3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.lunasvg---2.4.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lunasvg/2.4.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.lz4---1.10.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lz4/1.10.0.bcr.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.lz4---1.9.4.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27618,14 +30946,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/lz4/lz4/releases/download/v1.9.4/lz4-1.9.4.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.lz4---1.10.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.lz4---1.10.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "lz4-1.10.0",
-    type = "tar.gz",
-    urls = ["https://github.com/lz4/lz4/releases/download/v1.10.0/lz4-1.10.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/lz4/1.10.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.lz4-erlang---1.9.2.5",
@@ -27635,6 +30961,13 @@ starlark_repository.archive(
     strip_prefix = "lz4-erlang-1.9.2.5",
     type = "tar.gz",
     urls = ["https://github.com/rabbitmq/lz4-erlang/releases/download/v1.9.2.5/lz4-erlang-1.9.2.5.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.lzo---2.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/lzo/2.10/overlay",
 )
 starlark_repository.local(
     name = "bzl.m4---1.4.20.bcr.4",
@@ -27657,6 +30990,13 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/m4/1.4.21/overlay",
 )
+starlark_repository.local(
+    name = "bzl.m4---1.4.20.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/m4/1.4.20.bcr.3/overlay",
+)
 starlark_repository.archive(
     name = "bzl.magic_enum---0.9.8",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27666,13 +31006,12 @@ starlark_repository.archive(
     urls = ["https://github.com/Neargye/magic_enum/releases/download/v0.9.8/magic_enum-v0.9.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.maliput---1.15.0",
+    name = "bzl.magic_enum---0.9.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "maliput-1.15.0",
     type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput/releases/download/1.15.0/maliput-1.15.0.tar.gz"],
+    urls = ["https://github.com/Neargye/magic_enum/releases/download/v0.9.7/magic_enum-v0.9.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.maliput---1.16.0",
@@ -27682,6 +31021,15 @@ starlark_repository.archive(
     strip_prefix = "maliput-1.16.0",
     type = "tar.gz",
     urls = ["https://github.com/maliput/maliput/releases/download/1.16.0/maliput-1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.maliput---1.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "maliput-1.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/maliput/maliput/releases/download/1.15.0/maliput-1.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.maliput_geopackage---0.5.0",
@@ -27710,14 +31058,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/maliput/maliput_sparse/releases/download/0.6.0/maliput_sparse-0.6.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.marisa-trie---0.3.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "marisa-trie-0.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/s-yata/marisa-trie/archive/refs/tags/v0.3.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/marisa-trie/0.3.1.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.masorange_rules_helm---1.7.1",
@@ -27728,23 +31074,68 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/masmovil/masorange_rules_helm/releases/download/v1.7.1/masorange_rules_helm-v1.7.1.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.mbedtls---3.6.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "mbedtls-3.6.5",
-    type = "tar.bz2",
-    urls = ["https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-3.6.5/mbedtls-3.6.5.tar.bz2"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.mbedtls---3.6.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "mbedtls-3.6.0",
-    type = "tar.bz2",
-    urls = ["https://github.com/Mbed-TLS/mbedtls/releases/download/v3.6.0/mbedtls-3.6.0.tar.bz2"],
+    path = "data/bazel-central-registry/modules/mbedtls/3.6.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mbedtls---3.6.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mbedtls/3.6.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mcap---2.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mcap/2.1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mimalloc---2.2.4.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mimalloc/2.2.4.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mimick---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mimick/0.9.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.minicoro---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/minicoro/0.1.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.miniply---0.0.0-20220915-1a235c7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/miniply/0.0.0-20220915-1a235c7/overlay",
+)
+starlark_repository.local(
+    name = "bzl.minitrace---0.0.0-20241021-242da50",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/minitrace/0.0.0-20241021-242da50/overlay",
+)
+starlark_repository.local(
+    name = "bzl.miniz---3.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/miniz/3.1.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.modern-cpp-kafka---2024.07.03.bcr.1",
@@ -27756,11 +31147,46 @@ starlark_repository.archive(
     urls = ["https://github.com/morganstanley/modern-cpp-kafka/archive/refs/tags/v2024.07.03.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.mold---2.40.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mold/2.40.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mosquitto---2.1.2.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mosquitto/2.1.2.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mp-units---2.5.0.bcr.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mp-units/2.5.0.bcr.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.mpc---1.4.1.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/mpc/1.4.1.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.mpfr---4.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/mpfr/4.2.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.msgpack-c---7.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/msgpack-c/7.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.mvfst---2025.01.20.00.bcr.1",
@@ -27787,6 +31213,22 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/nicholasjng/nanobind-bazel/releases/download/v2.12.0/nanobind-bazel-2.12.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.nanoflann---1.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nanoflann/1.3.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.nanoflann---1.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "nanoflann-1.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.5.5.tar.gz"],
+)
 starlark_repository.archive(
     name = "bzl.nanopb---0.4.9.1.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27796,23 +31238,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/nanopb/nanopb/releases/download/nanopb-0.4.9.1/nanopb-0.4.9.1.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.nasm---2.16.03.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "nasm-2.16.03",
-    type = "tar.gz",
-    urls = ["https://mirror.bazel.build/github.com/user-attachments/files/19816158/nasm-2.16.03.tar.gz"],
+    path = "data/bazel-central-registry/modules/nasm/2.16.03.bcr.3/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.nasm---2.16.03",
+starlark_repository.local(
+    name = "bzl.nasm---2.16.03.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "nasm-2.16.03",
-    type = "tar.gz",
-    urls = ["https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz"],
+    path = "data/bazel-central-registry/modules/nasm/2.16.03.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.ncurses---6.4.20221231.bcr.9",
@@ -27820,6 +31258,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.9/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ncurses---6.4.20221231.bcr.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ncurses---6.4.20221231.bcr.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.10/overlay",
 )
 starlark_repository.local(
     name = "bzl.ncurses---6.4.20221231.bcr.4",
@@ -27836,11 +31288,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.11/overlay",
 )
 starlark_repository.local(
-    name = "bzl.ncurses---6.4.20221231.bcr.7",
+    name = "bzl.ncurses---6.4.20221231.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.7/overlay",
+    path = "data/bazel-central-registry/modules/ncurses/6.4.20221231.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.nextpnr---0.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nextpnr/0.9/overlay",
 )
 starlark_repository.archive(
     name = "bzl.ng-log---0.8.0-rc1",
@@ -27851,21 +31310,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/ng-log/ng-log/archive/refs/tags/v0.8.0-rc1.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.6.1",
+starlark_repository.local(
+    name = "bzl.nghttp2---1.65.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
+    path = "data/bazel-central-registry/modules/nghttp2/1.65.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.12.0.bcr.1",
+starlark_repository.local(
+    name = "bzl.ninjatracing---0.0.0-a669e3644cf2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
+    path = "data/bazel-central-registry/modules/ninjatracing/0.0.0-a669e3644cf2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.nlohmann_json---3.11.3.bcr.1",
@@ -27876,12 +31333,42 @@ starlark_repository.archive(
     urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
+)
+starlark_repository.archive(
     name = "bzl.nlohmann_json---3.11.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.12.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
+)
+starlark_repository.local(
+    name = "bzl.nlopt---2.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nlopt/2.7.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.nmea---1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nmea/1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.nogo_analyzer_bzlmod---0.1.0",
@@ -27892,6 +31379,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/jaeyeom/nogo-analyzer-bzlmod/releases/download/v0.1.0/nogo-analyzer-bzlmod-0.1.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.nonstd-span---0.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nonstd-span/0.11.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.nsync---1.29.2",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -27901,32 +31395,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/nsync/archive/refs/tags/1.29.2.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.numactl---2.0.19.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/numactl/2.0.19.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.octomap---1.9.7.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "octomap-1.9.7",
-    type = "tar.gz",
-    urls = ["https://github.com/OctoMap/octomap/archive/refs/tags/v1.9.7.tar.gz"],
+    path = "data/bazel-central-registry/modules/octomap/1.9.7.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.octomap---1.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/octomap/1.10.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.ode---0.16.6.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "odedevs-ode-a5fc0bc28270",
-    type = "tar.gz",
-    urls = ["https://bitbucket.org/odedevs/ode/get/0.16.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.ofiuco---0.3.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ofiuco-0.3.7",
-    type = "tar.gz",
-    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
+    path = "data/bazel-central-registry/modules/ode/0.16.6.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.ofiuco---0.9.0",
@@ -27938,13 +31433,48 @@ starlark_repository.archive(
     urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.9.0/ofiuco-0.9.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.ofiuco---0.3.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ofiuco-0.3.7",
+    type = "tar.gz",
+    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.ogg---1.3.5.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ogg/1.3.5.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.ogre-next---2.3.3.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "ogre-next-2.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/OGRECave/ogre-next/archive/refs/tags/v2.3.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/ogre-next/2.3.3.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ogre-next---2.3.3.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ogre-next/2.3.3.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ogre-next---2.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ogre-next/2.3.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.onednn---2.7.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/onednn/2.7.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.onetbb---2022.2.0",
@@ -27964,12 +31494,42 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/uxlfoundation/oneTBB/archive/refs/tags/v2022.3.0.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.onetbb---2022.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "oneTBB-2022.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.onnx---1.20.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/onnx/1.20.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.open-inference-protocol---0.0.0-20250512-d49cc23.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/open-inference-protocol/0.0.0-20250512-d49cc23.bcr.1/overlay",
+)
 starlark_repository.local(
     name = "bzl.open62541---1.4.16",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/open62541/1.4.16/overlay",
+)
+starlark_repository.local(
+    name = "bzl.open62541pp---0.21.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/open62541pp/0.21.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.openapi_tools_generator_bazel---0.2.3",
@@ -28006,6 +31566,13 @@ starlark_repository.archive(
     strip_prefix = "opencensus-proto-0.4.1/src",
     type = "tar.gz",
     urls = ["https://github.com/census-instrumentation/opencensus-proto/archive/refs/tags/v0.4.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.opencl-sdk---2025.07.23",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/opencl-sdk/2025.07.23/overlay",
 )
 starlark_repository.archive(
     name = "bzl.openconfig_attestz---0.6.10",
@@ -28127,30 +31694,40 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://storage.googleapis.com/rime-public/mirror/openfst-1.8.4.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.opengl-registry---0.0.0-20250707",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "OpenGL-Registry-860ba03f4ed8f474b80a415fde635040fc668abf",
-    type = "tar.gz",
-    urls = ["https://github.com/KhronosGroup/OpenGL-Registry/archive/860ba03f4ed8f474b80a415fde635040fc668abf.tar.gz"],
+    path = "data/bazel-central-registry/modules/opengl-registry/0.0.0-20250707/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.openjph---0.27.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openjph/0.27.3/overlay",
+)
+starlark_repository.local(
     name = "bzl.openjph---0.26.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "OpenJPH-0.26.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aous72/OpenJPH/archive/refs/tags/0.26.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/openjph/0.26.3.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.openssl---3.3.1.bcr.9",
+    name = "bzl.openmp---21.1.5.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.3.1.bcr.9/overlay",
+    path = "data/bazel-central-registry/modules/openmp/21.1.5.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openssh---9.9p1.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssh/9.9p1.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.openssl---3.5.5.bcr.4",
@@ -28160,6 +31737,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.openssl---3.3.1.bcr.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.3.1.bcr.9/overlay",
+)
+starlark_repository.local(
     name = "bzl.openssl---3.5.4.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28167,11 +31751,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/openssl/3.5.4.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.openssl---3.5.4.bcr.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.4.bcr.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.openssl---3.5.5.bcr.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openssl---3.3.1.bcr.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.3.1.bcr.6/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openssl---3.5.5.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.openssl---3.5.5.bcr.1",
@@ -28187,28 +31792,14 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openssl/3.3.1.bcr.1/overlay",
 )
-starlark_repository.local(
-    name = "bzl.openssl---3.5.5.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.3/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openssl---3.5.4.bcr.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.4.bcr.0/overlay",
-)
 starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.19.0",
+    name = "bzl.opentelemetry-cpp---1.24.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.19.0",
+    strip_prefix = "opentelemetry-cpp-1.24.0",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.27.0",
@@ -28220,6 +31811,15 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.27.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.opentelemetry-cpp---1.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-cpp-1.19.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28229,22 +31829,22 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.24.0.bcr.1",
+    name = "bzl.opentelemetry-cpp---1.14.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.24.0",
+    strip_prefix = "opentelemetry-cpp-1.14.2",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
+    name = "bzl.opentelemetry-proto---1.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.4.0",
+    strip_prefix = "opentelemetry-proto-1.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.1.0",
@@ -28256,13 +31856,13 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.8.0",
+    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.8.0",
+    strip_prefix = "opentelemetry-proto-1.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.8.0.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.3.1",
@@ -28273,14 +31873,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.3.1.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.5.0",
+starlark_repository.local(
+    name = "bzl.opentelemetry-proto---1.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.5.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/opentelemetry-proto/1.8.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.opentracing-cpp---1.6.0",
@@ -28299,6 +31897,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/openusd/25.11.bcr.3/overlay",
 )
 starlark_repository.local(
+    name = "bzl.openvdb---11.0.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openvdb/11.0.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.opus---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28314,13 +31919,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/or-tools/releases/download/v9.15/or-tools-9.15.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.orocos-kdl---1.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/orocos-kdl/1.5.3/overlay",
+)
+starlark_repository.local(
     name = "bzl.osqp---1.0.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/osqp/osqp/releases/download/v1.0.0/osqp-v1.0.0-src.tar.gz"],
+    path = "data/bazel-central-registry/modules/osqp/1.0.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.osqp---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/osqp/1.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.osqp-eigen---0.10.3",
@@ -28359,15 +31977,6 @@ starlark_repository.archive(
     urls = ["https://github.com/p4lang/p4runtime/releases/download/v1.5.0/p4runtime-1.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.package_metadata---0.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.2/metadata",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.package_metadata---0.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28377,6 +31986,59 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.3/supply-chain-v0.0.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.package_metadata---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.2/metadata",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.package_metadata---0.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.1/metadata",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.1/supply-chain-v0.0.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.paho.mqtt.c---1.3.14.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/paho.mqtt.c/1.3.14.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.paho.mqtt.c---1.3.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/paho.mqtt.c/1.3.14/overlay",
+)
+starlark_repository.local(
+    name = "bzl.paho.mqtt.cpp---1.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/paho.mqtt.cpp/1.5.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.papilo---3.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/papilo/3.0.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.patch---2.8.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/patch/2.8.bcr.1/overlay",
+)
+starlark_repository.archive(
     name = "bzl.pathkit---1.0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28384,6 +32046,29 @@ starlark_repository.archive(
     strip_prefix = "PathKit-1.0.1",
     type = "tar.gz",
     urls = ["https://github.com/kylef/PathKit/archive/refs/tags/1.0.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.pcg---0.98.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pcg/0.98.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.pcl---1.15.1.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pcl/1.15.1.bcr.3/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.pcre2---10.46-DEV",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pcre2-b3ecb621bd0c38c7dd91d395608283cc4e849042",
+    type = "tar.gz",
+    urls = ["https://github.com/PCRE2Project/pcre2/archive/b3ecb621bd0c38c7dd91d395608283cc4e849042.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pcre2---10.43",
@@ -28395,13 +32080,20 @@ starlark_repository.archive(
     urls = ["https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.43.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pcre2---10.46-DEV",
+    name = "bzl.pcre2---10.45",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pcre2-b3ecb621bd0c38c7dd91d395608283cc4e849042",
-    type = "tar.gz",
-    urls = ["https://github.com/PCRE2Project/pcre2/archive/b3ecb621bd0c38c7dd91d395608283cc4e849042.tar.gz"],
+    strip_prefix = "pcre2-10.45",
+    type = "tar.bz2",
+    urls = ["https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.bz2"],
+)
+starlark_repository.local(
+    name = "bzl.pegtl---3.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pegtl/3.2.8/overlay",
 )
 starlark_repository.archive(
     name = "bzl.periphery---3.7.4",
@@ -28420,14 +32112,6 @@ starlark_repository.archive(
     urls = ["https://github.com/tzaeschke/phtree-cpp/releases/download/v1.7.0/phtree-cpp-v1.7.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.pico-sdk---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/pico-sdk/releases/download/2.1.0/pico-sdk-2.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pico-sdk---2.2.2-develop.bcr.20260420-79b38e95",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28437,12 +32121,12 @@ starlark_repository.archive(
     urls = ["https://github.com/raspberrypi/pico-sdk/archive/79b38e9543116e9be524388ae4650393e6453026.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.picotool---2.1.0",
+    name = "bzl.pico-sdk---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/picotool/releases/download/2.1.0/picotool-2.1.0.tar.gz"],
+    urls = ["https://github.com/raspberrypi/pico-sdk/releases/download/2.1.0/pico-sdk-2.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
@@ -28454,6 +32138,14 @@ starlark_repository.archive(
     urls = ["https://github.com/raspberrypi/picotool/archive/d1a8d35da3f622cf228c0a17e9b7a4295d5282d0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.picotool---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/raspberrypi/picotool/releases/download/2.1.0/picotool-2.1.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.picotool---2.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28461,6 +32153,20 @@ starlark_repository.archive(
     strip_prefix = "picotool-2.2.0",
     type = "tar.gz",
     urls = ["https://github.com/raspberrypi/picotool/releases/download/2.2.0/picotool-2.2.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.pict---3.7.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pict/3.7.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.pinocchio---2.6.21.bcr.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pinocchio/2.6.21.bcr.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.pixelmatch-cpp17---1.0.3",
@@ -28478,45 +32184,12 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/pixman/0.46.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.6",
+starlark_repository.local(
+    name = "bzl.pkg-config---0.29.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
+    path = "data/bazel-central-registry/modules/pkg-config/0.29.2.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.9",
@@ -28535,12 +32208,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.4",
+    name = "bzl.platforms---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.7",
@@ -28549,6 +32222,54 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms_contrib---0.2.3",
@@ -28568,6 +32289,41 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/BradleyMarie/plyodine/releases/download/v1.1.1/plyodine-1.1.1.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.pocketfft---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pocketfft/0.0.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.poco---1.14.2-20250528.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/poco/1.14.2-20250528.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.polyscope---2.4.0-20250430",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/polyscope/2.4.0-20250430/overlay",
+)
+starlark_repository.local(
+    name = "bzl.poppler---24.04.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/poppler/24.04.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.popt---1.19",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/popt/1.19/overlay",
+)
 starlark_repository.archive(
     name = "bzl.portable_cc_toolchain---2025.12.16",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -28576,6 +32332,34 @@ starlark_repository.archive(
     strip_prefix = "portable_cc_toolchain-2025.12.16",
     type = "tar.gz",
     urls = ["https://github.com/CACI-International/cpp-toolchain/releases/download/v2025.12.16/bazel_portable_cc_toolchain-v2025.12.16.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.portaudio---19.7.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/portaudio/19.7.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.postgres---16.2.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/postgres/16.2.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.pplib---2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pplib/2.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ppp---2.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ppp/2.5.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.prismo---0.1.4",
@@ -28586,6 +32370,27 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/alextac98/prismo/releases/download/v0.1.4/prismo-v0.1.4.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.prjtrellis---1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/prjtrellis/1.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.prjtrellis-db---1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/prjtrellis-db/1.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.procps-ng---4.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/procps-ng/4.0.5/overlay",
+)
 starlark_repository.archive(
     name = "bzl.prodrive_technologies_bazel_latex---1.2.2-20250401-c552d5b",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -28594,6 +32399,13 @@ starlark_repository.archive(
     strip_prefix = "bazel-latex-c552d5bd09e4e9e49040ede60dd97720acb1cbb7",
     type = "tar.gz",
     urls = ["https://github.com/ProdriveTechnologies/bazel-latex/archive/c552d5bd09e4e9e49040ede60dd97720acb1cbb7.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.proj---9.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/proj/9.8.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.prometheus-cpp---1.3.0.bcr.2",
@@ -28623,51 +32435,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/proto-converter/archive/d77ff301f48bf2e7a0f8935315e847c1a8e00017.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.5",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---3.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-3.19.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---32.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-32.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.protobuf---33.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28686,87 +32453,6 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---30.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.2",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---30.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---34.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protobuf-34.0.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.5",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---34.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-34.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---24.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-24.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-35.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protobuf-35.0.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---31.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.2",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
-)
-starlark_repository.archive(
     name = "bzl.protobuf---33.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28776,13 +32462,22 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.2",
+    name = "bzl.protobuf---32.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.2",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
+    strip_prefix = "protobuf-32.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---32.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-32.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---31.1",
@@ -28794,13 +32489,139 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---32.1",
+    name = "bzl.protobuf---30.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-32.1",
+    strip_prefix = "protobuf-30.1",
     type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-30.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---31.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---3.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-3.19.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---34.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-34.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0/protobuf-34.0.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-35.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protobuf-35.0.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---34.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-34.0-rc1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0-rc1.1/protobuf-34.0-rc1.1.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.2",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---34.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-34.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.2",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---24.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-24.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.1",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---30.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-30.2",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.5",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.5",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf-matchers---0.1.2",
@@ -28844,6 +32665,15 @@ starlark_repository.archive(
     strip_prefix = "protoc-gen-validate-1.0.4",
     type = "tar.gz",
     urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protoc-gen-validate---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protoc-gen-validate-1.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protothreads---0.1.6",
@@ -28899,6 +32729,13 @@ starlark_repository.archive(
     urls = ["https://github.com/proxy-wasm/proxy-wasm-rust-sdk/archive/refs/tags/v0.2.5.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.proxygen---2025.02.10.00.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/proxygen/2025.02.10.00.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.psmisc---23.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28914,14 +32751,12 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/google/pthreadpool/archive/9003ee6c137cea3b94161bd5c614fb43be523ee1.zip"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.pugixml---1.15",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pugixml-1.15/src",
-    type = "tar.gz",
-    urls = ["https://github.com/zeux/pugixml/releases/download/v1.15/pugixml-1.15.tar.gz"],
+    path = "data/bazel-central-registry/modules/pugixml/1.15/overlay",
 )
 starlark_repository.archive(
     name = "bzl.pybind11_abseil---202402.0",
@@ -28933,13 +32768,13 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_abseil/releases/download/v202402.0/pybind11_abseil-202402.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.11.1",
+    name = "bzl.pybind11_bazel---2.11.1.bzl.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.11.1",
+    strip_prefix = "pybind11_bazel-2.11.1.bzl.2",
     type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.zip"],
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.12.0",
@@ -28951,24 +32786,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.11.1.bzl.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.11.1.bzl.2",
-    type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.pybind11_bazel---3.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-3.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_bazel---3.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28976,6 +32793,15 @@ starlark_repository.archive(
     strip_prefix = "pybind11_bazel-3.0.1",
     type = "tar.gz",
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.1/pybind11_bazel-3.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---2.11.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-2.11.1",
+    type = "zip",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.13.6",
@@ -28987,13 +32813,13 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
+    name = "bzl.pybind11_bazel---3.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_protobuf-1d7a7296604537db5f6ace2ddafd1d08c967ec63",
+    strip_prefix = "pybind11_bazel-3.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_protobuf/archive/1d7a7296604537db5f6ace2ddafd1d08c967ec63.tar.gz"],
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
@@ -29005,13 +32831,55 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.qdldl---0.1.7.bcr.1",
+    name = "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "qdldl-0.1.7",
+    strip_prefix = "pybind11_protobuf-1d7a7296604537db5f6ace2ddafd1d08c967ec63",
     type = "tar.gz",
-    urls = ["https://github.com/osqp/qdldl/archive/refs/tags/v0.1.7.tar.gz"],
+    urls = ["https://github.com/pybind/pybind11_protobuf/archive/1d7a7296604537db5f6ace2ddafd1d08c967ec63.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.pystring---1.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/pystring/1.1.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.qdldl---0.1.8.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/qdldl/0.1.8.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.qdldl---0.1.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/qdldl/0.1.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.qhull---8.0.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/qhull/8.0.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.qhull---8.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/qhull/8.0.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.quickjs-ng---0.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/quickjs-ng/0.13.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.quill---11.1.0",
@@ -29022,14 +32890,12 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/odygrd/quill/releases/download/v11.1.0/quill-11.1.0.zip"],
 )
-starlark_repository.archive(
-    name = "bzl.range-v3---0.12.1-20260505-108f93c",
+starlark_repository.local(
+    name = "bzl.ragel---26.04.0-20260414092900-8841e561489e",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "range-v3-108f93c279c8f9cec175dac361084983d0176e99",
-    type = "tar.gz",
-    urls = ["https://github.com/ericniebler/range-v3/archive/108f93c279c8f9cec175dac361084983d0176e99.tar.gz"],
+    path = "data/bazel-central-registry/modules/ragel/26.04.0-20260414092900-8841e561489e/overlay",
 )
 starlark_repository.archive(
     name = "bzl.range-v3---0.12.0",
@@ -29041,6 +32907,15 @@ starlark_repository.archive(
     urls = ["https://github.com/ericniebler/range-v3/archive/refs/tags/0.12.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.range-v3---0.12.1-20260505-108f93c",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "range-v3-108f93c279c8f9cec175dac361084983d0176e99",
+    type = "tar.gz",
+    urls = ["https://github.com/ericniebler/range-v3/archive/108f93c279c8f9cec175dac361084983d0176e99.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rapidjson---1.1.0.bcr.20241007",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29049,14 +32924,19 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/Tencent/rapidjson/archive/858451e5b7d1c56cf8f6d58f88cf958351837e53.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.rapidjson---1.1.0.bcr.20250205",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rapidjson-24b5e7a8b27f42fa16b96fc70aade9106cf7102f",
-    type = "tar.gz",
-    urls = ["https://github.com/Tencent/rapidjson/archive/24b5e7a8b27f42fa16b96fc70aade9106cf7102f.tar.gz"],
+    path = "data/bazel-central-registry/modules/rapidjson/1.1.0.bcr.20250205/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rapidyaml---0.12.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rapidyaml/0.12.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.rapidyaml---0.9.0",
@@ -29067,14 +32947,47 @@ starlark_repository.archive(
     type = "tgz",
     urls = ["https://github.com/biojppm/rapidyaml/releases/download/v0.9.0/rapidyaml-0.9.0-src.tgz"],
 )
-starlark_repository.archive(
-    name = "bzl.rapidyaml---0.12.1",
+starlark_repository.local(
+    name = "bzl.rawrtc---0.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rapidyaml-0.12.1-src",
-    type = "tgz",
-    urls = ["https://github.com/biojppm/rapidyaml/releases/download/v0.12.1/rapidyaml-0.12.1-src.tgz"],
+    path = "data/bazel-central-registry/modules/rawrtc/0.5.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rawrtc_common---0.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rawrtc_common/0.1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rawrtc_data_channel---0.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rawrtc_data_channel/0.1.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rawrtc_re---0.6.0-3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rawrtc_re/0.6.0-3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rawrtc_rew---0.6.0-3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rawrtc_rew/0.6.0-3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rawrtc_usrsctp---1.0.0-td113",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rawrtc_usrsctp/1.0.0-td113/overlay",
 )
 starlark_repository.archive(
     name = "bzl.re.bzl---0.3.1",
@@ -29086,6 +32999,15 @@ starlark_repository.archive(
     urls = ["https://github.com/jvolkman/re.bzl/releases/download/v0.3.1/re.bzl-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.re2---2021-09-01",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2021-09-01",
+    type = "zip",
+    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
+)
+starlark_repository.archive(
     name = "bzl.re2---2024-07-02.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29093,15 +33015,6 @@ starlark_repository.archive(
     strip_prefix = "re2-2024-07-02",
     type = "zip",
     urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.re2---2025-08-12.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2025-08-12",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2025-08-12/re2-2025-08-12.zip"],
 )
 starlark_repository.archive(
     name = "bzl.re2---2025-11-05.bcr.1",
@@ -29113,13 +33026,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2021-09-01",
+    name = "bzl.re2---2025-08-12.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "re2-2021-09-01",
+    strip_prefix = "re2-2025-08-12",
     type = "zip",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
+    urls = ["https://github.com/google/re2/releases/download/2025-08-12/re2-2025-08-12.zip"],
 )
 starlark_repository.archive(
     name = "bzl.re2---2023-09-01",
@@ -29131,13 +33044,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2024-07-01",
+    name = "bzl.re2---2024-06-01",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-07-01",
+    strip_prefix = "re2-2024-06-01",
     type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-07-01/re2-2024-07-01.zip"],
+    urls = ["https://github.com/google/re2/releases/download/2024-06-01/re2-2024-06-01.zip"],
 )
 starlark_repository.archive(
     name = "bzl.readerwriterqueue---1.0.6",
@@ -29148,14 +33061,33 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/cameron314/readerwriterqueue/archive/refs/tags/v1.0.6.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.readline---8.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/readline/8.3.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.readline---8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "readline-8.3",
-    type = "tar.gz",
-    urls = ["https://mirrors.kernel.org/gnu/readline/readline-8.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/readline/8.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.redis---8.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/redis/8.6.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.reflexxes-rmltype2---1.2.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/reflexxes-rmltype2/1.2.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.remotery---1.0.0",
@@ -29165,6 +33097,13 @@ starlark_repository.archive(
     strip_prefix = "Remotery-1.0.0",
     type = "tar.gz",
     urls = ["https://github.com/Celtoys/Remotery/archive/refs/tags/v1.0.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.reproc---14.2.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/reproc/14.2.5/overlay",
 )
 starlark_repository.archive(
     name = "bzl.riegeli---0.0.0-20240927-cdfb25a",
@@ -29184,14 +33123,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/riegeli/archive/9f2744dc23e81d84c02f6f51244e9e9bb9802d57.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.roaring---4.3.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/roaring/4.3.11/overlay",
+)
+starlark_repository.local(
     name = "bzl.robin-map---1.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "robin-map-1.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/robin-map/1.4.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.roboticslibrary.rl---0.0.0-20250723-5bbd773.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/roboticslibrary.rl/0.0.0-20250723-5bbd773.bcr.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.rocksdb---9.11.2",
@@ -29201,6 +33152,13 @@ starlark_repository.archive(
     strip_prefix = "rocksdb-9.11.2",
     type = "tar.gz",
     urls = ["https://github.com/facebook/rocksdb/archive/refs/tags/v9.11.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.rply---1.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rply/1.1.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.rpmpack---0.6.0",
@@ -29219,6 +33177,20 @@ starlark_repository.archive(
     strip_prefix = "rsync-3.4.2",
     type = "tar.gz",
     urls = ["https://github.com/RsyncProject/rsync/releases/download/v3.4.2/rsync-3.4.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.rsyslog---8.2504.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rsyslog/8.2504.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.rtipc---1.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rtipc/1.0.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.ruff_prebuilt---0.15.12.1",
@@ -29239,13 +33211,22 @@ starlark_repository.archive(
     urls = ["https://github.com/michaeljs1990/rules_abs/releases/download/0.1.0/rules_abs-0.1.0.tar"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.7.1",
+    name = "bzl.rules_android---0.6.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.1",
+    strip_prefix = "rules_android-0.6.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.4/rules_android-v0.6.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android---0.6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android---0.7.2",
@@ -29266,22 +33247,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.6.6",
+    name = "bzl.rules_android---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.6.6",
+    strip_prefix = "rules_android-0.7.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_android---0.6.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.6.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.4/rules_android-v0.6.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android_ndk---0.1.3",
@@ -29329,20 +33301,12 @@ starlark_repository.archive(
     urls = ["https://github.com/lalten/rules_appimage/releases/download/v1.20.0/rules_appimage-v1.20.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.0",
+    name = "bzl.rules_apple---3.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.0/rules_apple.4.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.3.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.1.0",
@@ -29353,12 +33317,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.1.0/rules_apple.4.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.3",
+    name = "bzl.rules_apple---4.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.0/rules_apple.4.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.5.2",
@@ -29369,44 +33333,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.2/rules_apple.4.5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---3.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_apple---4.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---3.5.1",
@@ -29417,12 +33349,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_apple---4.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_apple---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple_linker---0.7.0",
@@ -29451,6 +33423,15 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/rules_auto_dotnet/releases/download/v0.3.5/rules_auto_dotnet-v0.3.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_autoconf---0.0.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_autoconf-0.0.16",
+    type = "tar.gz",
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.16/rules_autoconf-v0.0.16.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_autoconf---0.0.14",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29460,13 +33441,22 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.14/rules_autoconf-v0.0.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_autoconf---0.0.16",
+    name = "bzl.rules_autoconf---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_autoconf-0.0.16",
+    strip_prefix = "rules_autoconf-0.0.9",
     type = "tar.gz",
-    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.16/rules_autoconf-v0.0.16.tar.gz"],
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.9/rules_autoconf-v0.0.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_autoconf---0.0.15",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_autoconf-0.0.15",
+    type = "tar.gz",
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.15/rules_autoconf-v0.0.15.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_batch---0.0.1",
@@ -29518,6 +33508,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bfreis/rules_bsx/releases/download/v1.0.1/rules_bsx-v1.0.1.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_buf---0.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_buf-0.5.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.2/rules_buf-0.5.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_buf---0.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29534,15 +33533,6 @@ starlark_repository.archive(
     strip_prefix = "rules_buf-abbbfce7c3fccf1d4b87afa28140d9ce53f80057",
     type = "zip",
     urls = ["https://github.com/bufbuild/rules_buf/archive/abbbfce7c3fccf1d4b87afa28140d9ce53f80057.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_buf---0.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_buf-0.5.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.2/rules_buf-0.5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_buf---0.3.0",
@@ -29579,13 +33569,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.4",
+    name = "bzl.rules_cc---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.4",
+    strip_prefix = "rules_cc-0.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.16",
@@ -29597,42 +33587,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.17",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.17",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.17/rules_cc-0.2.17.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.18",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.18",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cc---0.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29640,86 +33594,6 @@ starlark_repository.archive(
     strip_prefix = "rules_cc-0.0.6",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.14",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.14",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.11",
@@ -29731,24 +33605,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.11/rules_cc-0.2.11.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.15",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.15",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_cc---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29756,6 +33612,24 @@ starlark_repository.archive(
     strip_prefix = "rules_cc-0.1.1",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.13",
@@ -29767,6 +33641,140 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.15",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.15",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.3/rules_cc-0.1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.18",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.18",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.17",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.17",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.17/rules_cc-0.2.17.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.8",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.11",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.11/rules_cc-0.0.11.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.8",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.14",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_cc---0.0.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29776,44 +33784,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.11.0",
+    name = "bzl.rules_cc---0.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.5",
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.11.0/rules_cc_autoconf-0.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.5.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.5/rules_cc_autoconf-0.5.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.5.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.6/rules_cc_autoconf-0.5.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.0/rules_cc_autoconf-0.10.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.10.1",
@@ -29824,12 +33801,76 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.1/rules_cc_autoconf-0.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.3",
+    name = "bzl.rules_cc_autoconf---0.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.3/rules_cc_autoconf-0.10.3.tar.gz"],
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.3/rules_cc_autoconf-0.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.11.0/rules_cc_autoconf-0.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.5.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.6/rules_cc_autoconf-0.5.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.5/rules_cc_autoconf-0.5.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.4/rules_cc_autoconf-0.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.8.0/rules_cc_autoconf-0.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.0/rules_cc_autoconf-0.10.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.2/rules_cc_autoconf-0.10.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.7.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.7.14/rules_cc_autoconf-0.7.14.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.7.15",
@@ -29838,6 +33879,22 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.7.15/rules_cc_autoconf-0.7.15.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.3/rules_cc_autoconf-0.10.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_hdrs_map---0.31.1",
@@ -29919,15 +33976,6 @@ starlark_repository.archive(
     urls = ["https://github.com/nya3jp/rules_contest/releases/download/v0.9.3/rules_contest-0.9.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_coreutils---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_coreutils-v1.0.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.1/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_coreutils---1.0.0-beta.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29937,6 +33985,15 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.0-beta.6/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_coreutils---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_coreutils-v1.0.1",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.1/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_cpan---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29944,6 +34001,15 @@ starlark_repository.archive(
     strip_prefix = "rules_cpan-1.1.0",
     type = "tar.gz",
     urls = ["https://github.com/lalten/rules_cpan/releases/download/v1.1.0/rules_cpan-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cuda---0.3.0-beta1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cuda-v0.3.0-beta1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.3.0-beta1/rules_cuda-v0.3.0-beta1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cuda---0.3.0",
@@ -30115,15 +34181,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kczulko/rules_elm/releases/download/v1.1.1/rules_elm-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_erlang---3.10.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_erlang-3.10.5",
-    type = "tar.gz",
-    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.10.5/rules_erlang-3.10.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_erlang---3.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30133,20 +34190,13 @@ starlark_repository.archive(
     urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.16.0/rules_erlang-3.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_flex---0.4",
+    name = "bzl.rules_erlang---3.10.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4/rules_flex-v0.4.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_flex---0.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+    strip_prefix = "rules_erlang-3.10.5",
+    type = "tar.gz",
+    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.10.5/rules_erlang-3.10.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_flex---0.3",
@@ -30157,6 +34207,22 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.3/rules_flex-v0.3.tar.xz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_flex---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_flex---0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4/rules_flex-v0.4.tar.xz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_foreign_cc---0.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30164,6 +34230,15 @@ starlark_repository.archive(
     strip_prefix = "rules_foreign_cc-0.9.0",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_foreign_cc---0.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_foreign_cc-0.13.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.13.0/rules_foreign_cc-0.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_foreign_cc---0.12.0",
@@ -30202,15 +34277,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_gazebo---0.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_gazebo-0.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/rules_gazebo/releases/download/0.0.2/rules_gazebo-0.0.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_gazebo---0.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30218,6 +34284,15 @@ starlark_repository.archive(
     strip_prefix = "rules_gazebo-v0.0.6",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/rules_gazebo/releases/download/v0.0.6/rules_gazebo-v0.0.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_gazebo---0.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_gazebo-0.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/rules_gazebo/releases/download/0.0.2/rules_gazebo-0.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_gcs---1.0.1",
@@ -30256,116 +34331,12 @@ starlark_repository.archive(
     urls = ["https://github.com/iocat/rules_gleam/releases/download/v0.1.14/rules_gleam-v0.1.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.43.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.60.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.49.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.57.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.41.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.50.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.52.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_go---0.54.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.39.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.45.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.39.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.53.0",
@@ -30376,6 +34347,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.53.0/rules_go-v0.53.0.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_go---0.42.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.41.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.rules_go---0.59.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30384,12 +34371,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.58.3",
+    name = "bzl.rules_go---0.57.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.52.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.45.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.49.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.60.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.46.0",
@@ -30400,20 +34427,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.42.0",
+    name = "bzl.rules_go---0.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.54.0",
+    name = "bzl.rules_go---0.51.0-rc1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.48.0",
@@ -30422,6 +34457,46 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.58.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.50.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0-rc2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.54.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_graalvm---0.11.1",
@@ -30500,20 +34575,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_img/releases/download/v0.3.11/rules_img_tool-v0.3.11.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_ios---6.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-ios/rules_ios/releases/download/6.0.1/rules_ios.6.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_ios---5.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-ios/rules_ios/releases/download/5.0.0/rules_ios.5.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_ios---6.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-ios/rules_ios/releases/download/6.0.1/rules_ios.6.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ispc---0.0.6",
@@ -30534,44 +34609,12 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_itest/releases/download/v0.0.52/rules_itest-v0.0.52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---5.5.0",
+    name = "bzl.rules_java---5.3.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.6.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.11.0",
@@ -30582,28 +34625,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.11.0/rules_java-8.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---9.3.0",
+    name = "bzl.rules_java---6.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.15.1",
+    name = "bzl.rules_java---8.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---7.1.0",
@@ -30614,92 +34649,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---5.3.5",
+    name = "bzl.rules_java---5.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.6.1",
+    name = "bzl.rules_java---9.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.8.0",
@@ -30710,12 +34673,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.4.0",
+    name = "bzl.rules_java---7.6.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---6.1.0",
@@ -30726,20 +34705,124 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_java---8.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.9.0/rules_java-8.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.0.0/rules_java-6.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.15.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.15.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jni---0.11.1",
@@ -30784,103 +34867,13 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_jupyter/releases/download/0.7.2/rules_jupyter-0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.6",
+    name = "bzl.rules_jvm_external---6.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.6",
+    strip_prefix = "rules_jvm_external-6.8",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.1/rules_jvm_external-6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---4.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-4.4.2",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.7",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.9/rules_jvm_external-6.9.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.8/rules_jvm_external-6.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---5.1",
@@ -30892,13 +34885,103 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.8",
+    name = "bzl.rules_jvm_external---6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.8",
+    strip_prefix = "rules_jvm_external-6.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.8/rules_jvm_external-6.8.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.1/rules_jvm_external-6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---4.4.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-4.4.2",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-5.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.7",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-5.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.9/rules_jvm_external-6.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kconfig---0.4.0",
@@ -30917,14 +35000,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_kotlin---2.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30939,6 +35014,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kotlin---1.9.6",
@@ -30957,12 +35040,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.9/rules_kotlin-v2.1.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.1.3",
+    name = "bzl.rules_kotlin---1.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kustomize---0.5.3",
@@ -30972,14 +35055,6 @@ starlark_repository.archive(
     strip_prefix = "rules_kustomize-0.5.3",
     type = "tar.gz",
     urls = ["https://github.com/seh/rules_kustomize/releases/download/v0.5.3/vcs-archive-v0.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_libusb---0.1.0-rc2.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/pigweed-project/rules_libusb/releases/download/v0.1.0-rc2/rules_libusb-8720113729935528369-7f91dc339a79292ab8aa5ca127572e54b0b586e8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_libusb---0.1.0-rc2",
@@ -30998,28 +35073,20 @@ starlark_repository.archive(
     urls = ["https://storage.googleapis.com/pigweed-bazel-tarballs/rules_libusb-8745211641617303569-f5c0af2f037b6e8405b4158b5e3041675da8e522.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_libusb---0.1.0-rc2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/pigweed-project/rules_libusb/releases/download/v0.1.0-rc2/rules_libusb-8720113729935528369-7f91dc339a79292ab8aa5ca127572e54b0b586e8.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_license---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---0.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---0.0.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_license---0.0.4",
@@ -31030,6 +35097,14 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_license---0.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_license---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31038,20 +35113,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_m4---0.3.bcr.1",
+    name = "bzl.rules_license---0.0.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3/rules_m4-v0.3.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_m4---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.4/rules_m4-v0.2.4.tar.xz"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.3.1",
@@ -31076,6 +35143,22 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.5/rules_m4-v0.2.5.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_m4---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.4/rules_m4-v0.2.4.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_m4---0.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3/rules_m4-v0.3.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mayhem---0.8.9",
@@ -31130,24 +35213,6 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/rules_multirun/releases/download/0.13.0/rules_multirun.0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---1.11.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-1.11.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_multitool/releases/download/v1.11.1/rules_multitool-1.11.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_multitool---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-1.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_multitool---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31155,6 +35220,15 @@ starlark_repository.archive(
     strip_prefix = "rules_multitool-0.4.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.4.0/rules_multitool-0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_multitool---1.11.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_multitool-1.11.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_multitool/releases/download/v1.11.1/rules_multitool-1.11.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_multitool---1.0.0",
@@ -31173,6 +35247,15 @@ starlark_repository.archive(
     strip_prefix = "rules_multitool-0.11.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_multitool---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_multitool-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mypy---0.41.0",
@@ -31218,66 +35301,29 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.13.0/rules_nixpkgs-0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.5.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_nodejs---5.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-core-5.8.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---5.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---5.8.2",
@@ -31297,30 +35343,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.2",
+    name = "bzl.rules_nodejs---6.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.2",
+    strip_prefix = "rules_nodejs-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---5.5.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.5.3/rules_nodejs-core-5.5.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.3.3",
@@ -31332,22 +35361,58 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_oci---2.2.0",
+    name = "bzl.rules_nodejs---6.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-2.2.0",
+    strip_prefix = "rules_nodejs-6.5.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.0/rules_oci-v2.2.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_oci---1.6.0",
+    name = "bzl.rules_nodejs---6.7.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-1.6.0",
+    strip_prefix = "rules_nodejs-6.7.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.7.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.7.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_oci---2.3.0",
@@ -31359,6 +35424,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_oci---2.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-2.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.0/rules_oci-v2.2.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_oci---1.7.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31366,6 +35440,15 @@ starlark_repository.archive(
     strip_prefix = "rules_oci-1.7.4",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_oci---1.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-1.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_openscad---0.1",
@@ -31386,12 +35469,13 @@ starlark_repository.archive(
     urls = ["https://github.com/opicaud/rules_pact/releases/download/v1.1.9/rules_pact-v1.1.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---1.1.0",
+    name = "bzl.rules_perl---0.2.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_perl-0.2.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---1.0.0",
@@ -31402,6 +35486,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.0.0/rules_perl-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_perl---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_perl-0.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.4.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_perl---0.6.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31410,13 +35503,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/0.6.7/rules_perl-0.6.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---0.2.4",
+    name = "bzl.rules_perl---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.2.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---0.5.0",
@@ -31445,14 +35537,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bookingcom/rules_pitest/releases/download/v0.0.2/rules_mylang-v0.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pkg---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31469,12 +35553,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.1.0",
+    name = "bzl.rules_pkg---1.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg---0.9.1",
@@ -31483,6 +35567,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg_providers---0.0.1",
@@ -31572,15 +35664,6 @@ starlark_repository.archive(
     urls = ["https://github.com/hexdae/rules_probe_rs/releases/download/v0.0.6/rules_probe_rs-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-4.0.0",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_proto---7.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31588,15 +35671,6 @@ starlark_repository.archive(
     strip_prefix = "rules_proto-7.0.2",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---7.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-7.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---5.3.0-21.7",
@@ -31608,13 +35682,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---6.0.2",
+    name = "bzl.rules_proto---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-6.0.2",
+    strip_prefix = "rules_proto-4.0.0",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto---7.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-7.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---6.0.0-rc1",
@@ -31626,13 +35709,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---7.0.0",
+    name = "bzl.rules_proto---6.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-7.0.0",
+    strip_prefix = "rules_proto-6.0.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.0/rules_proto-7.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc---5.0.0",
@@ -31779,6 +35862,15 @@ starlark_repository.archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.8.0/rules_proto_grpc_swift-5.8.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_pycross---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_pycross-0.8.1",
+    type = "tar.gz",
+    urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.1/rules_pycross-v0.8.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_pycross---0.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31795,6 +35887,14 @@ starlark_repository.archive(
     strip_prefix = "rules_pydeps-0.5.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---0.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_python---0.10.2",
@@ -31815,23 +35915,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.7.0/rules_python-1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---0.32.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.32.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.32.0/rules_python-0.32.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_python_gazelle_plugin---1.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31841,13 +35924,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.1/rules_python-1.5.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python_gazelle_plugin---1.5.0-rc0",
+    name = "bzl.rules_python_gazelle_plugin---1.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.5.0-rc0/gazelle",
+    strip_prefix = "rules_python-1.5.3/gazelle",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.0-rc0/rules_python-1.5.0-rc0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.3/rules_python-1.5.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_qemu---0.1.1",
@@ -31902,13 +35985,13 @@ starlark_repository.archive(
     urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/v4.16.1/robolectric-bazel-v4.16.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.82",
+    name = "bzl.rules_rs---0.0.68",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.82",
+    strip_prefix = "rules_rs-0.0.68",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.82/rules_rs-v0.0.82.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rs---0.0.73",
@@ -31920,13 +36003,13 @@ starlark_repository.archive(
     urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.73/rules_rs-v0.0.73.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.68",
+    name = "bzl.rules_rs---0.0.82",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.68",
+    strip_prefix = "rules_rs-0.0.82",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.82/rules_rs-v0.0.82.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ruby---0.26.0",
@@ -31956,14 +36039,6 @@ starlark_repository.archive(
     urls = ["https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.5/rules_runfiles_group-v0.0.1-rc.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.51.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_rust---0.45.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31972,12 +36047,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.45.1/rules_rust-v0.45.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.46.0",
+    name = "bzl.rules_rust---0.51.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.46.0/rules_rust-v0.46.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rust---0.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.39.0/rules_rust-v0.39.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_mutants---0.69.1",
@@ -32041,15 +36124,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Ryang20718/rules_s5/releases/download/v0.0.13/rules_s5-0.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.1.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.1.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.5/rules_scala-v7.1.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_scala---7.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32057,15 +36131,6 @@ starlark_repository.archive(
     strip_prefix = "rules_scala-7.0.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_scala---7.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.2.4",
@@ -32084,6 +36149,24 @@ starlark_repository.archive(
     strip_prefix = "rules_scala-7.1.3",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.3/rules_scala-v7.1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.5/rules_scala-v7.1.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala_native---0.1.0",
@@ -32121,40 +36204,13 @@ starlark_repository.archive(
     urls = ["https://github.com/filmil/rules_shar/releases/download/v1.0.0/rules_shar-v1.0.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.7.1",
+    name = "bzl.rules_shell---0.4.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.7.1",
+    strip_prefix = "rules_shell-0.4.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.2.0/rules_shell-v0.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.8.0",
@@ -32166,13 +36222,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.8.0/rules_shell-v0.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.6.1",
+    name = "bzl.rules_shell---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.6.1",
+    strip_prefix = "rules_shell-0.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.2.0/rules_shell-v0.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.7.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.7.1/rules_shell-v0.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shell---0.4.0",
@@ -32184,13 +36258,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.0/rules_shell-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.4.1",
+    name = "bzl.rules_shell---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.4.1",
+    strip_prefix = "rules_shell-0.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_shell---0.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellcheck---0.6.2",
@@ -32244,6 +36327,30 @@ starlark_repository.archive(
     urls = ["https://github.com/tharakadesilva/rules_spring_aot/releases/download/v0.1.0/rules_spring_aot-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_swift---3.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.1/rules_swift.3.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_swift---3.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32260,52 +36367,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.1.2",
+    name = "bzl.rules_swift---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.1/rules_swift.3.6.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.4.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.2/rules_swift.3.4.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.3.0/rules_swift.2.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.0.2",
@@ -32316,20 +36383,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.5.0",
+    name = "bzl.rules_swift---3.4.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.2/rules_swift.3.4.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---2.3.0",
+    name = "bzl.rules_swift---1.18.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.3.0/rules_swift.2.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---2.1.1",
@@ -32340,12 +36407,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift_package_manager---1.9.0",
+    name = "bzl.rules_swift---3.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.9.0/rules_swift_package_manager.v1.9.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_package_manager---1.15.0",
@@ -32362,6 +36437,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.17.1/rules_swift_package_manager.v1.17.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift_package_manager---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.9.0/rules_swift_package_manager.v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_previews---0.1.1",
@@ -32459,6 +36542,15 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_typst/releases/download/0.2.0/rules_typst-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_uv---0.89.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_uv-0.89.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_uv---0.44.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32477,37 +36569,12 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_uv---0.89.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_uv-0.89.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_venv---0.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.15.0/rules_venv-0.15.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_venv---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.16.0/rules_venv-0.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_venv---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_venv---0.18.0",
@@ -32518,12 +36585,36 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.18.0/rules_venv-0.18.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_venv---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_venv---0.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.15.0/rules_venv-0.15.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_venv---0.17.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_verilator---0.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilator---0.1.0",
@@ -32533,14 +36624,6 @@ starlark_repository.archive(
     strip_prefix = "bazel_rules_verilator-0.1.0",
     type = "tar.gz",
     urls = ["https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.1.0/bazel_rules_verilator-0.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_verilator---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.2/rules_verilator-0.3.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilog---1.1.0",
@@ -32620,6 +36703,15 @@ starlark_repository.archive(
     urls = ["https://github.com/ekhabarov/rules_ytt/releases/download/v0.4.0/rules_ytt-v0.4.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_zig---0.12.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_zig-0.12.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aherrmann/rules_zig/releases/download/v0.12.1/rules_zig-0.12.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_zig---0.15.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32664,6 +36756,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/dfed/SafeDI/releases/download/2.0.0/SafeDI-2.0.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.safeint---3.0.28",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/safeint/3.0.28/overlay",
+)
 starlark_repository.archive(
     name = "bzl.sajson---0.0.0-20210905003841-ec644013e34f",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -32673,23 +36772,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/chadaustin/sajson/archive/ec64401.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.scip---9.2.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "scip-923",
-    type = "tar.gz",
-    urls = ["https://github.com/scipopt/scip/archive/refs/tags/v923.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.sdformat---16.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "sdformat-sdformat16_16.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/scip/9.2.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.sdformat---16.0.0",
@@ -32700,6 +36788,15 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.0.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.sdformat---16.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "sdformat-sdformat16_16.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
+)
 starlark_repository.local(
     name = "bzl.sdl2---2.32.0.bcr.beta.5",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -32707,14 +36804,26 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/sdl2/2.32.0.bcr.beta.5/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.sdl2_mixer---2.8.1.bcr.beta.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "SDL2_mixer-2.8.1",
-    type = "tar.gz",
-    urls = ["https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.1/SDL2_mixer-2.8.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/sdl2_mixer/2.8.1.bcr.beta.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.seastar---26.03.0-20260302212502-e639df376395",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/seastar/26.03.0-20260302212502-e639df376395/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sed---4.9.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sed/4.9.bcr.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.sed---4.9.bcr.5",
@@ -32724,11 +36833,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/sed/4.9.bcr.5/overlay",
 )
 starlark_repository.local(
-    name = "bzl.sed---4.9.bcr.3",
+    name = "bzl.sed---4.9.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/sed/4.9.bcr.3/overlay",
+    path = "data/bazel-central-registry/modules/sed/4.9.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.sha256.bzl---0.0.1",
@@ -32738,6 +36847,20 @@ starlark_repository.archive(
     strip_prefix = "sha256.bzl-0.0.1",
     type = "tar.gz",
     urls = ["https://github.com/hermeticbuild/sha256.star/releases/download/v0.0.1/sha256.bzl-v0.0.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.simde---0.8.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/simde/0.8.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.simdutf---7.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/simdutf/7.7.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.simplehttp---0.2.0",
@@ -32766,15 +36889,6 @@ starlark_repository.archive(
     urls = ["https://github.com/apache/skywalking-data-collect-protocol/archive/refs/tags/v10.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.snappy---1.2.2.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "snappy-1.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.snappy---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32784,13 +36898,34 @@ starlark_repository.archive(
     urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.soplex---7.1.3",
+    name = "bzl.snappy---1.2.2.bcr.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "soplex-release-713",
+    strip_prefix = "snappy-1.2.2",
     type = "tar.gz",
-    urls = ["https://github.com/scipopt/soplex/archive/refs/tags/release-713.tar.gz"],
+    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.sockpp---1.0.0-20260101-b8e19c8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sockpp/1.0.0-20260101-b8e19c8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.soplex---7.1.4.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/soplex/7.1.4.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.soplex---7.1.4.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/soplex/7.1.4.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.sourcekit_bazel_bsp---0.8.3",
@@ -32836,24 +36971,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.spdlog---1.17.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "spdlog-1.17.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.17.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.spdlog---1.15.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "spdlog-1.15.3",
-    type = "tar.gz",
-    urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.15.3.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.spdlog---1.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32861,6 +36978,27 @@ starlark_repository.archive(
     strip_prefix = "spdlog-1.12.0",
     type = "tar.gz",
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.spdlog---1.15.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/spdlog/1.15.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.spdlog---1.17.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/spdlog/1.17.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.spdlog---1.15.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/spdlog/1.15.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.sphinxdocs---2.0.1",
@@ -32898,88 +37036,68 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/sqids/sqids-bazel/releases/download/v0.1.0/sqids-bazel-v0.1.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.sqlite3---3.50.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "sqlite-amalgamation-3500300",
-    type = "zip",
-    urls = ["https://sqlite.org/2025/sqlite-amalgamation-3500300.zip"],
-)
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.sqlite3---3.51.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "sqlite-amalgamation-3510200",
-    type = "zip",
-    urls = ["https://sqlite.org/2026/sqlite-amalgamation-3510200.zip"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.51.2.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.sqlite3---3.50.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.50.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite3---3.50.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.50.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite3---3.49.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.49.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite3---3.51.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.51.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite_orm---1.9.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite_orm/1.9.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.squashfs-tools---4.7.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/squashfs-tools/4.7.5/overlay",
+)
+starlark_repository.local(
     name = "bzl.squashfs-tools---4.7.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "squashfs-tools-4.7.4/squashfs-tools",
-    type = "tar.gz",
-    urls = ["https://github.com/plougher/squashfs-tools/releases/download/4.7.4/squashfs-tools-4.7.4.tar.gz"],
+    path = "data/bazel-central-registry/modules/squashfs-tools/4.7.4/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.0",
+starlark_repository.local(
+    name = "bzl.squashfuse---0.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/squashfuse/0.5.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.7.2",
@@ -32998,12 +37116,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.8.1",
+    name = "bzl.stardoc---0.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.8.0",
@@ -33014,6 +37140,68 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.stardoc---0.5.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.stb---0.0.0-20241109-5c20573",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/stb/0.0.0-20241109-5c20573/overlay",
+)
+starlark_repository.local(
+    name = "bzl.stb---0.0.0-20251026-f1c79c0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/stb/0.0.0-20251026-f1c79c0/overlay",
+)
+starlark_repository.archive(
     name = "bzl.subspace---2.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33021,6 +37209,13 @@ starlark_repository.archive(
     strip_prefix = "subspace-2.7.0",
     type = "tar.gz",
     urls = ["https://github.com/dallison/subspace/releases/download/2.7.0/subspace-2.7.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.suitesparse---7.10.1.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/suitesparse/7.10.1.bcr.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.supply-chain-go---0.0.10",
@@ -33048,6 +37243,13 @@ starlark_repository.archive(
     strip_prefix = "supply-chain-tools-0.0.1/tools",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/supply-chain/archive/refs/tags/tools-0.0.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.sv-lang---10.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sv-lang/10.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.swift-filename-matcher---2.0.1",
@@ -33077,15 +37279,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kateinoigakukun/swift-indexstore/archive/refs/tags/0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.swift-syntax---603.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-syntax-603.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.swift-syntax---603.0.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33093,6 +37286,15 @@ starlark_repository.archive(
     strip_prefix = "swift-syntax-603.0.0",
     type = "tar.gz",
     urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.swift-syntax---603.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "swift-syntax-603.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/swiftlang/swift-syntax/archive/refs/tags/603.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swift-system---1.6.4.bcr.1",
@@ -33129,15 +37331,6 @@ starlark_repository.archive(
     strip_prefix = "swift-argument-parser-1.3.1",
     type = "tar.gz",
     urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.3.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.swift_argument_parser---1.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-argument-parser-1.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swift_bep_parser---0.0.6",
@@ -33188,14 +37381,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/drmohundro/SWXMLHash/archive/refs/tags/7.0.2.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.symengine---0.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/symengine/0.12.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.systemc---3.0.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "systemc-3.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/accellera-official/systemc/archive/refs/tags/3.0.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/systemc/3.0.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.systemc---3.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/systemc/3.0.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.systemd---260.1",
@@ -33214,33 +37419,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.5/tar.bzl-v0.5.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.5.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.tar.bzl---0.10.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33248,24 +37426,6 @@ starlark_repository.archive(
     strip_prefix = "tar.bzl-0.10.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.1/tar.bzl-v0.10.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tar.bzl---0.10.4",
@@ -33277,31 +37437,84 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.4/tar.bzl-v0.10.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.tar.bzl---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.tcl_lang---9.0.2.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tcl9.0.2",
-    type = "tar.gz",
-    urls = ["https://downloads.sourceforge.net/project/tcl/Tcl/9.0.2/tcl9.0.2-src.tar.gz"],
+    path = "data/bazel-central-registry/modules/tcl_lang/9.0.2.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.tcl_lang---8.6.16.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tcl8.6.16",
-    type = "tar.gz",
-    urls = ["https://downloads.sourceforge.net/project/tcl/Tcl/8.6.16/tcl8.6.16-src.tar.gz"],
+    path = "data/bazel-central-registry/modules/tcl_lang/8.6.16.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.tcl_lang---8.6.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tcl_lang/8.6.16/overlay",
+)
+starlark_repository.local(
     name = "bzl.tclap---1.2.5.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tclap-1.2.5",
-    type = "tar.gz",
-    urls = ["https://github.com/mirror/tclap/archive/refs/tags/v1.2.5.tar.gz"],
+    path = "data/bazel-central-registry/modules/tclap/1.2.5.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.tclreadline---2.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tclreadline/2.4.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.tcmalloc---0.0.0-20250927-12f2552",
@@ -33312,6 +37525,20 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/google/tcmalloc/archive/12f255231938d30493186b0a037feedd70f5a1c1.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.tcpdump---4.99.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tcpdump/4.99.6/overlay",
+)
+starlark_repository.local(
+    name = "bzl.teckit---2.5.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/teckit/2.5.12/overlay",
+)
 starlark_repository.archive(
     name = "bzl.textforge---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -33320,6 +37547,20 @@ starlark_repository.archive(
     strip_prefix = "TextForge-1.0.0",
     type = "tar.gz",
     urls = ["https://github.com/RobertoRojas/TextForge/releases/download/v1.0.0/TextForge-1.0.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.tftp-hpa---5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tftp-hpa/5.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.thorvg---1.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/thorvg/1.0.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.thrax---1.3.9.bcr.1",
@@ -33331,6 +37572,15 @@ starlark_repository.archive(
     urls = ["https://storage.googleapis.com/rime-public/mirror/thrax-1.3.9.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.tink_cc---2.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tink-cc-2.7.0",
+    type = "zip",
+    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.7.0/tink-cc-2.7.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.tink_cc---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33339,14 +37589,12 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.3.0/tink-cc-2.3.0.zip"],
 )
-starlark_repository.archive(
-    name = "bzl.tink_cc---2.7.0",
+starlark_repository.local(
+    name = "bzl.tinygltf---2.9.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tink-cc-2.7.0",
-    type = "zip",
-    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.7.0/tink-cc-2.7.0.zip"],
+    path = "data/bazel-central-registry/modules/tinygltf/2.9.6/overlay",
 )
 starlark_repository.archive(
     name = "bzl.tinyobjloader---2.0.0-rc1.bcr.2",
@@ -33366,14 +37614,26 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/ddiakopoulos/tinyply/archive/refs/tags/3.0.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.tinyxml---2.6.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    sha256 = "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593",
-    type = "tar.gz",
-    urls = ["http://archive.ubuntu.com/ubuntu/pool/universe/t/tinyxml/tinyxml_2.6.2.orig.tar.gz"],
+    path = "data/bazel-central-registry/modules/tinyxml/2.6.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.tinyxml---2.6.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tinyxml/2.6.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.tinyxml2---11.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tinyxml2/11.0.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.tinyxml2---10.0.0",
@@ -33392,6 +37652,20 @@ starlark_repository.archive(
     strip_prefix = "tinyxml2-9.0.0",
     type = "tar.gz",
     urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/9.0.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.tl-expected---1.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tl-expected/1.3.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.tl-optional---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tl-optional/1.1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.toml.bzl---0.4.1",
@@ -33466,13 +37740,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.7.0/toolchains_llvm-v1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_llvm_bootstrapped---0.2.3",
+    name = "bzl.toolchains_llvm_bootstrapped---0.5.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_llvm_bootstrapped-0.2.3",
+    strip_prefix = "toolchains_llvm_bootstrapped-0.5.6",
     type = "tar.gz",
-    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.2.3/toolchains_llvm_bootstrapped-0.2.3.tar.gz"],
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.5.6/toolchains_llvm_bootstrapped-0.5.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_musl---0.1.27.bcr.1",
@@ -33481,15 +37755,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/musl-toolchain/releases/download/v0.1.27/musl_toolchain-v0.1.27.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.toolchains_protoc---0.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_protoc-0.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.3.1/toolchains_protoc-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_protoc---0.5.0",
@@ -33501,15 +37766,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.5.0/toolchains_protoc-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_protoc---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_protoc-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.toolchains_protoc---0.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33517,6 +37773,24 @@ starlark_repository.archive(
     strip_prefix = "toolchains_protoc-0.6.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.6.1/toolchains_protoc-v0.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.toolchains_protoc---0.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_protoc-0.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/toolchains_protoc/releases/download/v0.3.1/toolchains_protoc-v0.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.toolchains_protoc---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_protoc-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/alexeagle/toolchains_protoc/releases/download/v0.2.1/toolchains_protoc-v0.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_riscv_gnu---1.0.0",
@@ -33535,6 +37809,13 @@ starlark_repository.archive(
     strip_prefix = "tools_android-0.3.2",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/tools_android/archive/refs/tags/0.3.2.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.toybox---0.8.12.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/toybox/0.8.12.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.tree-sitter-bazel---0.24.4",
@@ -33563,6 +37844,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/zadlg/tree-sitter-c-bazel/releases/download/v0.23.4/tree-sitter-c.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.triton-inference-server-common---0.0.0-20251104-c09e98a",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/triton-inference-server-common/0.0.0-20251104-c09e98a/overlay",
+)
 starlark_repository.archive(
     name = "bzl.trlc---2.0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -33571,6 +37859,13 @@ starlark_repository.archive(
     strip_prefix = "trlc-trlc-2.0.4",
     type = "tar.gz",
     urls = ["https://github.com/bmw-software-engineering/trlc/archive/refs/tags/trlc-2.0.4.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.trompeloeil---49",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/trompeloeil/49/overlay",
 )
 starlark_repository.archive(
     name = "bzl.tweag-credential-helper---0.0.9",
@@ -33588,6 +37883,20 @@ starlark_repository.archive(
     strip_prefix = "ultrajson-5.10.0",
     type = "tar.gz",
     urls = ["https://github.com/ultrajson/ultrajson/archive/refs/tags/5.10.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.uncrustify---0.82.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/uncrustify/0.82.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.universal-robots-client-library---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/universal-robots-client-library/2.4.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.upb---0.0.0-20230907-e7430e6",
@@ -33615,6 +37924,34 @@ starlark_repository.archive(
     strip_prefix = "upb-a5477045acaa34586420942098f5fecd3570f577",
     type = "tar.gz",
     urls = ["https://github.com/protocolbuffers/upb/archive/a5477045acaa34586420942098f5fecd3570f577.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.urdfdom---2.3.4.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/urdfdom/2.3.4.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.urdfdom_headers---1.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/urdfdom_headers/1.0.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.userspace_rcu---0.15.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/userspace_rcu/0.15.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.uthash---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/uthash/2.3.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.verible---0.0.3933",
@@ -33664,6 +38001,27 @@ starlark_repository.archive(
     urls = ["https://github.com/filmil/bazel_vhdl_ls_gen/releases/download/v0.3.0/bazel_vhdl_ls_gen-v0.3.0.zip"],
 )
 starlark_repository.local(
+    name = "bzl.videoproto---2.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/videoproto/2.3.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.vulkan_headers---1.4.349",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/vulkan_headers/1.4.349/overlay",
+)
+starlark_repository.local(
+    name = "bzl.vulkan_utility_libraries---1.4.349",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/vulkan_utility_libraries/1.4.349/overlay",
+)
+starlark_repository.local(
     name = "bzl.wabt---1.0.37",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33678,23 +38036,40 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/facebook/wangle/releases/download/v2025.02.10.00/wangle-v2025.02.10.00.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.wayland---1.24.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "wayland-1.24.0",
-    type = "tar.gz",
-    urls = ["https://gitlab.freedesktop.org/wayland/wayland/-/archive/1.24.0/wayland-1.24.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/wayland/1.24.0.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.webgpu_headers---0.0.0-20260319-7d3186c",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/webgpu_headers/0.0.0-20260319-7d3186c/overlay",
+)
+starlark_repository.local(
     name = "bzl.websocketpp---0.8.2.bcr.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "websocketpp-0.8.2",
-    type = "tar.gz",
-    urls = ["https://github.com/zaphoyd/websocketpp/archive/refs/tags/0.8.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/websocketpp/0.8.2.bcr.6/overlay",
+)
+starlark_repository.local(
+    name = "bzl.websocketpp---0.8.2.bcr.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/websocketpp/0.8.2.bcr.5/overlay",
+)
+starlark_repository.local(
+    name = "bzl.websocketpp---0.8.2.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/websocketpp/0.8.2.bcr.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.wheelos_common_msgs---0.1.2",
@@ -33715,13 +38090,13 @@ starlark_repository.archive(
     urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.7/windows_support-v0.1.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.with_cfg.bzl---0.14.6",
+    name = "bzl.with_cfg.bzl---0.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "with_cfg.bzl-0.14.6",
+    strip_prefix = "with_cfg.bzl-0.12.0",
     type = "tar.gz",
-    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.6/with_cfg.bzl-v0.14.6.tar.gz"],
+    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.12.0/with_cfg.bzl-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.with_cfg.bzl---0.14.1",
@@ -33733,13 +38108,13 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.1/with_cfg.bzl-v0.14.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.with_cfg.bzl---0.12.0",
+    name = "bzl.with_cfg.bzl---0.14.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "with_cfg.bzl-0.12.0",
+    strip_prefix = "with_cfg.bzl-0.14.6",
     type = "tar.gz",
-    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.12.0/with_cfg.bzl-v0.12.0.tar.gz"],
+    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.6/with_cfg.bzl-v0.14.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.wolfd_bazel_compile_commands---0.5.2",
@@ -33749,23 +38124,26 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/wolfd/bazel-compile-commands/releases/download/v0.5.2/bazel-compile-commands.zip"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.x264---2023.10.1.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "x264-31e19f92f00c7003fa115047ce50978bc98c3a0d",
-    type = "tar.gz",
-    urls = ["https://code.videolan.org/videolan/x264/-/archive/31e19f92f00c7003fa115047ce50978bc98c3a0d/x264-31e19f92f00c7003fa115047ce50978bc98c3a0d.tar.gz"],
+    path = "data/bazel-central-registry/modules/x264/2023.10.1.bcr.2/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.x265---4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/x265/4.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.xcb-proto---1.17.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "xcbproto-xcb-proto-1.17.0",
-    type = "tar.gz",
-    urls = ["https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/archive/xcb-proto-1.17.0/xcbproto-xcb-proto-1.17.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/xcb-proto/1.17.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.xcodeproj---9.10.1",
@@ -33795,6 +38173,13 @@ starlark_repository.archive(
     urls = ["https://github.com/cncf/xds/archive/555b57ec207be86f811fb0c04752db6f85e3d7e2.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.xilinx_bootgen---2025.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xilinx_bootgen/2025.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.xkbcommon---1.9.2.bcr.beta.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33810,23 +38195,61 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/scottpledger/xml.bzl/releases/download/v0.2.3/xml.bzl-v0.2.3.tar.gz"],
 )
-starlark_repository.archive(
+starlark_repository.local(
     name = "bzl.xorgproto---2024.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "xorgproto-xorgproto-2024.1",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/xorgproto/archive/refs/tags/xorgproto-2024.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/xorgproto/2024.1.bcr.1/overlay",
 )
-starlark_repository.archive(
+starlark_repository.local(
+    name = "bzl.xpdf---4.06",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xpdf/4.06/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xtensor---0.27.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xtensor/0.27.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xtl---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xtl/0.8.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xtl---0.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xtl/0.8.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xxd---9.1.0917.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xxd/9.1.0917.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xxd---9.1.0917",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xxd/9.1.0917/overlay",
+)
+starlark_repository.local(
     name = "bzl.xxhash---0.8.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "xxHash-0.8.3",
-    type = "tar.gz",
-    urls = ["https://github.com/Cyan4973/xxHash/archive/refs/tags/v0.8.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/xxhash/0.8.3.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.xz---5.4.5.bcr.8",
@@ -33834,6 +38257,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/xz/5.4.5.bcr.8/overlay",
+)
+starlark_repository.local(
+    name = "bzl.xz---5.4.5.bcr.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/xz/5.4.5.bcr.7/overlay",
 )
 starlark_repository.local(
     name = "bzl.xz---5.4.5.bcr.6",
@@ -33848,13 +38278,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/xz/5.4.5.bcr.5/overlay",
-)
-starlark_repository.local(
-    name = "bzl.xz---5.4.5.bcr.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/xz/5.4.5.bcr.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.yaml-cpp---0.9.0",
@@ -33883,15 +38306,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/yaml.bzl/releases/download/v0.1.2/yaml.bzl-v0.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yams---6.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Yams-6.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yams---6.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33900,21 +38314,28 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/jpsim/Yams/archive/refs/tags/6.2.0.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.yams---6.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Yams-6.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.yoga---2.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/yoga/2.0.1/overlay",
+)
 starlark_repository.local(
     name = "bzl.yosys---0.63",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/yosys/0.63/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.yq.bzl---0.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.6",
@@ -33926,15 +38347,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.6/yq.bzl-v0.3.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yq.bzl---0.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.2/yq.bzl-v0.3.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33944,6 +38356,24 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.1/yq.bzl-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.yq.bzl---0.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yq.bzl---0.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.3.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.2/yq.bzl-v0.3.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33951,6 +38381,13 @@ starlark_repository.archive(
     strip_prefix = "yq.bzl-0.3.4",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.4/yq.bzl-v0.3.4.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.yyjson---0.10.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/yyjson/0.10.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.z3---4.15.2",
@@ -33968,6 +38405,27 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/zenoh-c/1.7.2.bcr.1/overlay",
 )
+starlark_repository.local(
+    name = "bzl.zenoh-cpp---1.7.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zenoh-cpp/1.7.2.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.zenoh-pico---1.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zenoh-pico/1.7.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.zip---3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zip/3.0/overlay",
+)
 starlark_repository.archive(
     name = "bzl.zipkin-api---1.0.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -33978,15 +38436,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openzipkin/zipkin-api/archive/refs/tags/1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.zlib---1.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.zlib---1.2.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33994,6 +38443,13 @@ starlark_repository.archive(
     strip_prefix = "zlib-1.2.12",
     type = "zip",
     urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.12.zip"],
+)
+starlark_repository.local(
+    name = "bzl.zlib---1.3.1.bcr.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zlib/1.3.1.bcr.8/overlay",
 )
 starlark_repository.archive(
     name = "bzl.zlib---1.3",
@@ -34013,14 +38469,19 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"],
 )
-starlark_repository.archive(
-    name = "bzl.zlib---1.3.1.bcr.8",
+starlark_repository.local(
+    name = "bzl.zlib---1.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/zlib/1.3.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.zlib-ng---2.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zlib-ng/2.3.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.zlib-ng---2.0.7",
@@ -34032,15 +38493,6 @@ starlark_repository.archive(
     urls = ["https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.zstd---1.5.7.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zstd-1.5.7",
-    type = "tar.gz",
-    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.zstd---1.5.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34048,6 +38500,15 @@ starlark_repository.archive(
     strip_prefix = "zstd-1.5.6",
     type = "tar.gz",
     urls = ["https://github.com/facebook/zstd/releases/download/v1.5.6/zstd-1.5.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.zstd---1.5.7.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zstd-1.5.7",
+    type = "tar.gz",
+    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.zstd-jni---1.5.6-9",
@@ -34059,13 +38520,20 @@ starlark_repository.archive(
     urls = ["https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.6-9.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.zstr---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zstr-1.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/mateidavid/zstr/archive/refs/tags/v1.1.0.tar.gz"],
+)
+starlark_repository.local(
     name = "bzl.zstr---1.0.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "zstr-1.0.7",
-    type = "tar.gz",
-    urls = ["https://github.com/mateidavid/zstr/archive/refs/tags/v1.0.7.tar.gz"],
+    path = "data/bazel-central-registry/modules/zstr/1.0.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.zsync3---0.0.3",
@@ -34075,4 +38543,11 @@ starlark_repository.archive(
     strip_prefix = "zsync-0.0.3",
     type = "tar.gz",
     urls = ["https://github.com/lalten/zsync/releases/download/v0.0.3/v0.0.3.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.zziplib---0.13.72",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zziplib/0.13.72/overlay",
 )

--- a/language/bcr/bcr.go
+++ b/language/bcr/bcr.go
@@ -52,7 +52,7 @@ func NewLanguage() language.Language {
 		moduleSourceRules:        make(map[moduleID]*protoRule[*bzpb.ModuleSource]),
 		bazelReleasesByVersion:   make(map[string]*bzpb.BazelRelease),
 		prAuthorsByPR:            make(map[int]*bzpb.PRAuthor),
-		overlayBzlByID:           make(map[moduleID]bool),
+		overlayStarlarkByID:           make(map[moduleID]bool),
 	}
 }
 
@@ -95,7 +95,7 @@ type bcrExtension struct {
 	docsModuleFilter          string                                          // comma-separated module name prefixes to limit doc generation
 	docsSiteRepo              string                                          // URL of site repo to check for existing docs
 	existingDocs              map[moduleID]bool                               // module versions with docs already on site repo
-	overlayBzlByID            map[moduleID]bool                               // module versions whose BCR overlay contains at least one .bzl file
+	overlayStarlarkByID       map[moduleID]bool                               // module versions whose BCR overlay contains Starlark-evaluable files (.bzl, BUILD, BUILD.bazel, MODULE.bazel)
 	bcrCommitSHA              string                                          // committed SHA of the bazel-central-registry submodule
 	bcrRepositoryURL          string                                          // remote URL of the bazel-central-registry submodule
 	fetchAttestations         bool                                            // whether to emit http_file rules for .intoto.jsonl bundles
@@ -320,7 +320,7 @@ func (ext *bcrExtension) GenerateRules(args language.GenerateArgs) language.Gene
 
 	// log.Println("visiting:", args.Rel, args.RegularFiles)
 
-	ext.scanForOverlayBzlFiles(args)
+	ext.scanForOverlayStarlark(args)
 
 	var rules []*rule.Rule
 
@@ -526,11 +526,19 @@ func inOverlayDir(rel string) bool {
 	return strings.Contains(rel, "/overlay")
 }
 
-// scanForOverlayBzlFiles records, for each module-version whose BCR overlay
-// directory (or any of its descendants) contains a .bzl file, that the module
-// version has overlay starlark. Used later as a fallback signal to generate
-// documentation when the upstream source repo doesn't advertise Starlark.
-func (ext *bcrExtension) scanForOverlayBzlFiles(args language.GenerateArgs) {
+// scanForOverlayStarlark records, for each module-version whose BCR overlay
+// directory (or any of its descendants) contains Starlark-evaluable content
+// — .bzl files, BUILD/BUILD.bazel, or MODULE.bazel — that the module version
+// has overlay starlark. Used later as a fallback signal to generate
+// documentation AND scan packages when the upstream source repo doesn't
+// advertise Starlark.
+//
+// BUILD/MODULE matching matters for header-only / single-BUILD upstreams
+// (e.g. safeint) where BCR overlays only a BUILD.bazel + MODULE.bazel
+// onto the upstream tarball — no .bzl files exist, but the constellate
+// package compiler still needs to see the overlay BUILD for /packages to
+// have any content.
+func (ext *bcrExtension) scanForOverlayStarlark(args language.GenerateArgs) {
 	if ext.modulesRoot == "" || !strings.HasPrefix(args.Rel, ext.modulesRoot+"/") {
 		return
 	}
@@ -544,9 +552,23 @@ func (ext *bcrExtension) scanForOverlayBzlFiles(args language.GenerateArgs) {
 		return
 	}
 	for _, f := range args.RegularFiles {
-		if strings.HasSuffix(f, ".bzl") {
-			ext.overlayBzlByID[newModuleID(parts[0], parts[1])] = true
+		if isOverlayStarlarkFile(f) {
+			ext.overlayStarlarkByID[newModuleID(parts[0], parts[1])] = true
 			return
 		}
 	}
+}
+
+// isOverlayStarlarkFile returns true for files the constellate evaluator can
+// consume as Starlark input from a BCR overlay directory: any .bzl, plus the
+// well-known BUILD-class file basenames.
+func isOverlayStarlarkFile(name string) bool {
+	if strings.HasSuffix(name, ".bzl") {
+		return true
+	}
+	switch filepath.Base(name) {
+	case "BUILD", "BUILD.bazel", "MODULE.bazel":
+		return true
+	}
+	return false
 }

--- a/language/bcr/stardoc.go
+++ b/language/bcr/stardoc.go
@@ -280,22 +280,22 @@ func (ext *bcrExtension) prepareBzlRepositories() rankedModuleVersionMap {
 
 // addOverlayBzlRepositories appends rankedVersion entries backed by a local
 // path into the BCR submodule for module-versions whose upstream source repo
-// does NOT advertise Starlark but whose overlay directory contains .bzl
-// files. Uses the on-disk submodule (no network) — the alternative of
-// fetching the BCR archive from GitHub once per module-version exhausts the
-// rate limit.
+// does NOT advertise Starlark but whose overlay directory contains
+// Starlark-evaluable content (.bzl files OR BUILD/BUILD.bazel/MODULE.bazel).
+// Uses the on-disk submodule (no network) — the alternative of fetching the
+// BCR archive from GitHub once per module-version exhausts the rate limit.
 func (ext *bcrExtension) addOverlayBzlRepositories(versions rankedModuleVersionMap) {
-	if len(ext.overlayBzlByID) == 0 {
+	if len(ext.overlayStarlarkByID) == 0 {
 		return
 	}
 	if ext.registryRoot == "" {
-		log.Printf("warning: %d overlay-bzl modules detected but registry root unavailable; skipping overlay docs", len(ext.overlayBzlByID))
+		log.Printf("warning: %d overlay-starlark modules detected but registry root unavailable; skipping overlay docs", len(ext.overlayStarlarkByID))
 		return
 	}
 
 	added := 0
 	replaced := 0
-	for id := range ext.overlayBzlByID {
+	for id := range ext.overlayStarlarkByID {
 		name := id.name()
 		ver := id.version()
 
@@ -338,7 +338,7 @@ func (ext *bcrExtension) addOverlayBzlRepositories(versions rankedModuleVersionM
 		added++
 	}
 	if added > 0 || replaced > 0 {
-		log.Printf("Overlay-bzl starlark_repository entries: %d added, %d replaced (modules with no upstream Starlark)", added, replaced)
+		log.Printf("Overlay-starlark starlark_repository entries: %d added, %d replaced (modules with no upstream Starlark)", added, replaced)
 	}
 }
 
@@ -377,7 +377,7 @@ func (ext *bcrExtension) rankBzlRepositoryVersionsForModule(id moduleID, deps mo
 		// Generate docs if the module's upstream repo advertises Starlark, OR
 		// (as a fallback) if the BCR overlay for this version carries .bzl files.
 		if !hasStarlarkLanguage(moduleMetadataProtoRule.Rule(), ext.repositoriesMetadataByID) &&
-			!ext.overlayBzlByID[id] {
+			!ext.overlayStarlarkByID[id] {
 			continue
 		}
 

--- a/language/bcr/stardoc_test.go
+++ b/language/bcr/stardoc_test.go
@@ -44,7 +44,7 @@ func TestMakeOverlayBzlRepository(t *testing.T) {
 	}
 }
 
-func TestScanForOverlayBzlFiles(t *testing.T) {
+func TestScanForOverlayStarlark(t *testing.T) {
 	tests := []struct {
 		name         string
 		modulesRoot  string
@@ -67,7 +67,28 @@ func TestScanForOverlayBzlFiles(t *testing.T) {
 			wantIDs:      []moduleID{newModuleID("libxcrypt", "4.4.36")},
 		},
 		{
-			name:         "no .bzl files in overlay subdir",
+			name:         "BUILD.bazel-only overlay (header-only upstream)",
+			modulesRoot:  "modules",
+			rel:          "modules/safeint/3.0.28/overlay",
+			regularFiles: []string{"BUILD.bazel", "MODULE.bazel"},
+			wantIDs:      []moduleID{newModuleID("safeint", "3.0.28")},
+		},
+		{
+			name:         "MODULE.bazel-only overlay",
+			modulesRoot:  "modules",
+			rel:          "modules/foo/1.0/overlay",
+			regularFiles: []string{"MODULE.bazel"},
+			wantIDs:      []moduleID{newModuleID("foo", "1.0")},
+		},
+		{
+			name:         "BUILD (no extension) in overlay",
+			modulesRoot:  "modules",
+			rel:          "modules/bar/2.0/overlay",
+			regularFiles: []string{"BUILD"},
+			wantIDs:      []moduleID{newModuleID("bar", "2.0")},
+		},
+		{
+			name:         "no starlark files in overlay subdir",
 			modulesRoot:  "modules",
 			rel:          "modules/foo/1.0/overlay/data",
 			regularFiles: []string{"README.md"},
@@ -98,19 +119,19 @@ func TestScanForOverlayBzlFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ext := &bcrExtension{
-				modulesRoot:    tt.modulesRoot,
-				overlayBzlByID: make(map[moduleID]bool),
+				modulesRoot:         tt.modulesRoot,
+				overlayStarlarkByID: make(map[moduleID]bool),
 			}
-			ext.scanForOverlayBzlFiles(language.GenerateArgs{
+			ext.scanForOverlayStarlark(language.GenerateArgs{
 				Rel:          tt.rel,
 				RegularFiles: tt.regularFiles,
 			})
-			if len(ext.overlayBzlByID) != len(tt.wantIDs) {
-				t.Fatalf("overlayBzlByID size = %d, want %d (got %v)", len(ext.overlayBzlByID), len(tt.wantIDs), ext.overlayBzlByID)
+			if len(ext.overlayStarlarkByID) != len(tt.wantIDs) {
+				t.Fatalf("overlayStarlarkByID size = %d, want %d (got %v)", len(ext.overlayStarlarkByID), len(tt.wantIDs), ext.overlayStarlarkByID)
 			}
 			for _, id := range tt.wantIDs {
-				if !ext.overlayBzlByID[id] {
-					t.Errorf("expected overlayBzlByID[%s] to be true", id)
+				if !ext.overlayStarlarkByID[id] {
+					t.Errorf("expected overlayStarlarkByID[%s] to be true", id)
 				}
 			}
 		})
@@ -151,7 +172,7 @@ func TestAddOverlayBzlRepositories_OverlayOnlyModule(t *testing.T) {
 	metaRule, repoMeta := fakeNonStarlarkMetadataRule()
 
 	ext := &bcrExtension{
-		overlayBzlByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
+		overlayStarlarkByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
 		moduleMetadataRules:      map[moduleName]*protoRule[*bzpb.ModuleMetadata]{"colordiff": metaRule},
 		repositoriesMetadataByID: repoMeta,
 		registryRoot:             "data/bazel-central-registry",
@@ -198,7 +219,7 @@ func TestAddOverlayBzlRepositories_ReplacesSourceURLEntry(t *testing.T) {
 	}
 
 	ext := &bcrExtension{
-		overlayBzlByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
+		overlayStarlarkByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
 		moduleMetadataRules:      map[moduleName]*protoRule[*bzpb.ModuleMetadata]{"colordiff": metaRule},
 		repositoriesMetadataByID: repoMeta,
 		registryRoot:             "data/bazel-central-registry",
@@ -239,7 +260,7 @@ func TestAddOverlayBzlRepositories_SkipsWhenUpstreamHasStarlark(t *testing.T) {
 	}
 
 	ext := &bcrExtension{
-		overlayBzlByID:           map[moduleID]bool{newModuleID("rules_foo", "1.0"): true},
+		overlayStarlarkByID:           map[moduleID]bool{newModuleID("rules_foo", "1.0"): true},
 		moduleMetadataRules:      map[moduleName]*protoRule[*bzpb.ModuleMetadata]{"rules_foo": metaRule},
 		repositoriesMetadataByID: repoMeta,
 		registryRoot:             "data/bazel-central-registry",
@@ -261,7 +282,7 @@ func TestAddOverlayBzlRepositories_NoRegistryRootSkips(t *testing.T) {
 	// rules with empty path attrs.
 	metaRule, repoMeta := fakeNonStarlarkMetadataRule()
 	ext := &bcrExtension{
-		overlayBzlByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
+		overlayStarlarkByID:           map[moduleID]bool{newModuleID("colordiff", "1.0.22"): true},
 		moduleMetadataRules:      map[moduleName]*protoRule[*bzpb.ModuleMetadata]{"colordiff": metaRule},
 		repositoriesMetadataByID: repoMeta,
 		// registryRoot intentionally empty

--- a/rules/prerender.bzl
+++ b/rules/prerender.bzl
@@ -12,6 +12,7 @@ and compiler tool defaults are baked in as private attrs; callers usually
 just need to supply `tarball` and (for prerender_pages) `url_list`.
 """
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@rules_browsers//browsers:named_files_info.bzl", "NamedFilesInfo")
 
 _DEFAULT_CHROMIUM = "@rules_browsers//browsers/chromium:chromium"
@@ -240,10 +241,10 @@ def _prerender_pages_impl(ctx):
             shard_total = n,
             timeout = ctx.attr.timeout_seconds,
             settle_ms = ctx.attr.settle_ms,
-            pool = ctx.attr.pool_size,
-            tab_max_pages = ctx.attr.tab_max_pages,
+            pool = ctx.attr.pool_size[BuildSettingInfo].value,
+            tab_max_pages = ctx.attr.tab_max_pages[BuildSettingInfo].value,
             retries = ctx.attr.retries,
-            warmup_concurrency = ctx.attr.warmup_concurrency,
+            warmup_concurrency = ctx.attr.warmup_concurrency[BuildSettingInfo].value,
         )
         ctx.actions.run_shell(
             outputs = [shard_out],
@@ -317,21 +318,23 @@ prerender_pages = rule(
                   "in well under the cap. The cap is the fallback for routes that fail " +
                   "to settle.",
         ),
-        "pool_size": attr.int(
-            default = 8,
-            doc = "Number of reusable chromedp tabs per shard. One Chrome process hosts all " +
-                  "tabs; each tab is reused for many SPA-pushState renders. Default 8 keeps " +
-                  "memory headroom; at 16 the combined V8 heaps + accumulated SPA state can " +
-                  "OOM mid-batch on smaller machines.",
+        "pool_size": attr.label(
+            default = "//app/bcr:prerender_pool_size",
+            providers = [BuildSettingInfo],
+            doc = "Label of an int_flag for the number of reusable chromedp tabs per " +
+                  "shard. One Chrome process hosts all tabs; each tab is reused for many " +
+                  "SPA-pushState renders. Default flag value is 8 (tuned for 16GB/10-CPU); " +
+                  "CI raises it via --//app/bcr:prerender_pool_size=24 (see .bazelrc " +
+                  "build:ci).",
         ),
-        "tab_max_pages": attr.int(
-            default = 27,
-            doc = "Recycle each tab after this many renders. Keeps JS heap bounded across " +
-                  "long batches — the previous warm-tab attempt was abandoned because the " +
-                  "SPA's per-route state accumulated without bound; this bounds it. Default " +
-                  "25 balances heap ceiling against per-recycle Navigate cost: too aggressive " +
-                  "(10) and the extra Navigates dominate; too lax (50 at pool_size=16) and " +
-                  "the combined heaps OOM the machine.",
+        "tab_max_pages": attr.label(
+            default = "//app/bcr:prerender_tab_max_pages",
+            providers = [BuildSettingInfo],
+            doc = "Label of an int_flag for per-tab render budget before recycling. " +
+                  "Bounds JS heap drift across long batches. Default flag value 27 " +
+                  "balances heap ceiling against per-recycle Navigate cost: too aggressive " +
+                  "(10) and extra Navigates dominate; too lax (50 at pool_size=16) and " +
+                  "combined heaps OOM smaller machines.",
         ),
         "retries": attr.int(
             default = 1,
@@ -341,16 +344,16 @@ prerender_pages = rule(
                   "almost all of them. Increase if you see a particular module " +
                   "consistently failing once but rendering fine on a second try.",
         ),
-        "warmup_concurrency": attr.int(
-            default = 4,
-            doc = "Pre-warm every pool tab against the SPA root before processing real " +
-                  "URLs, with at most this many REGISTRY_DATA parses in flight. " +
-                  "Without warmup, all pool_size tabs Navigate simultaneously on cold " +
-                  "start and the 16-way concurrent ~2.7MB protobuf parse contends hard " +
-                  "enough to push tabs past --timeout_seconds (observed: 30s+ tail, " +
-                  "11 timeouts clustered in the first batch). Serializing the parse to " +
-                  "4-way concurrency lets each tab pay close to the ~1.5s solo cost. " +
-                  "Set to 0 to disable warmup.",
+        "warmup_concurrency": attr.label(
+            default = "//app/bcr:prerender_warmup_concurrency",
+            providers = [BuildSettingInfo],
+            doc = "Label of an int_flag for max in-flight cold-start REGISTRY_DATA parses " +
+                  "during pool warmup. Without warmup, all pool_size tabs Navigate " +
+                  "simultaneously on cold start and the N-way concurrent ~2.7MB protobuf " +
+                  "parse contends hard enough to push tabs past --timeout_seconds " +
+                  "(observed: 30s+ tail, timeouts clustered in the first batch). " +
+                  "Serializing the parse to 4-way concurrency lets each tab pay close to " +
+                  "the ~1.5s solo cost. Set the flag to 0 to disable warmup.",
         ),
     }, **_TOOL_ATTRS),
 )


### PR DESCRIPTION
Broaden the Gazelle extension's overlay-Starlark detection from just .bzl to also match BUILD/BUILD.bazel/MODULE.bazel, so module versions whose BCR overlay supplies only a BUILD.bazel (e.g. header-only upstreams like safeint) get a starlark_repository.local target wired and feed the package-compile pipeline. /packages no longer renders empty for these modules.

- scanForOverlayBzlFiles → scanForOverlayStarlark; field overlayBzlByID → overlayStarlarkByID. New isOverlayStarlarkFile helper matches .bzl OR the BUILD-class basenames.
- addOverlayBzlRepositories unchanged in structure — its trigger broadens via the renamed map. Upstream-Starlark modules still take the upstream path; overlay remains fallback-only.
- BUILD-only overlays produce no stardoc output (no rules to document); the existing zero-rules path covers this.
- Patches-only modules where the BUILD comes from a patch on the upstream (no overlay file present) remain uncovered — detecting those would need fetch+patch at scan time, which we don't do.

PR also includes new prerendering flags for CI (somewhat unrelated change)