### PR TITLE
fix: hard-fail on constellate connection errors during extraction

### DIFF
--- a/app/bcr/registry.soy
+++ b/app/bcr/registry.soy
@@ -673,9 +673,9 @@ import {
             <div style="display: flex; align-items: center;">
               <span style="position: relative; padding-right: 0.5em;" data-version="{$version}">
                 {if $currentVersion === $version}
-                  <span class="text-bold">{$version|truncate:18}</span>
+                  <span class="text-bold f4">{$version|truncate:18}</span>
                 {else}
-                  <a class="Box-row-link" href="{moduleVersionUrl(name: $moduleName, version: $version)}"
+                  <a class="Box-row-link f5" href="{moduleVersionUrl(name: $moduleName, version: $version)}"
                       {if $yanked.get($version)}style="text-decoration: line-through; color: var(--color-fg-muted);"{/if}
                   >{$version|truncate:18}</a>
                 {/if}

--- a/cmd/builtininfocompiler/reshape.go
+++ b/cmd/builtininfocompiler/reshape.go
@@ -394,6 +394,9 @@ func typeFieldsToStructFields(t *builtinpb.Type, extras []*builtinpb.Value) []*s
 		if f == nil {
 			continue
 		}
+		if f.GetName() == "" {
+			log.Panicf("typeFieldsToStructFields: empty field name in type %q: %+v", t.GetName(), f)
+		}
 		out = append(out, &slpb.StructField{
 			Name:          f.GetName(),
 			TargetSymbol:  f.GetName(),
@@ -404,7 +407,13 @@ func typeFieldsToStructFields(t *builtinpb.Type, extras []*builtinpb.Value) []*s
 		if e == nil {
 			continue
 		}
+		if e.GetName() == "" {
+			log.Panicf("typeFieldsToStructFields: empty extra name under type %q: %+v", t.GetName(), e)
+		}
 		_, suffix, _ := splitNamespacePrefix(e.GetName())
+		if suffix == "" {
+			log.Panicf("typeFieldsToStructFields: empty suffix after splitting extra name %q under type %q: %+v", e.GetName(), t.GetName(), e)
+		}
 		out = append(out, &slpb.StructField{
 			Name:          suffix,
 			TargetSymbol:  suffix,

--- a/cmd/bzlcompiler/extract.go
+++ b/cmd/bzlcompiler/extract.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	sympb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/symbol/v1"
@@ -11,12 +13,22 @@ import (
 	"github.com/bazel-contrib/bcr-frontend/pkg/stardoc"
 )
 
+var errConstellateUnavailable = errors.New("constellate server unavailable")
+
+func isConnectionError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connect: no route to host") ||
+		(strings.Contains(s, "dial tcp") && strings.Contains(s, "connect:"))
+}
+
 func extractModuleVersionSymbols(cfg *config, bzlFileByPath map[string]*bzlFile, filesToExtract []string) (*sympb.ModuleVersionSymbols, error) {
 	result := &sympb.ModuleVersionSymbols{
 		Source: sympb.SymbolSource_BEST_EFFORT,
 	}
 
-	var errors int
+	var errCount int
 	for _, filePath := range filesToExtract {
 		bzlFile, found := bzlFileByPath[filePath]
 		if !found {
@@ -33,13 +45,16 @@ func extractModuleVersionSymbols(cfg *config, bzlFileByPath map[string]*bzlFile,
 
 		module, err := extractModule(cfg, bzlFile)
 		if err != nil {
+			if errors.Is(err, errConstellateUnavailable) {
+				return nil, err
+			}
 			file.Error = err.Error()
-			if cfg.ErrorLimit > 0 && errors > cfg.ErrorLimit {
+			if cfg.ErrorLimit > 0 && errCount > cfg.ErrorLimit {
 				cfg.Logger.Panicf("🔴 failed to extract %+v: %v", bzlFile, err)
 			} else {
 				cfg.Logger.Printf("🔴 failed to extract %+v: %v", bzlFile, err)
 			}
-			errors++
+			errCount++
 		} else {
 			stardoc.ModuleToFile(file, module)
 			// cfg.Logger.Printf("🟢 successfully extracted %s", bzlFile.Label)
@@ -51,7 +66,7 @@ func extractModuleVersionSymbols(cfg *config, bzlFileByPath map[string]*bzlFile,
 
 	// Report success rate
 	total := len(cfg.FilesToExtract)
-	success := total - errors
+	success := total - errCount
 	pct := float64(success) / float64(total) * 100.0
 	cfg.Logger.Printf("Extraction: %d/%d %.1f%%", success, total, pct)
 
@@ -75,6 +90,9 @@ func extractModule(cfg *config, file *bzlFile) (*slpb.Module, error) {
 	if err != nil {
 		// Strip absolute path prefix from error messages
 		cleanErr := cleanErrorMessage(err, cfg.Cwd)
+		if isConnectionError(err) {
+			return nil, fmt.Errorf("%w: %v", errConstellateUnavailable, cleanErr)
+		}
 		return nil, fmt.Errorf("ModuleInfo request error: %v", cleanErr)
 	}
 

--- a/cmd/packagecompiler/extract.go
+++ b/cmd/packagecompiler/extract.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	sympb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/symbol/v1"
@@ -11,12 +13,22 @@ import (
 	"github.com/bazel-contrib/bcr-frontend/pkg/stardoc"
 )
 
+var errConstellateUnavailable = errors.New("constellate server unavailable")
+
+func isConnectionError(err error) bool {
+	s := err.Error()
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connect: no route to host") ||
+		(strings.Contains(s, "dial tcp") && strings.Contains(s, "connect:"))
+}
+
 func extractModuleVersionPackages(cfg *config, packageFileByPath map[string]*packageFile, filesToExtract []string) (*sympb.ModuleVersionPackages, error) {
 	result := &sympb.ModuleVersionPackages{
 		Source: sympb.SymbolSource_BEST_EFFORT,
 	}
 
-	var errors int
+	var errCount int
 	for _, filePath := range filesToExtract {
 		pkgFile, found := packageFileByPath[filePath]
 		if !found {
@@ -25,15 +37,15 @@ func extractModuleVersionPackages(cfg *config, packageFileByPath map[string]*pac
 
 		pkg, err := extractPackage(cfg, pkgFile)
 		if err != nil {
-			if cfg.ErrorLimit > 0 && errors > cfg.ErrorLimit {
+			if errors.Is(err, errConstellateUnavailable) {
+				return nil, err
+			}
+			if cfg.ErrorLimit > 0 && errCount > cfg.ErrorLimit {
 				cfg.Logger.Panicf("🔴 failed to extract %+v: %v", pkgFile, err)
 			} else {
 				cfg.Logger.Printf("🔴 failed to extract %+v: %v", pkgFile, err)
 			}
-			errors++
-			// Preserve a stub entry so the registry-side aggregation still has
-			// something to attribute to this file (mirrors bzlcompiler's
-			// behavior of appending a sympb.File with .Error set).
+			errCount++
 			result.Package = append(result.Package, &slpb.Package{
 				Filename: filePath,
 				Error:    []string{err.Error()},
@@ -44,7 +56,7 @@ func extractModuleVersionPackages(cfg *config, packageFileByPath map[string]*pac
 	}
 
 	total := len(cfg.FilesToExtract)
-	success := total - errors
+	success := total - errCount
 	pct := float64(success) / float64(total) * 100.0
 	cfg.Logger.Printf("Extraction: %d/%d %.1f%%", success, total, pct)
 
@@ -67,6 +79,9 @@ func extractPackage(cfg *config, file *packageFile) (*slpb.Package, error) {
 	})
 	if err != nil {
 		cleanErr := cleanErrorMessage(err, cfg.Cwd)
+		if isConnectionError(err) {
+			return nil, fmt.Errorf("%w: %v", errConstellateUnavailable, cleanErr)
+		}
 		return nil, fmt.Errorf("PackageInfo request error: %v", cleanErr)
 	}
 

--- a/rules/release.bzl
+++ b/rules/release.bzl
@@ -4,7 +4,7 @@ def _write_executable_action(ctx, archive_file):
     ctx.actions.write(
         output = ctx.outputs.executable,
         content = """
-{server} {archive_file}
+{server} "$@" {archive_file}
 """.format(
             server = ctx.executable._releaseserver.short_path,
             archive_file = archive_file.short_path,


### PR DESCRIPTION
bzlcompiler and packagecompiler were swallowing dial failures into per-file Error fields, so the registry build "succeeded" with module pages full of "connection refused" entries (visible on rules_shar's Documentation and Packages tabs). Detect connection-class errors (refused, reset, no route, dial+connect) and wrap them in a sentinel errConstellateUnavailable that short-circuits the extract loop, making the bazel action fail visibly instead.

Also:
- rules/release.bzl: forward extra args through the release wrapper ($@ before the tarball) so `bazel run //app/bcr:release -- --host=0.0.0.0` binds for LAN access (needed for testing on physical mobile devices).
- builtininfocompiler/reshape.go: panic on empty field/extra names in typeFieldsToStructFields instead of emitting blank entries.
- registry.soy: bump version-list font sizes (f4 current, f5 links).