### PR TITLE
feat: add Registry Data Refresh setting + header indicator

### DIFF
--- a/app/bcr/BUILD.bazel
+++ b/app/bcr/BUILD.bazel
@@ -282,6 +282,7 @@ closure_js_library(
         "mvs_tree.js",
         "packages.js",
         "presubmit.js",
+        "refresh.js",
         "search.js",
         "selectnav.js",
         "settings.js",

--- a/app/bcr/app.js
+++ b/app/bcr/app.js
@@ -15,6 +15,11 @@ const { App, Component, Route, RouteEvent, RouteEventType } =
 	goog.require("stack.ui");
 const { Application, SearchProvider } = goog.requireType("bcrfrontend.common");
 const { BodySelect } = goog.require("bcrfrontend.body");
+const {
+	EVENT_CHANGE: REFRESH_EVENT_CHANGE,
+	RefreshController,
+	RefreshMode,
+} = goog.require("bcrfrontend.refresh");
 const { MVS } = goog.require("bcrfrontend.mvs");
 const { SCOPE_ALL, SCOPE_MODULES, SCOPE_SYMBOLS, UnifiedSearchHandler } =
 	goog.require("bcrfrontend.unified_search");
@@ -37,6 +42,7 @@ class RegistryApp extends App {
 	 * @param {!Promise<!Registry>} registryWithPackages
 	 * @param {!Promise<*>} ruleUsageIndex resolves to Map<urlKey, Array<TargetRef>>.
 	 * @param {function():!Promise<*>} bazelFlagDbLoader memoized lazy loader.
+	 * @param {!RefreshController} refreshController
 	 * @param {?dom.DomHelper=} opt_domHelper
 	 */
 	constructor(
@@ -45,6 +51,7 @@ class RegistryApp extends App {
 		registryWithPackages,
 		ruleUsageIndex,
 		bazelFlagDbLoader,
+		refreshController,
 		opt_domHelper,
 	) {
 		super(opt_domHelper);
@@ -63,6 +70,12 @@ class RegistryApp extends App {
 
 		/** @private @const @type {function():!Promise<*>} */
 		this.bazelFlagDbLoader_ = bazelFlagDbLoader;
+
+		/** @private @const @type {!RefreshController} */
+		this.refreshController_ = refreshController;
+
+		/** @private @type {?number} */
+		this.autoReloadTimerId_ = null;
 
 		/** @private @type {!Map<string,string>} */
 		this.options_ = new Map();
@@ -170,6 +183,7 @@ class RegistryApp extends App {
 		this.enterSearch();
 		this.enterKeys();
 		this.enterTopLevelClickEvents();
+		this.enterRefresh();
 	}
 
 	/**
@@ -226,6 +240,54 @@ class RegistryApp extends App {
 	 */
 	getUnifiedSearchHandler() {
 		return this.unifiedSearchHandler_;
+	}
+
+	/**
+	 * @return {!RefreshController}
+	 */
+	getRefreshController() {
+		return this.refreshController_;
+	}
+
+	/**
+	 * Wire the refresh poller: apply the persisted mode (default Notify)
+	 * and listen for CHANGE events so we can reveal the header indicator
+	 * (and, in Auto mode, schedule a window reload).
+	 */
+	enterRefresh() {
+		let mode = RefreshMode.NOTIFY;
+		try {
+			const stored = window.localStorage?.getItem("refresh-mode");
+			if (
+				stored === RefreshMode.OFF ||
+				stored === RefreshMode.NOTIFY ||
+				stored === RefreshMode.AUTO
+			) {
+				mode = stored;
+			}
+		} catch (/** @type {*} */ e) {}
+
+		this.getHandler().listen(
+			this.refreshController_,
+			REFRESH_EVENT_CHANGE,
+			this.handleRefreshChange,
+		);
+		this.refreshController_.setMode(mode);
+		document.documentElement.classList.add("bcr-refresh-available");
+	}
+
+	/**
+	 * @param {!events.Event} e
+	 */
+	handleRefreshChange(e) {
+		document.documentElement.classList.add("bcr-refresh-available");
+		if (this.refreshController_.getMode() === RefreshMode.AUTO) {
+			if (this.autoReloadTimerId_ === null) {
+				this.autoReloadTimerId_ = window.setTimeout(() => {
+					window.location.reload();
+				}, 3000);
+			}
+		}
 	}
 
 	/**
@@ -510,6 +572,10 @@ class RegistryApp extends App {
 				}
 				if (action === "prev-sibling") {
 					this.gotoSibling(-1);
+					return true;
+				}
+				if (action === "reload") {
+					window.location.reload();
 					return true;
 				}
 				if (node instanceof HTMLAnchorElement) {

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -29,6 +29,7 @@ import {
     octiconSparkleFill16,
     octiconSquareFill16,
     octiconStarFill16,
+    octiconSync16,
     octiconTable16,
     octiconWorkflow16
 } from 'app/bcr/octicons.soy';
@@ -163,13 +164,18 @@ import {
 
 {template header}
 <div class="Header" style="background-color: unset">
-  <div class="Header-item" style="max-width: 54px">
+  <div class="Header-item" style="max-width: 54px; position: relative;">
     <a href="/home">{logo()}</a>
+    <a href="javascript:void(0)" data-action="reload"
+       class="bcr-refresh-indicator"
+       title="New registry data available — click to reload">
+      {octiconSync16()}
+    </a>
   </div>
   <div class="Header-item Header-item--full">
     <form class="d-flex flex-items-stretch width-full" style="margin-block-end: 0">
-      <input class="form-control input-hide-webkit-autofill flex-auto" type="text" placeholder="Search..." style="background-color: var(--button-default-bgColor-rest, var(--color-btn-bg)); border-top-right-radius: 0; border-bottom-right-radius: 0; border-right: 0;"/>
-      <div class="BtnGroup flex-shrink-0" role="group" aria-label="Search scope">
+      <input class="form-control input-hide-webkit-autofill flex-auto search-scope-fused" type="text" placeholder="Search..." style="background-color: var(--button-default-bgColor-rest, var(--color-btn-bg));"/>
+      <div class="BtnGroup flex-shrink-0 d-none d-md-inline-block" role="group" aria-label="Search scope">
         <button type="button" class="btn BtnGroup-item selected" data-searchscope="all" aria-pressed="true" style="border-top-left-radius: 0; border-bottom-left-radius: 0;">All</button>
         <button type="button" class="btn BtnGroup-item" data-searchscope="modules" aria-pressed="false">Modules</button>
         <button type="button" class="btn BtnGroup-item" data-searchscope="symbols" aria-pressed="false">Symbols</button>

--- a/app/bcr/common.js
+++ b/app/bcr/common.js
@@ -82,6 +82,14 @@ class Application {
 	 * @returns {!Promise<*>}
 	 */
 	getBazelFlagDb() {}
+
+	/**
+	 * Returns the registry-data refresh poller. Settings UI reads/writes
+	 * its mode; the app listens to its CHANGE event to reveal the header
+	 * indicator and (in Auto mode) schedule a reload.
+	 * @returns {*}
+	 */
+	getRefreshController() {}
 }
 exports.Application = Application;
 

--- a/app/bcr/index.html
+++ b/app/bcr/index.html
@@ -47,6 +47,7 @@
 		<meta name="bcr:symbols-url" content="/{symbols.pb.gz}">
 		<meta name="bcr:packages-url" content="/{packages.pb.gz}">
 		<meta name="bcr:bazelflagdb-url" content="/{bazelflagdb.pb.gz}">
+		<meta name="bcr:manifest-url" content="/manifest.pb.gz">
 		<script src="/{bcr.js}" defer></script>
 		<script src="/{registry.pb.gz.b64.js}" defer></script>
 	</head>

--- a/app/bcr/main.js
+++ b/app/bcr/main.js
@@ -13,6 +13,9 @@ const ModuleVersion = goog.require(
 const Registry = goog.require("proto.build.stack.bazel.registry.v1.Registry");
 const RegistryApp = goog.require("bcrfrontend.App");
 const base64 = goog.require("goog.crypt.base64");
+const { RefreshController, collectBootAssetHashes } = goog.require(
+	"bcrfrontend.refresh",
+);
 const { gzipDecode } = goog.require("bcrfrontend.common");
 const { loadLabelToUrlKey } = goog.require("bcrfrontend.starlark");
 
@@ -55,12 +58,19 @@ async function main(registryDataBase64) {
 		stale[i].remove();
 	}
 
+	const refreshController = new RefreshController({
+		manifestUrl: metaUrl("bcr:manifest-url"),
+		bootCommitSha: registry.getCommitSha() || "",
+		bootAssetHashes: collectBootAssetHashes(),
+	});
+
 	const app = new RegistryApp(
 		registry,
 		registryWithSymbols,
 		registryWithPackages,
 		ruleUsageIndex,
 		getBazelFlagDb,
+		refreshController,
 	);
 	app.render(document.body);
 	app.start();

--- a/app/bcr/refresh.js
+++ b/app/bcr/refresh.js
@@ -1,0 +1,240 @@
+/**
+ * @fileoverview RefreshController polls a tiny manifest.pb.gz at the
+ * release root and emits a CHANGE event when the deployed bundle has
+ * changed since boot — either a BCR data refresh (commit_sha advances)
+ * or a code redeploy (any asset hash differs).
+ */
+goog.module("bcrfrontend.refresh");
+
+const EventTarget = goog.require("goog.events.EventTarget");
+const RegistryManifest = goog.require(
+	"proto.build.stack.bazel.registry.v1.RegistryManifest",
+);
+const { gzipDecode } = goog.require("bcrfrontend.common");
+
+/** @enum {string} */
+const RefreshMode = {
+	OFF: "off",
+	NOTIFY: "notify",
+	AUTO: "auto",
+};
+exports.RefreshMode = RefreshMode;
+
+/** @enum {string} */
+const ChangeKind = {
+	NONE: "none",
+	DATA: "data",
+	CODE: "code",
+	BOTH: "both",
+};
+exports.ChangeKind = ChangeKind;
+
+/** Event type dispatched on the controller when a refresh is detected. */
+const EVENT_CHANGE = "refresh.change";
+exports.EVENT_CHANGE = EVENT_CHANGE;
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Scans the document for content-hashed assets and returns a snapshot
+ * keyed by un-hashed basename (matching the manifest's keys). Reads
+ * `<script src>`, `<link href>`, and `<meta name="bcr:*-url" content>`
+ * so that eagerly-loaded code AND meta-referenced lazy assets are both
+ * covered.
+ *
+ * @return {!Object<string, string>}
+ */
+function collectBootAssetHashes() {
+	/** @type {!Object<string, string>} */
+	const out = {};
+	const add = (/** @type {string} */ url) => {
+		if (!url) return;
+		// Strip leading slash + any query string.
+		const path = url.replace(/^\/+/, "").split("?")[0];
+		if (!path || path.indexOf("/") >= 0) return;
+		const original = unhashFilename(path);
+		if (original !== path) {
+			out[original] = path;
+		}
+	};
+	for (const el of document.querySelectorAll("script[src]")) {
+		add(el.getAttribute("src") || "");
+	}
+	for (const el of document.querySelectorAll("link[href]")) {
+		add(el.getAttribute("href") || "");
+	}
+	for (const el of document.querySelectorAll('meta[name^="bcr:"]')) {
+		add(el.getAttribute("content") || "");
+	}
+	return out;
+}
+exports.collectBootAssetHashes = collectBootAssetHashes;
+
+/**
+ * Strips the 8+-char hex content hash that releasecompiler inserts
+ * before the first extension. `bcr.abcd1234.js` → `bcr.js`. Returns
+ * the input unchanged if no hash is present.
+ *
+ * @param {string} name
+ * @return {string}
+ */
+function unhashFilename(name) {
+	const m = name.match(/^([^.]+)\.([a-f0-9]{6,})\.(.+)$/);
+	if (!m) return name;
+	return `${m[1]}.${m[3]}`;
+}
+
+/**
+ * Holds the boot snapshot + polling state. The OFF / NOTIFY / AUTO
+ * distinction is handled here only to the extent of starting/stopping
+ * the timer for OFF; AUTO vs NOTIFY only affects the consumer's
+ * reaction to the CHANGE event.
+ */
+class RefreshController extends EventTarget {
+	/**
+	 * @param {{
+	 *   manifestUrl: ?string,
+	 *   bootCommitSha: string,
+	 *   bootAssetHashes: !Object<string, string>,
+	 * }} opts
+	 */
+	constructor(opts) {
+		super();
+
+		/** @private @const @type {?string} */
+		this.manifestUrl_ = opts.manifestUrl || null;
+
+		/** @private @const @type {string} */
+		this.bootCommitSha_ = opts.bootCommitSha;
+
+		/** @private @const @type {!Object<string, string>} */
+		this.bootAssetHashes_ = opts.bootAssetHashes;
+
+		/** @private @type {string} */
+		this.mode_ = RefreshMode.OFF;
+
+		/** @private @type {?number} */
+		this.timerId_ = null;
+
+		/** @private @type {string} */
+		this.latestChangeKind_ = ChangeKind.NONE;
+
+		/** @private @const */
+		this.visibilityHandler_ = () => {
+			if (document.visibilityState === "visible") {
+				if (this.mode_ !== RefreshMode.OFF) {
+					this.pollNow();
+					this.restartTimer_();
+				}
+			} else {
+				this.stopTimer_();
+			}
+		};
+		document.addEventListener("visibilitychange", this.visibilityHandler_);
+	}
+
+	/** @return {string} */
+	getMode() {
+		return this.mode_;
+	}
+
+	/** @return {string} */
+	getLatestChangeKind() {
+		return this.latestChangeKind_;
+	}
+
+	/**
+	 * Enable / disable polling. Idempotent; safe to call repeatedly.
+	 * @param {string} mode
+	 */
+	setMode(mode) {
+		if (
+			mode !== RefreshMode.OFF &&
+			mode !== RefreshMode.NOTIFY &&
+			mode !== RefreshMode.AUTO
+		) {
+			return;
+		}
+		this.mode_ = mode;
+		if (mode === RefreshMode.OFF || !this.manifestUrl_) {
+			this.stopTimer_();
+			return;
+		}
+		this.restartTimer_();
+	}
+
+	/**
+	 * Triggers an immediate poll regardless of the timer phase. Used on
+	 * tab-visibility-becomes-visible.
+	 * @return {!Promise<void>}
+	 */
+	async pollNow() {
+		if (!this.manifestUrl_) return;
+		try {
+			const url = this.manifestUrl_ + "?t=" + Date.now();
+			const res = await fetch(url, { cache: "no-store" });
+			if (!res.ok) return;
+			const gz = new Uint8Array(await res.arrayBuffer());
+			const raw = await gzipDecode(gz);
+			const manifest = RegistryManifest.deserializeBinary(raw);
+			const kind = this.diff_(manifest);
+			if (kind === ChangeKind.NONE) return;
+			if (kind === this.latestChangeKind_) return;
+			this.latestChangeKind_ = kind;
+			this.dispatchEvent({ type: EVENT_CHANGE, kind, manifest });
+		} catch (/** @type {*} */ e) {
+			// Network blip / CORS / parse error: skip silently. The next
+			// tick will retry.
+		}
+	}
+
+	/**
+	 * @private
+	 * @param {!RegistryManifest} manifest
+	 * @return {string}
+	 */
+	diff_(manifest) {
+		const dataChanged =
+			!!this.bootCommitSha_ &&
+			manifest.getCommitSha() !== "" &&
+			manifest.getCommitSha() !== this.bootCommitSha_;
+		let codeChanged = false;
+		const map = manifest.getAssetHashesMap();
+		for (const original in this.bootAssetHashes_) {
+			const bootHashed = this.bootAssetHashes_[original];
+			const liveHashed = map.get(original);
+			if (liveHashed && liveHashed !== bootHashed) {
+				codeChanged = true;
+				break;
+			}
+		}
+		if (dataChanged && codeChanged) return ChangeKind.BOTH;
+		if (dataChanged) return ChangeKind.DATA;
+		if (codeChanged) return ChangeKind.CODE;
+		return ChangeKind.NONE;
+	}
+
+	/** @private */
+	restartTimer_() {
+		this.stopTimer_();
+		this.timerId_ = window.setInterval(() => {
+			this.pollNow();
+		}, POLL_INTERVAL_MS);
+	}
+
+	/** @private */
+	stopTimer_() {
+		if (this.timerId_ !== null) {
+			window.clearInterval(this.timerId_);
+			this.timerId_ = null;
+		}
+	}
+
+	/** @override */
+	disposeInternal() {
+		this.stopTimer_();
+		document.removeEventListener("visibilitychange", this.visibilityHandler_);
+		super.disposeInternal();
+	}
+}
+exports.RefreshController = RefreshController;

--- a/app/bcr/settings.js
+++ b/app/bcr/settings.js
@@ -8,6 +8,8 @@ const events = goog.require("goog.events");
 const soy = goog.require("goog.soy");
 const { Component, Route } = goog.require("stack.ui");
 const { ContentSelect } = goog.require("bcrfrontend.ContentSelect");
+const { getApplication } = goog.require("bcrfrontend.common");
+const { RefreshController, RefreshMode } = goog.require("bcrfrontend.refresh");
 const { settingsAppearanceComponent, settingsSelect } = goog.require(
 	"soy.bcrfrontend.settings",
 );
@@ -18,6 +20,7 @@ const { settingsAppearanceComponent, settingsSelect } = goog.require(
 const LocalStorageKey = {
 	COLOR_MODE: "color-mode",
 	DISPLAY_MODE: "display-mode",
+	REFRESH_MODE: "refresh-mode",
 };
 
 /**
@@ -94,6 +97,9 @@ class SettingsAppearanceComponent extends Component {
 
 		/** @private @type {?HTMLSelectElement} */
 		this.displaySelectEl_ = null;
+
+		/** @private @type {?HTMLSelectElement} */
+		this.refreshSelectEl_ = null;
 	}
 
 	/**
@@ -111,6 +117,7 @@ class SettingsAppearanceComponent extends Component {
 
 		this.enterThemeSelect();
 		this.enterDisplaySelect();
+		this.enterRefreshSelect();
 	}
 
 	/**
@@ -119,6 +126,7 @@ class SettingsAppearanceComponent extends Component {
 	exitDocument() {
 		this.themeSelectEl_ = null;
 		this.displaySelectEl_ = null;
+		this.refreshSelectEl_ = null;
 		super.exitDocument();
 	}
 
@@ -184,6 +192,45 @@ class SettingsAppearanceComponent extends Component {
 		window.location.reload();
 	}
 
+	enterRefreshSelect() {
+		this.refreshSelectEl_ = /** @type {!HTMLSelectElement} */ (
+			this.getCssElement("refresh")
+		);
+
+		let refreshMode = this.getLocalStorageRefreshMode();
+		if (
+			refreshMode !== RefreshMode.OFF &&
+			refreshMode !== RefreshMode.NOTIFY &&
+			refreshMode !== RefreshMode.AUTO
+		) {
+			refreshMode = RefreshMode.NOTIFY;
+			this.setLocalStorageRefreshMode(refreshMode);
+		}
+		this.refreshSelectEl_.value = refreshMode;
+
+		this.getHandler().listen(
+			this.refreshSelectEl_,
+			events.EventType.CHANGE,
+			this.handleRefreshSelectChange,
+		);
+	}
+
+	/**
+	 * @param {!events.BrowserEvent=} e
+	 */
+	handleRefreshSelectChange(e) {
+		const refreshMode = this.refreshSelectEl_.value || RefreshMode.NOTIFY;
+		this.setLocalStorageRefreshMode(refreshMode);
+		// Notify the live controller — no page reload needed, this setting
+		// only controls the polling behavior, not anything rendered.
+		const controller = /** @type {?RefreshController} */ (
+			getApplication(this).getRefreshController()
+		);
+		if (controller) {
+			controller.setMode(refreshMode);
+		}
+	}
+
 	/**
 	 * @returns {string}
 	 */
@@ -234,6 +281,22 @@ class SettingsAppearanceComponent extends Component {
 	setLocalStorageDisplayMode(displayMode) {
 		if (window.localStorage) {
 			window.localStorage.setItem(LocalStorageKey.DISPLAY_MODE, displayMode);
+		}
+	}
+
+	/**
+	 * @returns {?string}
+	 */
+	getLocalStorageRefreshMode() {
+		return window.localStorage?.getItem(LocalStorageKey.REFRESH_MODE);
+	}
+
+	/**
+	 * @param {string} refreshMode
+	 */
+	setLocalStorageRefreshMode(refreshMode) {
+		if (window.localStorage) {
+			window.localStorage.setItem(LocalStorageKey.REFRESH_MODE, refreshMode);
 		}
 	}
 

--- a/app/bcr/settings.soy
+++ b/app/bcr/settings.soy
@@ -56,5 +56,17 @@ import {
       <p class="FormControl-caption">Choose your display preference.</p>
     </div>
 
+    <div class="FormControl-spacingWrapper mt-3" style="max-width: 50%;">
+      <label class="FormControl-label">
+        Registry Data Refresh
+      </label>
+      <select class="form-select {css('refresh')}">
+        <option value="off">Off (no polling)</option>
+        <option value="notify">Notify when new data is available</option>
+        <option value="auto">Automatically reload on change</option>
+      </select>
+      <p class="FormControl-caption">When enabled, BCR checks every 5 minutes whether the deployed registry data or site code has been refreshed.</p>
+    </div>
+
   </div>
 {/template}

--- a/app/bcr/style.css
+++ b/app/bcr/style.css
@@ -113,6 +113,19 @@ pre code {
 	}
 }
 
+/* The search input visually fuses with the scope BtnGroup on its right
+ * edge — clip the right border + radius so they share a single seam.
+ * The BtnGroup itself is hidden below md, so this fusion only applies
+ * once the pills are visible; below md the input keeps its natural
+ * full border so it doesn't look amputated. */
+@media (min-width: 768px) {
+	.search-scope-fused {
+		border-top-right-radius: 0;
+		border-bottom-right-radius: 0;
+		border-right: 0;
+	}
+}
+
 .btn-language {
 	color: var(--lang-fg) !important;
 	background-color: var(--lang-bg) !important;
@@ -279,6 +292,48 @@ pre code {
 	.skeleton-box {
 		outline: 1px solid transparent;
 		outline-offset: -1px;
+	}
+}
+
+/* ========================================
+ * Registry Data Refresh indicator
+ * ======================================== */
+
+/* Small octicon pinned to the upper-right of the Bazel logo. Hidden by
+ * default; revealed when RefreshController detects a backend change by
+ * toggling .bcr-refresh-available on <html>. Clicking the icon reloads. */
+.bcr-refresh-indicator {
+	position: absolute;
+	top: 6px;
+	left: -12px;
+	display: none;
+	background-color: var(--color-accent-emphasis, #0969da);
+	color: var(--color-fg-on-emphasis, #fff);
+	border-radius: 50%;
+	padding: 2px;
+	line-height: 0;
+	text-decoration: none;
+}
+
+html.bcr-refresh-available .bcr-refresh-indicator {
+	display: inline-flex;
+	animation: bcr-refresh-pulse 2s infinite;
+}
+
+@keyframes bcr-refresh-pulse {
+	0%,
+	100% {
+		transform: scale(1);
+	}
+
+	50% {
+		transform: scale(1.2);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html.bcr-refresh-available .bcr-refresh-indicator {
+		animation: none;
 	}
 }
 

--- a/build/stack/bazel/registry/v1/bcr.pb.go
+++ b/build/stack/bazel/registry/v1/bcr.pb.go
@@ -164,6 +164,74 @@ func (x *Registry) GetCommitDate() string {
 	return ""
 }
 
+type RegistryManifest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	CommitSha     string                 `protobuf:"bytes,1,opt,name=commit_sha,json=commitSha,proto3" json:"commit_sha,omitempty"`
+	CommitDate    string                 `protobuf:"bytes,2,opt,name=commit_date,json=commitDate,proto3" json:"commit_date,omitempty"`
+	Branch        string                 `protobuf:"bytes,3,opt,name=branch,proto3" json:"branch,omitempty"`
+	AssetHashes   map[string]string      `protobuf:"bytes,4,rep,name=asset_hashes,json=assetHashes,proto3" json:"asset_hashes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RegistryManifest) Reset() {
+	*x = RegistryManifest{}
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegistryManifest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegistryManifest) ProtoMessage() {}
+
+func (x *RegistryManifest) ProtoReflect() protoreflect.Message {
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RegistryManifest.ProtoReflect.Descriptor instead.
+func (*RegistryManifest) Descriptor() ([]byte, []int) {
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RegistryManifest) GetCommitSha() string {
+	if x != nil {
+		return x.CommitSha
+	}
+	return ""
+}
+
+func (x *RegistryManifest) GetCommitDate() string {
+	if x != nil {
+		return x.CommitDate
+	}
+	return ""
+}
+
+func (x *RegistryManifest) GetBranch() string {
+	if x != nil {
+		return x.Branch
+	}
+	return ""
+}
+
+func (x *RegistryManifest) GetAssetHashes() map[string]string {
+	if x != nil {
+		return x.AssetHashes
+	}
+	return nil
+}
+
 type Module struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Name               string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -176,7 +244,7 @@ type Module struct {
 
 func (x *Module) Reset() {
 	*x = Module{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[1]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -188,7 +256,7 @@ func (x *Module) String() string {
 func (*Module) ProtoMessage() {}
 
 func (x *Module) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[1]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -201,7 +269,7 @@ func (x *Module) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Module.ProtoReflect.Descriptor instead.
 func (*Module) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{1}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Module) GetName() string {
@@ -245,7 +313,7 @@ type Maintainer struct {
 
 func (x *Maintainer) Reset() {
 	*x = Maintainer{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[2]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -257,7 +325,7 @@ func (x *Maintainer) String() string {
 func (*Maintainer) ProtoMessage() {}
 
 func (x *Maintainer) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[2]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -270,7 +338,7 @@ func (x *Maintainer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Maintainer.ProtoReflect.Descriptor instead.
 func (*Maintainer) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{2}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Maintainer) GetEmail() string {
@@ -322,7 +390,7 @@ type ModuleMetadata struct {
 
 func (x *ModuleMetadata) Reset() {
 	*x = ModuleMetadata{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[3]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -334,7 +402,7 @@ func (x *ModuleMetadata) String() string {
 func (*ModuleMetadata) ProtoMessage() {}
 
 func (x *ModuleMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[3]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -347,7 +415,7 @@ func (x *ModuleMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleMetadata.ProtoReflect.Descriptor instead.
 func (*ModuleMetadata) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{3}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ModuleMetadata) GetHomepage() string {
@@ -408,7 +476,7 @@ type RepositoryMetadata struct {
 
 func (x *RepositoryMetadata) Reset() {
 	*x = RepositoryMetadata{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[4]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -420,7 +488,7 @@ func (x *RepositoryMetadata) String() string {
 func (*RepositoryMetadata) ProtoMessage() {}
 
 func (x *RepositoryMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[4]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -433,7 +501,7 @@ func (x *RepositoryMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryMetadata.ProtoReflect.Descriptor instead.
 func (*RepositoryMetadata) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{4}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RepositoryMetadata) GetType() RepositoryType {
@@ -501,7 +569,7 @@ type RepositoryMetadataSet struct {
 
 func (x *RepositoryMetadataSet) Reset() {
 	*x = RepositoryMetadataSet{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[5]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -513,7 +581,7 @@ func (x *RepositoryMetadataSet) String() string {
 func (*RepositoryMetadataSet) ProtoMessage() {}
 
 func (x *RepositoryMetadataSet) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[5]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -526,7 +594,7 @@ func (x *RepositoryMetadataSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryMetadataSet.ProtoReflect.Descriptor instead.
 func (*RepositoryMetadataSet) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{5}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RepositoryMetadataSet) GetRepositoryMetadata() []*RepositoryMetadata {
@@ -546,7 +614,7 @@ type BazelRepositoryMetadata struct {
 
 func (x *BazelRepositoryMetadata) Reset() {
 	*x = BazelRepositoryMetadata{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[6]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -558,7 +626,7 @@ func (x *BazelRepositoryMetadata) String() string {
 func (*BazelRepositoryMetadata) ProtoMessage() {}
 
 func (x *BazelRepositoryMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[6]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -571,7 +639,7 @@ func (x *BazelRepositoryMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BazelRepositoryMetadata.ProtoReflect.Descriptor instead.
 func (*BazelRepositoryMetadata) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{6}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *BazelRepositoryMetadata) GetRepositoryMetadata() *RepositoryMetadata {
@@ -599,7 +667,7 @@ type BazelRelease struct {
 
 func (x *BazelRelease) Reset() {
 	*x = BazelRelease{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[7]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -611,7 +679,7 @@ func (x *BazelRelease) String() string {
 func (*BazelRelease) ProtoMessage() {}
 
 func (x *BazelRelease) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[7]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -624,7 +692,7 @@ func (x *BazelRelease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BazelRelease.ProtoReflect.Descriptor instead.
 func (*BazelRelease) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{7}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *BazelRelease) GetVersion() string {
@@ -657,7 +725,7 @@ type BazelReleaseSet struct {
 
 func (x *BazelReleaseSet) Reset() {
 	*x = BazelReleaseSet{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[8]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -669,7 +737,7 @@ func (x *BazelReleaseSet) String() string {
 func (*BazelReleaseSet) ProtoMessage() {}
 
 func (x *BazelReleaseSet) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[8]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -682,7 +750,7 @@ func (x *BazelReleaseSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BazelReleaseSet.ProtoReflect.Descriptor instead.
 func (*BazelReleaseSet) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{8}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *BazelReleaseSet) GetRelease() []*BazelRelease {
@@ -703,7 +771,7 @@ type ResourceStatus struct {
 
 func (x *ResourceStatus) Reset() {
 	*x = ResourceStatus{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[9]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -715,7 +783,7 @@ func (x *ResourceStatus) String() string {
 func (*ResourceStatus) ProtoMessage() {}
 
 func (x *ResourceStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[9]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -728,7 +796,7 @@ func (x *ResourceStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceStatus.ProtoReflect.Descriptor instead.
 func (*ResourceStatus) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{9}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ResourceStatus) GetUrl() string {
@@ -761,7 +829,7 @@ type ResourceStatusSet struct {
 
 func (x *ResourceStatusSet) Reset() {
 	*x = ResourceStatusSet{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[10]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -773,7 +841,7 @@ func (x *ResourceStatusSet) String() string {
 func (*ResourceStatusSet) ProtoMessage() {}
 
 func (x *ResourceStatusSet) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[10]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -786,7 +854,7 @@ func (x *ResourceStatusSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourceStatusSet.ProtoReflect.Descriptor instead.
 func (*ResourceStatusSet) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{10}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ResourceStatusSet) GetStatus() []*ResourceStatus {
@@ -821,7 +889,7 @@ type ModuleSource struct {
 
 func (x *ModuleSource) Reset() {
 	*x = ModuleSource{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[11]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -833,7 +901,7 @@ func (x *ModuleSource) String() string {
 func (*ModuleSource) ProtoMessage() {}
 
 func (x *ModuleSource) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[11]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -846,7 +914,7 @@ func (x *ModuleSource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleSource.ProtoReflect.Descriptor instead.
 func (*ModuleSource) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{11}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ModuleSource) GetUrl() string {
@@ -978,7 +1046,7 @@ type Attestations struct {
 
 func (x *Attestations) Reset() {
 	*x = Attestations{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[12]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1058,7 @@ func (x *Attestations) String() string {
 func (*Attestations) ProtoMessage() {}
 
 func (x *Attestations) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[12]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1003,7 +1071,7 @@ func (x *Attestations) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Attestations.ProtoReflect.Descriptor instead.
 func (*Attestations) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{12}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Attestations) GetMediaType() string {
@@ -1042,7 +1110,7 @@ type ModuleVersion struct {
 
 func (x *ModuleVersion) Reset() {
 	*x = ModuleVersion{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[13]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1054,7 +1122,7 @@ func (x *ModuleVersion) String() string {
 func (*ModuleVersion) ProtoMessage() {}
 
 func (x *ModuleVersion) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[13]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1067,7 +1135,7 @@ func (x *ModuleVersion) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleVersion.ProtoReflect.Descriptor instead.
 func (*ModuleVersion) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{13}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ModuleVersion) GetName() string {
@@ -1182,7 +1250,7 @@ type ModuleCommit struct {
 
 func (x *ModuleCommit) Reset() {
 	*x = ModuleCommit{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[14]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1194,7 +1262,7 @@ func (x *ModuleCommit) String() string {
 func (*ModuleCommit) ProtoMessage() {}
 
 func (x *ModuleCommit) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[14]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1207,7 +1275,7 @@ func (x *ModuleCommit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleCommit.ProtoReflect.Descriptor instead.
 func (*ModuleCommit) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{14}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ModuleCommit) GetSha1() string {
@@ -1264,7 +1332,7 @@ type PRAuthor struct {
 
 func (x *PRAuthor) Reset() {
 	*x = PRAuthor{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[15]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1276,7 +1344,7 @@ func (x *PRAuthor) String() string {
 func (*PRAuthor) ProtoMessage() {}
 
 func (x *PRAuthor) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[15]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1289,7 +1357,7 @@ func (x *PRAuthor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PRAuthor.ProtoReflect.Descriptor instead.
 func (*PRAuthor) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{15}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *PRAuthor) GetPullRequest() int32 {
@@ -1329,7 +1397,7 @@ type PRAuthorSet struct {
 
 func (x *PRAuthorSet) Reset() {
 	*x = PRAuthorSet{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[16]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1341,7 +1409,7 @@ func (x *PRAuthorSet) String() string {
 func (*PRAuthorSet) ProtoMessage() {}
 
 func (x *PRAuthorSet) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[16]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1354,7 +1422,7 @@ func (x *PRAuthorSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PRAuthorSet.ProtoReflect.Descriptor instead.
 func (*PRAuthorSet) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{16}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *PRAuthorSet) GetAuthors() []*PRAuthor {
@@ -1381,7 +1449,7 @@ type ModuleDependencyOverride struct {
 
 func (x *ModuleDependencyOverride) Reset() {
 	*x = ModuleDependencyOverride{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[17]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1393,7 +1461,7 @@ func (x *ModuleDependencyOverride) String() string {
 func (*ModuleDependencyOverride) ProtoMessage() {}
 
 func (x *ModuleDependencyOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[17]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1406,7 +1474,7 @@ func (x *ModuleDependencyOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleDependencyOverride.ProtoReflect.Descriptor instead.
 func (*ModuleDependencyOverride) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{17}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ModuleDependencyOverride) GetModuleName() string {
@@ -1509,7 +1577,7 @@ type ModuleDependency struct {
 
 func (x *ModuleDependency) Reset() {
 	*x = ModuleDependency{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[18]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1521,7 +1589,7 @@ func (x *ModuleDependency) String() string {
 func (*ModuleDependency) ProtoMessage() {}
 
 func (x *ModuleDependency) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[18]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1534,7 +1602,7 @@ func (x *ModuleDependency) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModuleDependency.ProtoReflect.Descriptor instead.
 func (*ModuleDependency) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{18}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ModuleDependency) GetName() string {
@@ -1599,7 +1667,7 @@ type GitOverride struct {
 
 func (x *GitOverride) Reset() {
 	*x = GitOverride{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[19]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1611,7 +1679,7 @@ func (x *GitOverride) String() string {
 func (*GitOverride) ProtoMessage() {}
 
 func (x *GitOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[19]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1624,7 +1692,7 @@ func (x *GitOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GitOverride.ProtoReflect.Descriptor instead.
 func (*GitOverride) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{19}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *GitOverride) GetCommit() string {
@@ -1677,7 +1745,7 @@ type ArchiveOverride struct {
 
 func (x *ArchiveOverride) Reset() {
 	*x = ArchiveOverride{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[20]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1689,7 +1757,7 @@ func (x *ArchiveOverride) String() string {
 func (*ArchiveOverride) ProtoMessage() {}
 
 func (x *ArchiveOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[20]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1702,7 +1770,7 @@ func (x *ArchiveOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArchiveOverride.ProtoReflect.Descriptor instead.
 func (*ArchiveOverride) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{20}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ArchiveOverride) GetIntegrity() string {
@@ -1765,7 +1833,7 @@ type SingleVersionOverride struct {
 
 func (x *SingleVersionOverride) Reset() {
 	*x = SingleVersionOverride{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[21]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1777,7 +1845,7 @@ func (x *SingleVersionOverride) String() string {
 func (*SingleVersionOverride) ProtoMessage() {}
 
 func (x *SingleVersionOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[21]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1790,7 +1858,7 @@ func (x *SingleVersionOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SingleVersionOverride.ProtoReflect.Descriptor instead.
 func (*SingleVersionOverride) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{21}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *SingleVersionOverride) GetPatchStrip() int32 {
@@ -1823,7 +1891,7 @@ type LocalPathOverride struct {
 
 func (x *LocalPathOverride) Reset() {
 	*x = LocalPathOverride{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[22]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +1903,7 @@ func (x *LocalPathOverride) String() string {
 func (*LocalPathOverride) ProtoMessage() {}
 
 func (x *LocalPathOverride) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[22]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +1916,7 @@ func (x *LocalPathOverride) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalPathOverride.ProtoReflect.Descriptor instead.
 func (*LocalPathOverride) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{22}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *LocalPathOverride) GetPath() string {
@@ -1869,7 +1937,7 @@ type Presubmit struct {
 
 func (x *Presubmit) Reset() {
 	*x = Presubmit{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[23]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1881,7 +1949,7 @@ func (x *Presubmit) String() string {
 func (*Presubmit) ProtoMessage() {}
 
 func (x *Presubmit) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[23]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1894,7 +1962,7 @@ func (x *Presubmit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Presubmit.ProtoReflect.Descriptor instead.
 func (*Presubmit) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{23}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Presubmit) GetBcrTestModule() *Presubmit_BcrTestModule {
@@ -1933,7 +2001,7 @@ type DependencyTreeNode struct {
 
 func (x *DependencyTreeNode) Reset() {
 	*x = DependencyTreeNode{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[24]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1945,7 +2013,7 @@ func (x *DependencyTreeNode) String() string {
 func (*DependencyTreeNode) ProtoMessage() {}
 
 func (x *DependencyTreeNode) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[24]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1958,7 +2026,7 @@ func (x *DependencyTreeNode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DependencyTreeNode.ProtoReflect.Descriptor instead.
 func (*DependencyTreeNode) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{24}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *DependencyTreeNode) GetModuleVersion() *ModuleVersion {
@@ -2020,7 +2088,7 @@ type DependencyTree struct {
 
 func (x *DependencyTree) Reset() {
 	*x = DependencyTree{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[25]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2032,7 +2100,7 @@ func (x *DependencyTree) String() string {
 func (*DependencyTree) ProtoMessage() {}
 
 func (x *DependencyTree) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[25]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2045,7 +2113,7 @@ func (x *DependencyTree) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DependencyTree.ProtoReflect.Descriptor instead.
 func (*DependencyTree) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{25}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *DependencyTree) GetModuleVersion() *ModuleVersion {
@@ -2073,7 +2141,7 @@ type Attestations_Attestation struct {
 
 func (x *Attestations_Attestation) Reset() {
 	*x = Attestations_Attestation{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[30]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2085,7 +2153,7 @@ func (x *Attestations_Attestation) String() string {
 func (*Attestations_Attestation) ProtoMessage() {}
 
 func (x *Attestations_Attestation) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[30]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2098,7 +2166,7 @@ func (x *Attestations_Attestation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Attestations_Attestation.ProtoReflect.Descriptor instead.
 func (*Attestations_Attestation) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{12, 0}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *Attestations_Attestation) GetUrl() string {
@@ -2147,7 +2215,7 @@ type Attestations_AttestationPayload struct {
 
 func (x *Attestations_AttestationPayload) Reset() {
 	*x = Attestations_AttestationPayload{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[31]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2159,7 +2227,7 @@ func (x *Attestations_AttestationPayload) String() string {
 func (*Attestations_AttestationPayload) ProtoMessage() {}
 
 func (x *Attestations_AttestationPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[31]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2172,7 +2240,7 @@ func (x *Attestations_AttestationPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Attestations_AttestationPayload.ProtoReflect.Descriptor instead.
 func (*Attestations_AttestationPayload) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{12, 1}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{13, 1}
 }
 
 func (x *Attestations_AttestationPayload) GetSubjectName() string {
@@ -2305,7 +2373,7 @@ type Presubmit_BcrTestModule struct {
 
 func (x *Presubmit_BcrTestModule) Reset() {
 	*x = Presubmit_BcrTestModule{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[33]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2317,7 +2385,7 @@ func (x *Presubmit_BcrTestModule) String() string {
 func (*Presubmit_BcrTestModule) ProtoMessage() {}
 
 func (x *Presubmit_BcrTestModule) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[33]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2330,7 +2398,7 @@ func (x *Presubmit_BcrTestModule) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Presubmit_BcrTestModule.ProtoReflect.Descriptor instead.
 func (*Presubmit_BcrTestModule) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{23, 0}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{24, 0}
 }
 
 func (x *Presubmit_BcrTestModule) GetModulePath() string {
@@ -2364,7 +2432,7 @@ type Presubmit_PresubmitMatrix struct {
 
 func (x *Presubmit_PresubmitMatrix) Reset() {
 	*x = Presubmit_PresubmitMatrix{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[34]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2376,7 +2444,7 @@ func (x *Presubmit_PresubmitMatrix) String() string {
 func (*Presubmit_PresubmitMatrix) ProtoMessage() {}
 
 func (x *Presubmit_PresubmitMatrix) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[34]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2389,7 +2457,7 @@ func (x *Presubmit_PresubmitMatrix) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Presubmit_PresubmitMatrix.ProtoReflect.Descriptor instead.
 func (*Presubmit_PresubmitMatrix) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{23, 1}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{24, 1}
 }
 
 func (x *Presubmit_PresubmitMatrix) GetPlatform() []string {
@@ -2421,7 +2489,7 @@ type Presubmit_PresubmitTask struct {
 
 func (x *Presubmit_PresubmitTask) Reset() {
 	*x = Presubmit_PresubmitTask{}
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[35]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2433,7 +2501,7 @@ func (x *Presubmit_PresubmitTask) String() string {
 func (*Presubmit_PresubmitTask) ProtoMessage() {}
 
 func (x *Presubmit_PresubmitTask) ProtoReflect() protoreflect.Message {
-	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[35]
+	mi := &file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2446,7 +2514,7 @@ func (x *Presubmit_PresubmitTask) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Presubmit_PresubmitTask.ProtoReflect.Descriptor instead.
 func (*Presubmit_PresubmitTask) Descriptor() ([]byte, []int) {
-	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{23, 2}
+	return file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP(), []int{24, 2}
 }
 
 func (x *Presubmit_PresubmitTask) GetName() string {
@@ -2512,7 +2580,17 @@ const file_build_stack_bazel_registry_v1_bcr_proto_rawDesc = "" +
 	"commit_sha\x18\x05 \x01(\tR\tcommitSha\x12%\n" +
 	"\x0ecommit_message\x18\x06 \x01(\tR\rcommitMessage\x12\x1f\n" +
 	"\vcommit_date\x18\a \x01(\tR\n" +
-	"commitDate\"\x95\x02\n" +
+	"commitDate\"\x8f\x02\n" +
+	"\x10RegistryManifest\x12\x1d\n" +
+	"\n" +
+	"commit_sha\x18\x01 \x01(\tR\tcommitSha\x12\x1f\n" +
+	"\vcommit_date\x18\x02 \x01(\tR\n" +
+	"commitDate\x12\x16\n" +
+	"\x06branch\x18\x03 \x01(\tR\x06branch\x12c\n" +
+	"\fasset_hashes\x18\x04 \x03(\v2@.build.stack.bazel.registry.v1.RegistryManifest.AssetHashesEntryR\vassetHashes\x1a>\n" +
+	"\x10AssetHashesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x95\x02\n" +
 	"\x06Module\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12I\n" +
 	"\bmetadata\x18\x02 \x01(\v2-.build.stack.bazel.registry.v1.ModuleMetadataR\bmetadata\x12H\n" +
@@ -2772,103 +2850,106 @@ func file_build_stack_bazel_registry_v1_bcr_proto_rawDescGZIP() []byte {
 }
 
 var file_build_stack_bazel_registry_v1_bcr_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_build_stack_bazel_registry_v1_bcr_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_build_stack_bazel_registry_v1_bcr_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_build_stack_bazel_registry_v1_bcr_proto_goTypes = []any{
 	(RepositoryType)(0),                     // 0: build.stack.bazel.registry.v1.RepositoryType
 	(*Registry)(nil),                        // 1: build.stack.bazel.registry.v1.Registry
-	(*Module)(nil),                          // 2: build.stack.bazel.registry.v1.Module
-	(*Maintainer)(nil),                      // 3: build.stack.bazel.registry.v1.Maintainer
-	(*ModuleMetadata)(nil),                  // 4: build.stack.bazel.registry.v1.ModuleMetadata
-	(*RepositoryMetadata)(nil),              // 5: build.stack.bazel.registry.v1.RepositoryMetadata
-	(*RepositoryMetadataSet)(nil),           // 6: build.stack.bazel.registry.v1.RepositoryMetadataSet
-	(*BazelRepositoryMetadata)(nil),         // 7: build.stack.bazel.registry.v1.BazelRepositoryMetadata
-	(*BazelRelease)(nil),                    // 8: build.stack.bazel.registry.v1.BazelRelease
-	(*BazelReleaseSet)(nil),                 // 9: build.stack.bazel.registry.v1.BazelReleaseSet
-	(*ResourceStatus)(nil),                  // 10: build.stack.bazel.registry.v1.ResourceStatus
-	(*ResourceStatusSet)(nil),               // 11: build.stack.bazel.registry.v1.ResourceStatusSet
-	(*ModuleSource)(nil),                    // 12: build.stack.bazel.registry.v1.ModuleSource
-	(*Attestations)(nil),                    // 13: build.stack.bazel.registry.v1.Attestations
-	(*ModuleVersion)(nil),                   // 14: build.stack.bazel.registry.v1.ModuleVersion
-	(*ModuleCommit)(nil),                    // 15: build.stack.bazel.registry.v1.ModuleCommit
-	(*PRAuthor)(nil),                        // 16: build.stack.bazel.registry.v1.PRAuthor
-	(*PRAuthorSet)(nil),                     // 17: build.stack.bazel.registry.v1.PRAuthorSet
-	(*ModuleDependencyOverride)(nil),        // 18: build.stack.bazel.registry.v1.ModuleDependencyOverride
-	(*ModuleDependency)(nil),                // 19: build.stack.bazel.registry.v1.ModuleDependency
-	(*GitOverride)(nil),                     // 20: build.stack.bazel.registry.v1.GitOverride
-	(*ArchiveOverride)(nil),                 // 21: build.stack.bazel.registry.v1.ArchiveOverride
-	(*SingleVersionOverride)(nil),           // 22: build.stack.bazel.registry.v1.SingleVersionOverride
-	(*LocalPathOverride)(nil),               // 23: build.stack.bazel.registry.v1.LocalPathOverride
-	(*Presubmit)(nil),                       // 24: build.stack.bazel.registry.v1.Presubmit
-	(*DependencyTreeNode)(nil),              // 25: build.stack.bazel.registry.v1.DependencyTreeNode
-	(*DependencyTree)(nil),                  // 26: build.stack.bazel.registry.v1.DependencyTree
-	nil,                                     // 27: build.stack.bazel.registry.v1.ModuleMetadata.YankedVersionsEntry
-	nil,                                     // 28: build.stack.bazel.registry.v1.RepositoryMetadata.LanguagesEntry
-	nil,                                     // 29: build.stack.bazel.registry.v1.ModuleSource.PatchesEntry
-	nil,                                     // 30: build.stack.bazel.registry.v1.ModuleSource.OverlayEntry
-	(*Attestations_Attestation)(nil),        // 31: build.stack.bazel.registry.v1.Attestations.Attestation
-	(*Attestations_AttestationPayload)(nil), // 32: build.stack.bazel.registry.v1.Attestations.AttestationPayload
-	nil,                                     // 33: build.stack.bazel.registry.v1.Attestations.AttestationsEntry
-	(*Presubmit_BcrTestModule)(nil),         // 34: build.stack.bazel.registry.v1.Presubmit.BcrTestModule
-	(*Presubmit_PresubmitMatrix)(nil),       // 35: build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
-	(*Presubmit_PresubmitTask)(nil),         // 36: build.stack.bazel.registry.v1.Presubmit.PresubmitTask
-	nil,                                     // 37: build.stack.bazel.registry.v1.Presubmit.TasksEntry
-	nil,                                     // 38: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry
-	(*v1.ModuleVersionSymbols)(nil),         // 39: build.stack.bazel.symbol.v1.ModuleVersionSymbols
-	(*v1.ModuleVersionPackages)(nil),        // 40: build.stack.bazel.symbol.v1.ModuleVersionPackages
+	(*RegistryManifest)(nil),                // 2: build.stack.bazel.registry.v1.RegistryManifest
+	(*Module)(nil),                          // 3: build.stack.bazel.registry.v1.Module
+	(*Maintainer)(nil),                      // 4: build.stack.bazel.registry.v1.Maintainer
+	(*ModuleMetadata)(nil),                  // 5: build.stack.bazel.registry.v1.ModuleMetadata
+	(*RepositoryMetadata)(nil),              // 6: build.stack.bazel.registry.v1.RepositoryMetadata
+	(*RepositoryMetadataSet)(nil),           // 7: build.stack.bazel.registry.v1.RepositoryMetadataSet
+	(*BazelRepositoryMetadata)(nil),         // 8: build.stack.bazel.registry.v1.BazelRepositoryMetadata
+	(*BazelRelease)(nil),                    // 9: build.stack.bazel.registry.v1.BazelRelease
+	(*BazelReleaseSet)(nil),                 // 10: build.stack.bazel.registry.v1.BazelReleaseSet
+	(*ResourceStatus)(nil),                  // 11: build.stack.bazel.registry.v1.ResourceStatus
+	(*ResourceStatusSet)(nil),               // 12: build.stack.bazel.registry.v1.ResourceStatusSet
+	(*ModuleSource)(nil),                    // 13: build.stack.bazel.registry.v1.ModuleSource
+	(*Attestations)(nil),                    // 14: build.stack.bazel.registry.v1.Attestations
+	(*ModuleVersion)(nil),                   // 15: build.stack.bazel.registry.v1.ModuleVersion
+	(*ModuleCommit)(nil),                    // 16: build.stack.bazel.registry.v1.ModuleCommit
+	(*PRAuthor)(nil),                        // 17: build.stack.bazel.registry.v1.PRAuthor
+	(*PRAuthorSet)(nil),                     // 18: build.stack.bazel.registry.v1.PRAuthorSet
+	(*ModuleDependencyOverride)(nil),        // 19: build.stack.bazel.registry.v1.ModuleDependencyOverride
+	(*ModuleDependency)(nil),                // 20: build.stack.bazel.registry.v1.ModuleDependency
+	(*GitOverride)(nil),                     // 21: build.stack.bazel.registry.v1.GitOverride
+	(*ArchiveOverride)(nil),                 // 22: build.stack.bazel.registry.v1.ArchiveOverride
+	(*SingleVersionOverride)(nil),           // 23: build.stack.bazel.registry.v1.SingleVersionOverride
+	(*LocalPathOverride)(nil),               // 24: build.stack.bazel.registry.v1.LocalPathOverride
+	(*Presubmit)(nil),                       // 25: build.stack.bazel.registry.v1.Presubmit
+	(*DependencyTreeNode)(nil),              // 26: build.stack.bazel.registry.v1.DependencyTreeNode
+	(*DependencyTree)(nil),                  // 27: build.stack.bazel.registry.v1.DependencyTree
+	nil,                                     // 28: build.stack.bazel.registry.v1.RegistryManifest.AssetHashesEntry
+	nil,                                     // 29: build.stack.bazel.registry.v1.ModuleMetadata.YankedVersionsEntry
+	nil,                                     // 30: build.stack.bazel.registry.v1.RepositoryMetadata.LanguagesEntry
+	nil,                                     // 31: build.stack.bazel.registry.v1.ModuleSource.PatchesEntry
+	nil,                                     // 32: build.stack.bazel.registry.v1.ModuleSource.OverlayEntry
+	(*Attestations_Attestation)(nil),        // 33: build.stack.bazel.registry.v1.Attestations.Attestation
+	(*Attestations_AttestationPayload)(nil), // 34: build.stack.bazel.registry.v1.Attestations.AttestationPayload
+	nil,                                     // 35: build.stack.bazel.registry.v1.Attestations.AttestationsEntry
+	(*Presubmit_BcrTestModule)(nil),         // 36: build.stack.bazel.registry.v1.Presubmit.BcrTestModule
+	(*Presubmit_PresubmitMatrix)(nil),       // 37: build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
+	(*Presubmit_PresubmitTask)(nil),         // 38: build.stack.bazel.registry.v1.Presubmit.PresubmitTask
+	nil,                                     // 39: build.stack.bazel.registry.v1.Presubmit.TasksEntry
+	nil,                                     // 40: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry
+	(*v1.ModuleVersionSymbols)(nil),         // 41: build.stack.bazel.symbol.v1.ModuleVersionSymbols
+	(*v1.ModuleVersionPackages)(nil),        // 42: build.stack.bazel.symbol.v1.ModuleVersionPackages
 }
 var file_build_stack_bazel_registry_v1_bcr_proto_depIdxs = []int32{
-	2,  // 0: build.stack.bazel.registry.v1.Registry.modules:type_name -> build.stack.bazel.registry.v1.Module
-	4,  // 1: build.stack.bazel.registry.v1.Module.metadata:type_name -> build.stack.bazel.registry.v1.ModuleMetadata
-	14, // 2: build.stack.bazel.registry.v1.Module.versions:type_name -> build.stack.bazel.registry.v1.ModuleVersion
-	5,  // 3: build.stack.bazel.registry.v1.Module.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
-	3,  // 4: build.stack.bazel.registry.v1.ModuleMetadata.maintainers:type_name -> build.stack.bazel.registry.v1.Maintainer
-	27, // 5: build.stack.bazel.registry.v1.ModuleMetadata.yanked_versions:type_name -> build.stack.bazel.registry.v1.ModuleMetadata.YankedVersionsEntry
-	0,  // 6: build.stack.bazel.registry.v1.RepositoryMetadata.type:type_name -> build.stack.bazel.registry.v1.RepositoryType
-	28, // 7: build.stack.bazel.registry.v1.RepositoryMetadata.languages:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata.LanguagesEntry
-	5,  // 8: build.stack.bazel.registry.v1.RepositoryMetadataSet.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
-	5,  // 9: build.stack.bazel.registry.v1.BazelRepositoryMetadata.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
-	8,  // 10: build.stack.bazel.registry.v1.BazelRepositoryMetadata.release:type_name -> build.stack.bazel.registry.v1.BazelRelease
-	15, // 11: build.stack.bazel.registry.v1.BazelRelease.commit:type_name -> build.stack.bazel.registry.v1.ModuleCommit
-	8,  // 12: build.stack.bazel.registry.v1.BazelReleaseSet.release:type_name -> build.stack.bazel.registry.v1.BazelRelease
-	10, // 13: build.stack.bazel.registry.v1.ResourceStatusSet.status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
-	29, // 14: build.stack.bazel.registry.v1.ModuleSource.patches:type_name -> build.stack.bazel.registry.v1.ModuleSource.PatchesEntry
-	30, // 15: build.stack.bazel.registry.v1.ModuleSource.overlay:type_name -> build.stack.bazel.registry.v1.ModuleSource.OverlayEntry
-	39, // 16: build.stack.bazel.registry.v1.ModuleSource.documentation:type_name -> build.stack.bazel.symbol.v1.ModuleVersionSymbols
-	10, // 17: build.stack.bazel.registry.v1.ModuleSource.docs_url_status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
-	10, // 18: build.stack.bazel.registry.v1.ModuleSource.url_status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
-	40, // 19: build.stack.bazel.registry.v1.ModuleSource.packages:type_name -> build.stack.bazel.symbol.v1.ModuleVersionPackages
-	33, // 20: build.stack.bazel.registry.v1.Attestations.attestations:type_name -> build.stack.bazel.registry.v1.Attestations.AttestationsEntry
-	19, // 21: build.stack.bazel.registry.v1.ModuleVersion.deps:type_name -> build.stack.bazel.registry.v1.ModuleDependency
-	12, // 22: build.stack.bazel.registry.v1.ModuleVersion.source:type_name -> build.stack.bazel.registry.v1.ModuleSource
-	13, // 23: build.stack.bazel.registry.v1.ModuleVersion.attestations:type_name -> build.stack.bazel.registry.v1.Attestations
-	24, // 24: build.stack.bazel.registry.v1.ModuleVersion.presubmit:type_name -> build.stack.bazel.registry.v1.Presubmit
-	18, // 25: build.stack.bazel.registry.v1.ModuleVersion.override:type_name -> build.stack.bazel.registry.v1.ModuleDependencyOverride
-	15, // 26: build.stack.bazel.registry.v1.ModuleVersion.commit:type_name -> build.stack.bazel.registry.v1.ModuleCommit
-	5,  // 27: build.stack.bazel.registry.v1.ModuleVersion.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
-	16, // 28: build.stack.bazel.registry.v1.PRAuthorSet.authors:type_name -> build.stack.bazel.registry.v1.PRAuthor
-	20, // 29: build.stack.bazel.registry.v1.ModuleDependencyOverride.git_override:type_name -> build.stack.bazel.registry.v1.GitOverride
-	21, // 30: build.stack.bazel.registry.v1.ModuleDependencyOverride.archive_override:type_name -> build.stack.bazel.registry.v1.ArchiveOverride
-	22, // 31: build.stack.bazel.registry.v1.ModuleDependencyOverride.single_version_override:type_name -> build.stack.bazel.registry.v1.SingleVersionOverride
-	23, // 32: build.stack.bazel.registry.v1.ModuleDependencyOverride.local_path_override:type_name -> build.stack.bazel.registry.v1.LocalPathOverride
-	18, // 33: build.stack.bazel.registry.v1.ModuleDependency.override:type_name -> build.stack.bazel.registry.v1.ModuleDependencyOverride
-	34, // 34: build.stack.bazel.registry.v1.Presubmit.bcr_test_module:type_name -> build.stack.bazel.registry.v1.Presubmit.BcrTestModule
-	35, // 35: build.stack.bazel.registry.v1.Presubmit.matrix:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
-	37, // 36: build.stack.bazel.registry.v1.Presubmit.tasks:type_name -> build.stack.bazel.registry.v1.Presubmit.TasksEntry
-	14, // 37: build.stack.bazel.registry.v1.DependencyTreeNode.module_version:type_name -> build.stack.bazel.registry.v1.ModuleVersion
-	25, // 38: build.stack.bazel.registry.v1.DependencyTreeNode.children:type_name -> build.stack.bazel.registry.v1.DependencyTreeNode
-	14, // 39: build.stack.bazel.registry.v1.DependencyTree.module_version:type_name -> build.stack.bazel.registry.v1.ModuleVersion
-	25, // 40: build.stack.bazel.registry.v1.DependencyTree.children:type_name -> build.stack.bazel.registry.v1.DependencyTreeNode
-	32, // 41: build.stack.bazel.registry.v1.Attestations.Attestation.payload:type_name -> build.stack.bazel.registry.v1.Attestations.AttestationPayload
-	31, // 42: build.stack.bazel.registry.v1.Attestations.AttestationsEntry.value:type_name -> build.stack.bazel.registry.v1.Attestations.Attestation
-	35, // 43: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.matrix:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
-	38, // 44: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.tasks:type_name -> build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry
-	36, // 45: build.stack.bazel.registry.v1.Presubmit.TasksEntry.value:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitTask
-	36, // 46: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry.value:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitTask
-	47, // [47:47] is the sub-list for method output_type
-	47, // [47:47] is the sub-list for method input_type
-	47, // [47:47] is the sub-list for extension type_name
-	47, // [47:47] is the sub-list for extension extendee
-	0,  // [0:47] is the sub-list for field type_name
+	3,  // 0: build.stack.bazel.registry.v1.Registry.modules:type_name -> build.stack.bazel.registry.v1.Module
+	28, // 1: build.stack.bazel.registry.v1.RegistryManifest.asset_hashes:type_name -> build.stack.bazel.registry.v1.RegistryManifest.AssetHashesEntry
+	5,  // 2: build.stack.bazel.registry.v1.Module.metadata:type_name -> build.stack.bazel.registry.v1.ModuleMetadata
+	15, // 3: build.stack.bazel.registry.v1.Module.versions:type_name -> build.stack.bazel.registry.v1.ModuleVersion
+	6,  // 4: build.stack.bazel.registry.v1.Module.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
+	4,  // 5: build.stack.bazel.registry.v1.ModuleMetadata.maintainers:type_name -> build.stack.bazel.registry.v1.Maintainer
+	29, // 6: build.stack.bazel.registry.v1.ModuleMetadata.yanked_versions:type_name -> build.stack.bazel.registry.v1.ModuleMetadata.YankedVersionsEntry
+	0,  // 7: build.stack.bazel.registry.v1.RepositoryMetadata.type:type_name -> build.stack.bazel.registry.v1.RepositoryType
+	30, // 8: build.stack.bazel.registry.v1.RepositoryMetadata.languages:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata.LanguagesEntry
+	6,  // 9: build.stack.bazel.registry.v1.RepositoryMetadataSet.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
+	6,  // 10: build.stack.bazel.registry.v1.BazelRepositoryMetadata.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
+	9,  // 11: build.stack.bazel.registry.v1.BazelRepositoryMetadata.release:type_name -> build.stack.bazel.registry.v1.BazelRelease
+	16, // 12: build.stack.bazel.registry.v1.BazelRelease.commit:type_name -> build.stack.bazel.registry.v1.ModuleCommit
+	9,  // 13: build.stack.bazel.registry.v1.BazelReleaseSet.release:type_name -> build.stack.bazel.registry.v1.BazelRelease
+	11, // 14: build.stack.bazel.registry.v1.ResourceStatusSet.status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
+	31, // 15: build.stack.bazel.registry.v1.ModuleSource.patches:type_name -> build.stack.bazel.registry.v1.ModuleSource.PatchesEntry
+	32, // 16: build.stack.bazel.registry.v1.ModuleSource.overlay:type_name -> build.stack.bazel.registry.v1.ModuleSource.OverlayEntry
+	41, // 17: build.stack.bazel.registry.v1.ModuleSource.documentation:type_name -> build.stack.bazel.symbol.v1.ModuleVersionSymbols
+	11, // 18: build.stack.bazel.registry.v1.ModuleSource.docs_url_status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
+	11, // 19: build.stack.bazel.registry.v1.ModuleSource.url_status:type_name -> build.stack.bazel.registry.v1.ResourceStatus
+	42, // 20: build.stack.bazel.registry.v1.ModuleSource.packages:type_name -> build.stack.bazel.symbol.v1.ModuleVersionPackages
+	35, // 21: build.stack.bazel.registry.v1.Attestations.attestations:type_name -> build.stack.bazel.registry.v1.Attestations.AttestationsEntry
+	20, // 22: build.stack.bazel.registry.v1.ModuleVersion.deps:type_name -> build.stack.bazel.registry.v1.ModuleDependency
+	13, // 23: build.stack.bazel.registry.v1.ModuleVersion.source:type_name -> build.stack.bazel.registry.v1.ModuleSource
+	14, // 24: build.stack.bazel.registry.v1.ModuleVersion.attestations:type_name -> build.stack.bazel.registry.v1.Attestations
+	25, // 25: build.stack.bazel.registry.v1.ModuleVersion.presubmit:type_name -> build.stack.bazel.registry.v1.Presubmit
+	19, // 26: build.stack.bazel.registry.v1.ModuleVersion.override:type_name -> build.stack.bazel.registry.v1.ModuleDependencyOverride
+	16, // 27: build.stack.bazel.registry.v1.ModuleVersion.commit:type_name -> build.stack.bazel.registry.v1.ModuleCommit
+	6,  // 28: build.stack.bazel.registry.v1.ModuleVersion.repository_metadata:type_name -> build.stack.bazel.registry.v1.RepositoryMetadata
+	17, // 29: build.stack.bazel.registry.v1.PRAuthorSet.authors:type_name -> build.stack.bazel.registry.v1.PRAuthor
+	21, // 30: build.stack.bazel.registry.v1.ModuleDependencyOverride.git_override:type_name -> build.stack.bazel.registry.v1.GitOverride
+	22, // 31: build.stack.bazel.registry.v1.ModuleDependencyOverride.archive_override:type_name -> build.stack.bazel.registry.v1.ArchiveOverride
+	23, // 32: build.stack.bazel.registry.v1.ModuleDependencyOverride.single_version_override:type_name -> build.stack.bazel.registry.v1.SingleVersionOverride
+	24, // 33: build.stack.bazel.registry.v1.ModuleDependencyOverride.local_path_override:type_name -> build.stack.bazel.registry.v1.LocalPathOverride
+	19, // 34: build.stack.bazel.registry.v1.ModuleDependency.override:type_name -> build.stack.bazel.registry.v1.ModuleDependencyOverride
+	36, // 35: build.stack.bazel.registry.v1.Presubmit.bcr_test_module:type_name -> build.stack.bazel.registry.v1.Presubmit.BcrTestModule
+	37, // 36: build.stack.bazel.registry.v1.Presubmit.matrix:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
+	39, // 37: build.stack.bazel.registry.v1.Presubmit.tasks:type_name -> build.stack.bazel.registry.v1.Presubmit.TasksEntry
+	15, // 38: build.stack.bazel.registry.v1.DependencyTreeNode.module_version:type_name -> build.stack.bazel.registry.v1.ModuleVersion
+	26, // 39: build.stack.bazel.registry.v1.DependencyTreeNode.children:type_name -> build.stack.bazel.registry.v1.DependencyTreeNode
+	15, // 40: build.stack.bazel.registry.v1.DependencyTree.module_version:type_name -> build.stack.bazel.registry.v1.ModuleVersion
+	26, // 41: build.stack.bazel.registry.v1.DependencyTree.children:type_name -> build.stack.bazel.registry.v1.DependencyTreeNode
+	34, // 42: build.stack.bazel.registry.v1.Attestations.Attestation.payload:type_name -> build.stack.bazel.registry.v1.Attestations.AttestationPayload
+	33, // 43: build.stack.bazel.registry.v1.Attestations.AttestationsEntry.value:type_name -> build.stack.bazel.registry.v1.Attestations.Attestation
+	37, // 44: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.matrix:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitMatrix
+	40, // 45: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.tasks:type_name -> build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry
+	38, // 46: build.stack.bazel.registry.v1.Presubmit.TasksEntry.value:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitTask
+	38, // 47: build.stack.bazel.registry.v1.Presubmit.BcrTestModule.TasksEntry.value:type_name -> build.stack.bazel.registry.v1.Presubmit.PresubmitTask
+	48, // [48:48] is the sub-list for method output_type
+	48, // [48:48] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_build_stack_bazel_registry_v1_bcr_proto_init() }
@@ -2876,7 +2957,7 @@ func file_build_stack_bazel_registry_v1_bcr_proto_init() {
 	if File_build_stack_bazel_registry_v1_bcr_proto != nil {
 		return
 	}
-	file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[17].OneofWrappers = []any{
+	file_build_stack_bazel_registry_v1_bcr_proto_msgTypes[18].OneofWrappers = []any{
 		(*ModuleDependencyOverride_GitOverride)(nil),
 		(*ModuleDependencyOverride_ArchiveOverride)(nil),
 		(*ModuleDependencyOverride_SingleVersionOverride)(nil),
@@ -2888,7 +2969,7 @@ func file_build_stack_bazel_registry_v1_bcr_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_build_stack_bazel_registry_v1_bcr_proto_rawDesc), len(file_build_stack_bazel_registry_v1_bcr_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   38,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/build/stack/bazel/registry/v1/bcr.proto
+++ b/build/stack/bazel/registry/v1/bcr.proto
@@ -25,6 +25,26 @@ message Registry {
     string commit_date = 7;
 }
 
+// RegistryManifest is a small always-fresh snapshot served at the release
+// tarball root. Clients poll it (default every 5 min) to detect when the
+// deployed bundle has changed — BCR data refresh (commit_sha advances) or
+// code redeploy (any asset_hash changes) — without re-fetching the multi-MB
+// registry/symbols/packages payloads.
+message RegistryManifest {
+    // BCR submodule commit fields, copied verbatim from the Registry proto
+    // baked into this release.
+    string commit_sha = 1;
+    // Git commit timestamp (ISO 8601), same source as Registry.commit_date.
+    string commit_date = 2;
+    // Git branch name (e.g. 'main').
+    string branch = 3;
+    // Map of asset basename (pre-hash) -> hashed filename. Includes every
+    // asset that releasecompiler content-hashed (bcr.js, bcr.css,
+    // symbols.pb.gz, packages.pb.gz, bazelflagdb.pb.gz, …). A change in
+    // any value signals a code-side redeploy.
+    map<string,string> asset_hashes = 4;
+}
+
 // Module represents a Bazel module and all its versions.
 message Module {
     // Module name (e.g., 'rules_go', 'protobuf')

--- a/cmd/releasecompiler/BUILD.bazel
+++ b/cmd/releasecompiler/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["releasecompiler.go"],
     importpath = "github.com/bazel-contrib/bcr-frontend/cmd/releasecompiler",
     visibility = ["//visibility:private"],
-    deps = ["//pkg/paramsfile"],
+    deps = [
+        "//build/stack/bazel/registry/v1:registry",
+        "//pkg/paramsfile",
+        "@org_golang_google_protobuf//proto",
+    ],
 )
 
 go_binary(

--- a/cmd/releasecompiler/releasecompiler.go
+++ b/cmd/releasecompiler/releasecompiler.go
@@ -15,7 +15,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	bzpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/registry/v1"
 	"github.com/bazel-contrib/bcr-frontend/pkg/paramsfile"
+	"google.golang.org/protobuf/proto"
 )
 
 const toolName = "releasecompiler"
@@ -119,6 +121,17 @@ func run(args []string) error {
 		log.Printf("Processed bazel flag db file: %s -> %s", asset.OriginalName, asset.HashedName)
 	}
 
+	// Emit manifest.pb.gz at the tarball root for the in-browser refresh
+	// poller. Must be appended AFTER every other asset's HashedName is
+	// finalized — the manifest records those hashes so clients can detect
+	// code redeploys without re-fetching the bundles themselves.
+	manifestAsset, err := buildManifestAsset(cfg.RegistryFile, assets)
+	if err != nil {
+		return fmt.Errorf("failed to build manifest: %v", err)
+	}
+	assets = append(assets, manifestAsset)
+	log.Printf("Processed manifest: %s (%d asset_hashes)", manifestAsset.OriginalName, len(assets)-1)
+
 	// Read and update index.html
 	indexContent, err := updateIndexHtml(cfg.IndexHtmlFile, assets)
 	if err != nil {
@@ -186,6 +199,55 @@ func processRegistryFile(registryPath string) ([]HashedAsset, error) {
 			HashedName:   gzOriginalName, // No hashing - keep original name
 			Content:      gzipContent,
 		},
+	}, nil
+}
+
+// buildManifestAsset reads the registry proto for commit metadata, collects
+// content-hashed asset names from `assets`, and returns a HashedAsset for
+// manifest.pb.gz at the tarball root (un-hashed name — clients fetch it by
+// fixed URL and the releaseserver/CDN serves it no-cache).
+func buildManifestAsset(registryPath string, assets []HashedAsset) (HashedAsset, error) {
+	registryBytes, err := os.ReadFile(registryPath)
+	if err != nil {
+		return HashedAsset{}, fmt.Errorf("read registry: %v", err)
+	}
+	registry := &bzpb.Registry{}
+	if err := proto.Unmarshal(registryBytes, registry); err != nil {
+		return HashedAsset{}, fmt.Errorf("unmarshal registry: %v", err)
+	}
+
+	manifest := &bzpb.RegistryManifest{
+		CommitSha:    registry.GetCommitSha(),
+		CommitDate:   registry.GetCommitDate(),
+		Branch:       registry.GetBranch(),
+		AssetHashes:  map[string]string{},
+	}
+	for _, a := range assets {
+		if a.OriginalName == a.HashedName {
+			continue // un-hashed assets are uninformative for change detection
+		}
+		manifest.AssetHashes[a.OriginalName] = a.HashedName
+	}
+
+	manifestBytes, err := proto.Marshal(manifest)
+	if err != nil {
+		return HashedAsset{}, fmt.Errorf("marshal manifest: %v", err)
+	}
+	var gzipBuf bytes.Buffer
+	gw := gzip.NewWriter(&gzipBuf)
+	if _, err := gw.Write(manifestBytes); err != nil {
+		return HashedAsset{}, fmt.Errorf("gzip manifest: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		return HashedAsset{}, fmt.Errorf("gzip close: %v", err)
+	}
+
+	const name = "manifest.pb.gz"
+	return HashedAsset{
+		OriginalPath: registryPath,
+		OriginalName: name,
+		HashedName:   name, // un-hashed: fixed URL the poller targets
+		Content:      gzipBuf.Bytes(),
 	}, nil
 }
 

--- a/cmd/releaseserver/main.go
+++ b/cmd/releaseserver/main.go
@@ -163,9 +163,10 @@ func (s *SPAServer) serveFile(w http.ResponseWriter, r *http.Request, path strin
 	w.Header().Set("Content-Type", contentType)
 
 	// Set caching headers
-	// For HTML files and raw protobufs that aren't hashed, don't cache (always fresh)
-	// For assets, cache for a long time (they should be content-hashed)
-	if strings.HasSuffix(path, ".html") || strings.HasSuffix(path, ".pb") {
+	// For HTML files, raw protobufs that aren't hashed, and the refresh
+	// manifest (always served from a fixed un-hashed path), don't cache.
+	// For assets, cache for a long time (they should be content-hashed).
+	if strings.HasSuffix(path, ".html") || strings.HasSuffix(path, ".pb") || path == "manifest.pb.gz" {
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	} else {
 		// Assets are content-hashed, so cache aggressively

--- a/data/generated.MODULE.bazel
+++ b/data/generated.MODULE.bazel
@@ -38,7 +38,7 @@ use_repo(
     "bzl.alsa_lib---1.2.9.bcr.4",
     "bzl.amqp-cpp---4.3.27",
     "bzl.antlr4-cpp-runtime---4.13.2",
-    "bzl.antlr4-cpp-runtime---4.13.2.bcr.1",
+    "bzl.antlr4-cpp-runtime---4.13.2.bcr.2",
     "bzl.aom---3.13.3",
     "bzl.ape---1.0.0-beta.12",
     "bzl.ape---1.0.0-beta.15",
@@ -99,7 +99,7 @@ use_repo(
     "bzl.aspect_bazel_lib---2.8.1",
     "bzl.aspect_bazel_lib---2.9.3",
     "bzl.aspect_bazel_lib---2.9.4",
-    "bzl.aspect_gazelle_prebuilt---0.0.11",
+    "bzl.aspect_gazelle_prebuilt---0.0.18",
     "bzl.aspect_rules_aws---0.8.3",
     "bzl.aspect_rules_cypress---0.7.2",
     "bzl.aspect_rules_esbuild---0.21.0",
@@ -151,7 +151,7 @@ use_repo(
     "bzl.at-spi2-core---2.58.2",
     "bzl.avro-cpp---1.12.0",
     "bzl.awk.bzl---0.2.3",
-    "bzl.aws-in-a-box---0.0.69",
+    "bzl.aws-in-a-box---0.0.73",
     "bzl.aws-lc---1.67.0.bcr.1",
     "bzl.aws_sdk---1.11.758",
     "bzl.azure-core-cpp---1.14.1.bcr.1",
@@ -226,7 +226,7 @@ use_repo(
     "bzl.bazel_skylib---1.9.0",
     "bzl.bazel_skylib_gazelle_plugin---1.9.0",
     "bzl.bazel_sonarqube---1.0.6",
-    "bzl.bazel_tools---8.7.0",
+    "bzl.bazel_tools---9.1.1rc1",
     "bzl.bazel_worker_api---0.0.1",
     "bzl.bazel_worker_api---0.0.10",
     "bzl.bazel_worker_api---0.0.4",
@@ -487,6 +487,7 @@ use_repo(
     "bzl.boost.heap---1.83.0.bcr.4",
     "bzl.boost.heap---1.89.0.bcr.2",
     "bzl.boost.heap---1.90.0.bcr.1",
+    "bzl.boost.histogram---1.89.0.bcr.2",
     "bzl.boost.histogram---1.90.0.bcr.1",
     "bzl.boost.hof---1.89.0.bcr.2",
     "bzl.boost.hof---1.90.0.bcr.1",
@@ -916,7 +917,7 @@ use_repo(
     "bzl.boringssl---0.20251124.0",
     "bzl.boringssl---0.20260327.0",
     "bzl.boringssl---0.20260413.0",
-    "bzl.boringssl---0.20260508.0",
+    "bzl.boringssl---0.20260526.0",
     "bzl.briansmith_ring---0.17.14.bcr.1",
     "bzl.brotli---1.1.0",
     "bzl.brotli---1.2.0",
@@ -966,6 +967,7 @@ use_repo(
     "bzl.catch2---3.13.0",
     "bzl.catch2---3.8.0",
     "bzl.ccd---2.1.0.bcr.1",
+    "bzl.ccronexpr---2.1.0",
     "bzl.cctz---2.4",
     "bzl.cdt---1.4.0",
     "bzl.cel-cpp---0.11.0",
@@ -1004,7 +1006,7 @@ use_repo(
     "bzl.codspeed_google_benchmark_compat---2.1.0",
     "bzl.coin-or-lemon---1.3.1",
     "bzl.colordiff---1.0.22",
-    "bzl.com_clementguillot_rules_quarkus---0.1.1",
+    "bzl.com_clementguillot_rules_quarkus---0.2.0",
     "bzl.com_github_benchsci_rules_nodejs_gazelle---0.8.4",
     "bzl.com_github_mvukov_rules_ros2---0.0.0-20250612-f0d04fe",
     "bzl.com_github_mvukov_rules_ros2---0.0.0-20260118-78d85ff",
@@ -1018,7 +1020,7 @@ use_repo(
     "bzl.copybara---0.0.0-20250728-6672ce2",
     "bzl.coroutines---3.3.2",
     "bzl.cpp-httplib---0.22.0",
-    "bzl.cpp-httplib---0.41.0",
+    "bzl.cpp-httplib---0.46.0",
     "bzl.cpp-peglib---1.0.1",
     "bzl.cpp-sqlite---0.0.0-20230222-7f931c4",
     "bzl.cpp-sqlite---0.0.0-20241111-21be8b5",
@@ -1281,7 +1283,7 @@ use_repo(
     "bzl.googletest---1.17.0",
     "bzl.googletest---1.17.0.bcr.1",
     "bzl.googletest---1.17.0.bcr.2",
-    "bzl.gotopt2---2.5.1",
+    "bzl.gotopt2---2.7.1",
     "bzl.gperf---3.1",
     "bzl.gperf---3.1.bcr.1",
     "bzl.gperftools---2.18.1",
@@ -1301,7 +1303,7 @@ use_repo(
     "bzl.grpc---1.76.0",
     "bzl.grpc---1.76.0.bcr.1",
     "bzl.grpc---1.80.0",
-    "bzl.grpc---1.81.0-pre1",
+    "bzl.grpc---1.81.0",
     "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
     "bzl.grpc-java---1.62.2",
     "bzl.grpc-java---1.66.0",
@@ -1347,6 +1349,7 @@ use_repo(
     "bzl.helly25_bashtest---0.1.0",
     "bzl.helly25_bashtest---0.2.0",
     "bzl.helly25_bzl---0.3.1",
+    "bzl.helly25_bzl---0.4.2",
     "bzl.helly25_mbo---0.10.0",
     "bzl.helly25_proto---1.2.0",
     "bzl.hermetic_cc_toolchain---4.1.0",
@@ -1354,6 +1357,7 @@ use_repo(
     "bzl.hermetic_launcher---0.0.3",
     "bzl.hermetic_launcher---0.0.5",
     "bzl.hermetic_launcher---0.0.8",
+    "bzl.hermetic_launcher---0.0.9",
     "bzl.hfsm2---2.10.0",
     "bzl.highs---1.11.0",
     "bzl.highs---1.14.0",
@@ -1366,7 +1370,7 @@ use_repo(
     "bzl.hugooole_muda---1.0.0",
     "bzl.hypothesis---0.0.0-20240425-3acfea6.bcr.1",
     "bzl.iceoryx---2.95.4",
-    "bzl.iceoryx2---0.6.1",
+    "bzl.iceoryx2---0.9.0",
     "bzl.icestorm---1.1",
     "bzl.icu---76.1.bcr.3",
     "bzl.icu---78.2",
@@ -1467,7 +1471,6 @@ use_repo(
     "bzl.libpcap---1.10.5.bcr.1",
     "bzl.libpcap---1.10.5.bcr.3",
     "bzl.libpfm---4.11.0",
-    "bzl.libpfm---4.11.0.bcr.2",
     "bzl.libpfm---4.13.0",
     "bzl.libpng---1.6.41",
     "bzl.libpng---1.6.44",
@@ -1478,6 +1481,7 @@ use_repo(
     "bzl.libprotobuf-mutator---1.5.bcr.1",
     "bzl.librdkafka---2.8.0.bcr.1",
     "bzl.librdkafka---2.8.0.bcr.2",
+    "bzl.libsl3---1.2.53001",
     "bzl.libsodium---1.0.19",
     "bzl.libssh2---1.11.1.bcr.1",
     "bzl.libstemmer---2.2.0",
@@ -1554,6 +1558,7 @@ use_repo(
     "bzl.m4---1.4.20.bcr.4",
     "bzl.m4---1.4.21",
     "bzl.m4---1.4.21.bcr.1",
+    "bzl.m4---1.4.21.bcr.2",
     "bzl.magic_enum---0.9.7",
     "bzl.magic_enum---0.9.8",
     "bzl.maliput---1.15.0",
@@ -1655,7 +1660,7 @@ use_repo(
     "bzl.openfst---1.8.4.bcr.1",
     "bzl.opengl-registry---0.0.0-20250707",
     "bzl.openjph---0.26.3.bcr.1",
-    "bzl.openjph---0.27.3",
+    "bzl.openjph---0.27.3.bcr.1",
     "bzl.openmp---21.1.5.bcr.2",
     "bzl.openssh---9.9p1.bcr.2",
     "bzl.openssl---3.3.1.bcr.1",
@@ -1819,7 +1824,7 @@ use_repo(
     "bzl.qhull---8.0.2",
     "bzl.qhull---8.0.2.bcr.1",
     "bzl.qr-code-generator---1.8.0",
-    "bzl.quickjs-ng---0.13.0",
+    "bzl.quickjs-ng---0.15.0",
     "bzl.quill---11.1.0",
     "bzl.rabbitmq_osiris---1.7.0-rc.1",
     "bzl.rabbitmq_ra---2.7.0",
@@ -1934,6 +1939,7 @@ use_repo(
     "bzl.rules_cc---0.2.16",
     "bzl.rules_cc---0.2.17",
     "bzl.rules_cc---0.2.18",
+    "bzl.rules_cc---0.2.19",
     "bzl.rules_cc---0.2.2",
     "bzl.rules_cc---0.2.3",
     "bzl.rules_cc---0.2.4",
@@ -1944,7 +1950,7 @@ use_repo(
     "bzl.rules_cc_autoconf---0.10.2",
     "bzl.rules_cc_autoconf---0.10.3",
     "bzl.rules_cc_autoconf---0.11.0",
-    "bzl.rules_cc_autoconf---0.11.2",
+    "bzl.rules_cc_autoconf---0.12.1",
     "bzl.rules_cc_autoconf---0.5.3",
     "bzl.rules_cc_autoconf---0.5.4",
     "bzl.rules_cc_autoconf---0.5.5",
@@ -1973,8 +1979,8 @@ use_repo(
     "bzl.rules_cue---0.18.0",
     "bzl.rules_curl---1.0.0-alpha.13",
     "bzl.rules_d---0.10.1",
-    "bzl.rules_dart---0.2.2",
-    "bzl.rules_dart_proto---0.2.2",
+    "bzl.rules_dart---0.4.3",
+    "bzl.rules_dart_proto---0.4.3",
     "bzl.rules_detekt---0.8.1.13",
     "bzl.rules_devicetree---0.1.4",
     "bzl.rules_diff---1.0.0",
@@ -2031,12 +2037,13 @@ use_repo(
     "bzl.rules_go---0.58.3",
     "bzl.rules_go---0.59.0",
     "bzl.rules_go---0.60.0",
+    "bzl.rules_go---0.61.0",
     "bzl.rules_graalvm---0.11.1",
     "bzl.rules_graphql---0.1.3",
     "bzl.rules_gzip---1.0.0",
     "bzl.rules_gzip---1.0.0-beta.6",
     "bzl.rules_haskell---1.0",
-    "bzl.rules_heir---0.0.5",
+    "bzl.rules_heir---0.0.6",
     "bzl.rules_helm---0.27.0",
     "bzl.rules_img---0.3.11",
     "bzl.rules_img---0.3.3",
@@ -2227,7 +2234,7 @@ use_repo(
     "bzl.rules_python---2.0.2",
     "bzl.rules_python_gazelle_plugin---1.5.1",
     "bzl.rules_python_gazelle_plugin---2.0.2",
-    "bzl.rules_qemu---0.1.1",
+    "bzl.rules_qemu---0.2.0",
     "bzl.rules_qt---0.0.6",
     "bzl.rules_req_compile---1.1.0",
     "bzl.rules_req_compile---1.1.3",
@@ -2235,13 +2242,12 @@ use_repo(
     "bzl.rules_robolectric---4.16.1",
     "bzl.rules_rs---0.0.68",
     "bzl.rules_rs---0.0.73",
-    "bzl.rules_rs---0.0.82",
+    "bzl.rules_rs---0.0.83",
     "bzl.rules_ruby---0.26.0",
     "bzl.rules_runfiles_group---0.0.1-rc.5",
     "bzl.rules_rust---0.45.1",
     "bzl.rules_rust---0.51.0",
     "bzl.rules_rust---0.59.2",
-    "bzl.rules_rust---0.61.0",
     "bzl.rules_rust---0.62.0",
     "bzl.rules_rust---0.65.0",
     "bzl.rules_rust---0.66.0",
@@ -2250,8 +2256,8 @@ use_repo(
     "bzl.rules_rust---0.69.0",
     "bzl.rules_rust---0.70.0",
     "bzl.rules_rust_bindgen---0.59.2",
-    "bzl.rules_rust_bindgen---0.61.0",
     "bzl.rules_rust_bindgen---0.67.0",
+    "bzl.rules_rust_bindgen---0.68.1",
     "bzl.rules_rust_bindgen---0.70.0",
     "bzl.rules_rust_mdbook---0.70.0",
     "bzl.rules_rust_mutants---0.69.1",
@@ -2265,11 +2271,13 @@ use_repo(
     "bzl.rules_rust_wasm_bindgen---0.70.0",
     "bzl.rules_s3---1.0.1",
     "bzl.rules_s5---0.0.13",
+    "bzl.rules_sbom---0.6.1",
     "bzl.rules_scala---7.0.0",
     "bzl.rules_scala---7.1.3",
     "bzl.rules_scala---7.1.5",
     "bzl.rules_scala---7.2.2",
     "bzl.rules_scala---7.2.4",
+    "bzl.rules_scala---7.2.5",
     "bzl.rules_scala_native---0.1.0",
     "bzl.rules_sh---0.4.0",
     "bzl.rules_sh---0.5.0",
@@ -2303,13 +2311,13 @@ use_repo(
     "bzl.rules_swift---3.6.0",
     "bzl.rules_swift---3.6.1",
     "bzl.rules_swift_package_manager---1.15.0",
-    "bzl.rules_swift_package_manager---1.17.1",
+    "bzl.rules_swift_package_manager---1.18.1",
     "bzl.rules_swift_package_manager---1.9.0",
     "bzl.rules_swift_previews---0.1.1",
     "bzl.rules_swift_resources---0.3.1",
     "bzl.rules_syft---0.0.2",
     "bzl.rules_synology---0.2.3",
-    "bzl.rules_systemrdl---0.2.0",
+    "bzl.rules_systemrdl---0.3.0",
     "bzl.rules_tar---1.0.1",
     "bzl.rules_tcl---0.2.1",
     "bzl.rules_tensorrt_rtx---0.3.0",
@@ -2327,10 +2335,10 @@ use_repo(
     "bzl.rules_venv---0.19.0",
     "bzl.rules_venv---0.7.0",
     "bzl.rules_verilator---0.1.0",
-    "bzl.rules_verilator---0.3.3.bcr.1",
+    "bzl.rules_verilator---1.0.0",
     "bzl.rules_verilog---1.1.0",
     "bzl.rules_verilog---1.1.1",
-    "bzl.rules_vhdl---0.1.1",
+    "bzl.rules_vhdl---0.1.2",
     "bzl.rules_vivado---0.1.1",
     "bzl.rules_vulkan---0.8.0",
     "bzl.rules_wasm---2.3.0",
@@ -2491,8 +2499,9 @@ use_repo(
     "bzl.toolchains_arm_gnu---1.1.0",
     "bzl.toolchains_avr---0.1.2",
     "bzl.toolchains_buildbuddy---0.0.4",
+    "bzl.toolchains_llvm---1.5.0",
     "bzl.toolchains_llvm---1.7.0",
-    "bzl.toolchains_llvm_bootstrapped---0.2.3",
+    "bzl.toolchains_llvm_bootstrapped---0.5.7",
     "bzl.toolchains_musl---0.1.27.bcr.1",
     "bzl.toolchains_protoc---0.2.1",
     "bzl.toolchains_protoc---0.3.1",
@@ -2539,7 +2548,7 @@ use_repo(
     "bzl.websocketpp---0.8.2.bcr.5",
     "bzl.websocketpp---0.8.2.bcr.6",
     "bzl.wheelos_common_msgs---0.1.2",
-    "bzl.windows_support---0.1.7",
+    "bzl.windows_support---0.1.8",
     "bzl.with_cfg.bzl---0.12.0",
     "bzl.with_cfg.bzl---0.14.1",
     "bzl.with_cfg.bzl---0.14.6",
@@ -3807,6 +3816,12 @@ http_archive(
 )
 
 http_archive(
+    name = "github.com_clementguillot_rules_quarkus_releases_download_v0.2.0_rules_quarkus-v0.2.0.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/clementguillot/rules_quarkus/releases/download/v0.2.0/rules_quarkus-v0.2.0.docs.tar.gz",
+)
+
+http_archive(
     name = "github.com_dzbarsky_rules_itest_releases_download_v0.0.49_rules_itest-v0.0.49.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/dzbarsky/rules_itest/releases/download/v0.0.49/rules_itest-v0.0.49.docs.tar.gz",
@@ -4053,6 +4068,12 @@ http_archive(
 )
 
 http_archive(
+    name = "github.com_hermeticbuild_hermetic-launcher_releases_download_v0.0.9_hermetic_launcher-v0.0.9.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.9/hermetic_launcher-v0.0.9.docs.tar.gz",
+)
+
+http_archive(
     name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.44_rules_rs-v0.0.44.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.44/rules_rs-v0.0.44.docs.tar.gz",
@@ -4239,6 +4260,12 @@ http_archive(
 )
 
 http_archive(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.83_rules_rs-v0.0.83.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.83/rules_rs-v0.0.83.docs.tar.gz",
+)
+
+http_archive(
     name = "github.com_hermeticbuild_rules_runfiles_group_releases_download_v0.0.1-rc.2_rules_runfiles_group-v0.0.1-rc.2.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.2/rules_runfiles_group-v0.0.1-rc.2.docs.tar.gz",
@@ -4284,6 +4311,12 @@ http_archive(
     name = "github.com_hermeticbuild_windows_support_releases_download_v0.1.7_windows_support-v0.1.7.binaryprotos",
     build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
     url = "https://github.com/hermeticbuild/windows_support/releases/download/v0.1.7/windows_support-v0.1.7.docs.tar.gz",
+)
+
+http_archive(
+    name = "github.com_hermeticbuild_windows_support_releases_download_v0.1.8_windows_support-v0.1.8.binaryprotos",
+    build_file_content = "filegroup(name = \"files\",\n    srcs = glob([\"**/*.binaryproto\"]),\n    visibility = [\"//visibility:public\"],\n)",
+    url = "https://github.com/hermeticbuild/windows_support/releases/download/v0.1.8/windows_support-v0.1.8.docs.tar.gz",
 )
 
 http_archive(
@@ -5577,6 +5610,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_aran_rules_dart_proto_releases_download_v0.4.3_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-6pMLQz839NdcPWIGDFL+OLArgrjt3zgtiFQMSqY1xmU=",
+    urls = ["https://github.com/aran/rules_dart_proto/releases/download/v0.4.3/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_proto_releases_download_v0.4.3_rules_dart_proto-v0.4.3.tar.gz.attestation",
+    downloaded_file_path = "rules_dart_proto-v0.4.3.tar.gz.intoto.jsonl",
+    integrity = "sha256-DqLtthNGYoiVn6xchzUG5KTIrlC43KUVF8h/DMTHclQ=",
+    urls = ["https://github.com/aran/rules_dart_proto/releases/download/v0.4.3/rules_dart_proto-v0.4.3.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_proto_releases_download_v0.4.3_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-H/4oNEQjAmS6xGlkhZPGGaMb1txa7ZTL9o/05RYiSHk=",
+    urls = ["https://github.com/aran/rules_dart_proto/releases/download/v0.4.3/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_aran_rules_dart_releases_download_v0.1.9_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-P7BED9yO0oE5rZ3mRv11eh3sbsLKe63MIU1c59HHK30=",
@@ -5661,6 +5715,69 @@ http_file(
 )
 
 http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.0_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-batD6yK9aq16mjXT6+XXUM13Z5sdBthWbM3UwCBz3uE=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.0/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.0_rules_dart-v0.4.0.tar.gz.attestation",
+    downloaded_file_path = "rules_dart-v0.4.0.tar.gz.intoto.jsonl",
+    integrity = "sha256-dl8IGYqeBeWK4njFfNPslpKmBYG2aiSi9t0dWhanCt0=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.0/rules_dart-v0.4.0.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.0_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-ZBw5ssbmzp1aFv/e8Je9TNz1Ry1NB9oG1de4cfvoDHA=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.0/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.2_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-zFaOUlzVCTAMuPdDgu8h9LMry9t3qnWYDCXXsIxFkmw=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.2/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.2_rules_dart-v0.4.2.tar.gz.attestation",
+    downloaded_file_path = "rules_dart-v0.4.2.tar.gz.intoto.jsonl",
+    integrity = "sha256-EIrEmqjf+My6LYmxXdxkzC8l1O/2ZZGX7NN5DciUxQc=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.2/rules_dart-v0.4.2.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.2_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-xQUXzawVp9BePxJs+mDCQx6iHpdfWf5rNOEmX2hQ2Jo=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.2/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.3_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-0GE+BxmMi9KnNV/nL+M8FXwXIF2lGPwqTiw4n0or/B8=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.3/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.3_rules_dart-v0.4.3.tar.gz.attestation",
+    downloaded_file_path = "rules_dart-v0.4.3.tar.gz.intoto.jsonl",
+    integrity = "sha256-IptobxcO829ZtewS8o0hnymgFucQIGEiXSIWV+wVurE=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.3/rules_dart-v0.4.3.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aran_rules_dart_releases_download_v0.4.3_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-SCHW5/UAttyi3JvtUdnCb2y4W1NsoNGI8XeKzCf4KxM=",
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.3/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_aspect-build_aspect-gazelle_releases_download_prebuilt-v0.0.11_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-pzFlfbb3LblgQMUYoFwYiOxXXAWWelX+5WUcI5dHcEs=",
@@ -5679,6 +5796,27 @@ http_file(
     downloaded_file_path = "source.json.intoto.jsonl",
     integrity = "sha256-+nciEqRVtGeCwuxmKkkGT8Ovy2lC+u59inrrOxtTfJI=",
     urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.11/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aspect-build_aspect-gazelle_releases_download_prebuilt-v0.0.18_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-WbyM+Y/tburKOoqDbOd85TjZSfSxSiD5St/n3P/7S0Y=",
+    urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.18/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aspect-build_aspect-gazelle_releases_download_prebuilt-v0.0.18_aspect-gazelle-prebuilt-v0.0.18.tar.gz.attestation",
+    downloaded_file_path = "aspect-gazelle-prebuilt-v0.0.18.tar.gz.intoto.jsonl",
+    integrity = "sha256-vQk4REAztmSD9nOmf9D6P5Ytbx4KUCWZSNU6ukW9occ=",
+    urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.18/aspect-gazelle-prebuilt-v0.0.18.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_aspect-build_aspect-gazelle_releases_download_prebuilt-v0.0.18_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-iNgrFt+csRg24vQm9keYdKOAefzemSIIXCJdebKYh7E=",
+    urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.18/source.json.intoto.jsonl"],
 )
 
 http_file(
@@ -12878,6 +13016,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_bazel-contrib_rules_scala_releases_download_v7.2.5_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-OqSXgJxmF9pCtCkecUuHqW1zXXGwdLnNlmFSDvLuEf0=",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.5/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_bazel-contrib_rules_scala_releases_download_v7.2.5_rules_scala-v7.2.5.tar.gz.attestation",
+    downloaded_file_path = "rules_scala-v7.2.5.tar.gz.intoto.jsonl",
+    integrity = "sha256-I21KmSca1oGwIJJ4rRwEcuhxMOMl6gsfGqrjJ6oP+hU=",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.5/rules_scala-v7.2.5.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_bazel-contrib_rules_scala_releases_download_v7.2.5_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-H2iaO1KiH68EtLzGu3iRdWqIRbQ5eh+YWlbKGRtqLYA=",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.5/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_bazel-contrib_rules_shell_releases_download_v0.7.1_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-3fJjyiDtTLI1DNJrBDl6SLvmfFUiswqr3kX3kJvJTiI=",
@@ -14229,6 +14388,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_bazelbuild_rules_cc_releases_download_0.2.19_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-Ocs7N2m7z6x16y1StIliYgbnNBbR/NaIun2KUhKsHbA=",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.19/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_bazelbuild_rules_cc_releases_download_0.2.19_rules_cc-0.2.19.tar.gz.attestation",
+    downloaded_file_path = "rules_cc-0.2.19.tar.gz.intoto.jsonl",
+    integrity = "sha256-1uHcQi3TTWxTqONr/HkPQGVkPeDOS4m2WieykAzAXOw=",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.19/rules_cc-0.2.19.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_bazelbuild_rules_cc_releases_download_0.2.19_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-jJwF4Gqn7qMAQmJJjJPg3f3RdOY+W7nkVphq4ek/yBg=",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.19/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_bazelbuild_rules_cc_releases_download_0.2.1_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-odaAlXl6JVpgiVF5eqw7PgPvMzCbtw5l74LXY6zwj4Y=",
@@ -15507,6 +15687,27 @@ http_file(
     downloaded_file_path = "source.json.intoto.jsonl",
     integrity = "sha256-jrBNAVdDFmpatrYY1HBHTCnMTfwQzKbraSCyVhUKDzc=",
     urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.1.1/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_clementguillot_rules_quarkus_releases_download_v0.2.0_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-3YpfTPH/pkbG5YV87KKnIc5GoivzECta+PE0JUBqJ6g=",
+    urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.2.0/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_clementguillot_rules_quarkus_releases_download_v0.2.0_rules_quarkus-v0.2.0.tar.gz.attestation",
+    downloaded_file_path = "rules_quarkus-v0.2.0.tar.gz.intoto.jsonl",
+    integrity = "sha256-YSqeV83RXfG7CiECGV/2hmIl8MKgOvccG6fu/7Nck9U=",
+    urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.2.0/rules_quarkus-v0.2.0.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_clementguillot_rules_quarkus_releases_download_v0.2.0_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-Zj0/Pc+8GLMnNb77mfcdmR7Vq1hhS6ZT2xMq0Bpff8g=",
+    urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.2.0/source.json.intoto.jsonl"],
 )
 
 http_file(
@@ -17022,6 +17223,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_hermeticbuild_aws-in-a-box_releases_download_v0.0.73_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-OpurjgLEWEY1up57owtQk3DUFaTXOaPvUyj73CLGcDw=",
+    urls = ["https://github.com/hermeticbuild/aws-in-a-box/releases/download/v0.0.73/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_aws-in-a-box_releases_download_v0.0.73_aws-in-a-box-v0.0.73.tar.gz.attestation",
+    downloaded_file_path = "aws-in-a-box-v0.0.73.tar.gz.intoto.jsonl",
+    integrity = "sha256-2qij0SGhb+eczqmDwH8AOf92yNTBpmUZ8OA8pnsEQQI=",
+    urls = ["https://github.com/hermeticbuild/aws-in-a-box/releases/download/v0.0.73/aws-in-a-box-v0.0.73.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_aws-in-a-box_releases_download_v0.0.73_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-fs1X66mMKTCnjJp084Y+1t3ngyqtjm/LZ4ON8q92V+w=",
+    urls = ["https://github.com/hermeticbuild/aws-in-a-box/releases/download/v0.0.73/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_hermeticbuild_cuda-toolkit_releases_download_v0.0.1_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-//YrShjbvXkjPZaMA4Y6mU+Kh5SGeP8vo26uRUgXXZk=",
@@ -17442,6 +17664,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_hermeticbuild_hermetic-launcher_releases_download_v0.0.9_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-ISaFu5BLz4qfsep5Et9ULSja9GeuWnpMNKMd6ST7t0s=",
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.9/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_hermetic-launcher_releases_download_v0.0.9_hermetic_launcher-v0.0.9.tar.gz.attestation",
+    downloaded_file_path = "hermetic_launcher-v0.0.9.tar.gz.intoto.jsonl",
+    integrity = "sha256-3VTIbjZ1B42HcZTlmSdz3fqOR9CheLOqQW7yTopugYE=",
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.9/hermetic_launcher-v0.0.9.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_hermetic-launcher_releases_download_v0.0.9_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-tC1jJBE9XP5kg+64YCedFl1qVl0vWUWl2VfOFBczLS0=",
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.9/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_hermeticbuild_hermetic-llvm_releases_download_v0.7.1_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-v0OhYOqtNZZ9Lof4SsMJ8obahQg6IXe4q0r/H7Osq8Y=",
@@ -17652,6 +17895,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_hermeticbuild_hermetic-llvm_releases_download_v0.8.4_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-MVVSbpqdnCkMQ1j5OFl/s3CE/AoCRegJ9wYLa4oYVxM=",
+    urls = ["https://github.com/hermeticbuild/hermetic-llvm/releases/download/v0.8.4/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_hermetic-llvm_releases_download_v0.8.4_hermetic-llvm-v0.8.4.tar.gz.attestation",
+    downloaded_file_path = "hermetic-llvm-v0.8.4.tar.gz.intoto.jsonl",
+    integrity = "sha256-lSpph4uJlKynkXGnEQMRKyCJW5avkFvgAExSf1vrUeQ=",
+    urls = ["https://github.com/hermeticbuild/hermetic-llvm/releases/download/v0.8.4/hermetic-llvm-v0.8.4.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_hermetic-llvm_releases_download_v0.8.4_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-CZyAUa/XqJulRWYeRWjyYRyvKlaz31VGS8vNSt7lYLc=",
+    urls = ["https://github.com/hermeticbuild/hermetic-llvm/releases/download/v0.8.4/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_hermeticbuild_rules_qemu_releases_download_v0.1.0_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-gBeI3mi/ntpNCjleWymQyb+009UdrgSG9jFvGEkJj28=",
@@ -17691,6 +17955,27 @@ http_file(
     downloaded_file_path = "source.json.intoto.jsonl",
     integrity = "sha256-VZZErckDmEgNZlWwALmr14I/0OpCERs/wdNDK2YoUqw=",
     urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.1.1/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_rules_qemu_releases_download_v0.2.0_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-l8WeaZ9u7O9upGUGTgYlTh+rQRZCTO7zh+ZmRbJb3xQ=",
+    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.2.0/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_rules_qemu_releases_download_v0.2.0_rules_qemu-v0.2.0.tar.gz.attestation",
+    downloaded_file_path = "rules_qemu-v0.2.0.tar.gz.intoto.jsonl",
+    integrity = "sha256-iGD7JJ7MAaDV/2BZUWYRTYWEUKVSFaKbEYWo6o5Gogw=",
+    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.2.0/rules_qemu-v0.2.0.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_rules_qemu_releases_download_v0.2.0_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-QtQX5/OrJ2JoBwXVtPtRGzcI3AbhUB1pJssgyIKU694=",
+    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.2.0/source.json.intoto.jsonl"],
 )
 
 http_file(
@@ -18345,6 +18630,27 @@ http_file(
 )
 
 http_file(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.83_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-SBIk1umBTfl3gKGQve4VerjNEcOHr5EY27XoFZbpQxI=",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.83/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.83_rules_rs-v0.0.83.tar.gz.attestation",
+    downloaded_file_path = "rules_rs-v0.0.83.tar.gz.intoto.jsonl",
+    integrity = "sha256-hCo5umA0npONDqEkikPN3lVexc8zhe66J2ErzyrkDFs=",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.83/rules_rs-v0.0.83.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_rules_rs_releases_download_v0.0.83_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-hoj/woJ1XSxeqGDKZPmxPxyITIS5piHaF7hdDpCJN5w=",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.83/source.json.intoto.jsonl"],
+)
+
+http_file(
     name = "github.com_hermeticbuild_rules_runfiles_group_releases_download_v0.0.1-rc.2_MODULE.bazel.attestation",
     downloaded_file_path = "MODULE.bazel.intoto.jsonl",
     integrity = "sha256-gtr2mv1hwJ9U9FFCGVFgth0m+iM6u81GIZm6ZFYYqdw=",
@@ -18531,6 +18837,27 @@ http_file(
     downloaded_file_path = "windows_support-v0.1.7.tar.gz.intoto.jsonl",
     integrity = "sha256-/r8Wm5SUoQ5US8+oclWba2F9tXNHEGxbd8uHc0beBF0=",
     urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.7/windows_support-v0.1.7.tar.gz.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_windows_support_releases_download_v0.1.8_MODULE.bazel.attestation",
+    downloaded_file_path = "MODULE.bazel.intoto.jsonl",
+    integrity = "sha256-Zt1UNgV511GfMFyiWOMa60+bGPPPcfJVIOfqDanVRa4=",
+    urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.8/MODULE.bazel.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_windows_support_releases_download_v0.1.8_source.json.attestation",
+    downloaded_file_path = "source.json.intoto.jsonl",
+    integrity = "sha256-iNriF9JQtrv3x1h1F2lTTDtP143BXHuz1/sfzTLc/uA=",
+    urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.8/source.json.intoto.jsonl"],
+)
+
+http_file(
+    name = "github.com_hermeticbuild_windows_support_releases_download_v0.1.8_windows_support-v0.1.8.tar.gz.attestation",
+    downloaded_file_path = "windows_support-v0.1.8.tar.gz.intoto.jsonl",
+    integrity = "sha256-U38BAt07pKse90ylrG73UItZHEFaE1bgSgz44zrSBjs=",
+    urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.8/windows_support-v0.1.8.tar.gz.intoto.jsonl"],
 )
 
 http_file(
@@ -20634,108 +20961,18 @@ http_file(
 )
 
 starlark_repository.local(
-    name = "bzl.abc---0.62-yosyshq",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/abc/0.62-yosyshq/overlay",
-)
-starlark_repository.local(
     name = "bzl.abc---0.65-yosyshq",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/abc/0.65-yosyshq/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.0",
+starlark_repository.local(
+    name = "bzl.abc---0.62-yosyshq",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250512.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250512.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230125.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230125.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.2",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250127.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250127.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20210324.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20210324.2",
-    type = "zip",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20230802.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20230802.1",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+    path = "data/bazel-central-registry/modules/abc/0.62-yosyshq/overlay",
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20260107.1",
@@ -20747,40 +20984,13 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.1/abseil-cpp-20260107.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20211102.0",
+    name = "bzl.abseil-cpp---20230125.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20211102.0",
+    strip_prefix = "abseil-cpp-20230125.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20260107.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20260107.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.2",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.abseil-cpp---20240116.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20240116.0",
-    type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230125.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20250127.1",
@@ -20792,13 +21002,22 @@ starlark_repository.archive(
     urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.abseil-cpp---20250814.1",
+    name = "bzl.abseil-cpp---20240116.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-cpp-20250814.1",
+    strip_prefix = "abseil-cpp-20240116.1",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.1/abseil-cpp-20240116.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20211102.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20211102.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-cpp---20240722.0",
@@ -20824,13 +21043,112 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/abseil-cpp/20240722.0.bcr.2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.abseil-py---2.4.0",
+    name = "bzl.abseil-cpp---20250814.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "abseil-py-2.4.0",
+    strip_prefix = "abseil-cpp-20250814.0",
     type = "tar.gz",
-    urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.4.0.tar.gz"],
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.0/abseil-cpp-20250814.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.0/abseil-cpp-20240116.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250814.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250814.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20230802.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20230802.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250127.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250127.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250127.0/abseil-cpp-20250127.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20240116.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20240116.2",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20240116.2/abseil-cpp-20240116.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250814.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250814.2",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250814.2/abseil-cpp-20250814.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20210324.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20210324.2",
+    type = "zip",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20210324.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20230802.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20230802.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20230802.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20230802.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20250512.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20250512.1",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20250512.1/abseil-cpp-20250512.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-cpp---20260107.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-cpp-20260107.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-cpp/releases/download/20260107.0/abseil-cpp-20260107.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.abseil-py---2.1.0",
@@ -20840,6 +21158,15 @@ starlark_repository.archive(
     strip_prefix = "abseil-py-2.1.0",
     type = "tar.gz",
     urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.abseil-py---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "abseil-py-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/abseil/abseil-py/archive/refs/tags/v2.4.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.ada-url---3.4.4",
@@ -20887,14 +21214,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.antlr4-cpp-runtime---4.13.2.bcr.1",
+starlark_repository.local(
+    name = "bzl.antlr4-cpp-runtime---4.13.2.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "antlr4-4.13.2/runtime/Cpp",
-    type = "tar.gz",
-    urls = ["https://github.com/antlr/antlr4/archive/refs/tags/4.13.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/antlr4-cpp-runtime/4.13.2.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.aom---3.13.3",
@@ -20904,15 +21229,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/aom/3.13.3/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.ape---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ape-v1.0.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.1/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.ape---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -20920,6 +21236,24 @@ starlark_repository.archive(
     strip_prefix = "ape-v1.1.0",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.1.0/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.ape---1.0.0-beta.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ape-v1.0.0-beta.16",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-beta.16/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.ape---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ape-v1.0.1",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ape---1.0.0-beta.12",
@@ -20938,15 +21272,6 @@ starlark_repository.archive(
     strip_prefix = "ape-v1.0.0-beta.15",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-beta.15/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.ape---1.0.0-beta.16",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ape-v1.0.0-beta.16",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/ape/-/releases/v1.0.0-beta.16/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apilark---0.1",
@@ -20976,140 +21301,12 @@ starlark_repository.archive(
     urls = ["https://github.com/apple/apple_rules_lint/releases/download/0.4.0/apple_rules_lint-0.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.23.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.21.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.22.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.0/apple_support.1.22.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.apple_support---1.24.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.2/apple_support.1.24.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.15.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.11.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.18.0/apple_support.1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.24.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.17.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---2.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.apple_support---1.23.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.0/apple_support.1.23.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---2.4.0",
@@ -21120,12 +21317,60 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.4.0/apple_support.2.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---1.8.1",
+    name = "bzl.apple_support---2.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.22.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.0/apple_support.1.22.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.0.0/apple_support.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.15.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.15.1/apple_support.1.15.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.3.0/apple_support.2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.13.0/apple_support.1.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.apple_support---1.22.1",
@@ -21136,12 +21381,92 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.22.1/apple_support.1.22.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.apple_support---2.5.4",
+    name = "bzl.apple_support---2.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.5.4/apple_support.2.5.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.2.0/apple_support.2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.18.0/apple_support.1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/2.1.0/apple_support.2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.23.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.0/apple_support.1.23.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.11.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.17.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.17.1/apple_support.1.17.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.5/apple_support.1.24.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.24.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.24.1/apple_support.1.24.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.23.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.23.1/apple_support.1.23.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.apple_support---1.21.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/apple_support/releases/download/1.21.1/apple_support.1.21.1.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.apriltag---3.4.5",
@@ -21227,78 +21552,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/asio-grpc/3.1.0.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.9.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.9.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.11.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.11.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.13.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.14.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.14.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.40.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.40.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---1.38.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21306,33 +21559,6 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-1.38.1",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.38.1/bazel-lib-v1.38.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.8.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.16.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.42.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.42.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.9.4",
@@ -21344,49 +21570,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.4/bazel-lib-v2.9.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.39.0",
+    name = "bzl.aspect_bazel_lib---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.39.0",
+    strip_prefix = "bazel-lib-2.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.3.0/bazel-lib-v2.3.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.0",
+    name = "bzl.aspect_bazel_lib---1.42.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.0",
+    strip_prefix = "bazel-lib-1.42.3",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.0/bazel-lib-v2.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---1.28.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-1.28.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_bazel_lib---2.7.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-2.7.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.42.3/bazel-lib-v1.42.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_bazel_lib---2.7.7",
@@ -21398,13 +21597,139 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_gazelle_prebuilt---0.0.11",
+    name = "bzl.aspect_bazel_lib---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "aspect-gazelle-prebuilt-v0.0.11",
+    strip_prefix = "bazel-lib-2.1.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.11/aspect-gazelle-prebuilt-v0.0.11.tar.gz"],
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.1.0/bazel-lib-v2.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.6.1/bazel-lib-v2.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.40.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.40.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.40.3/bazel-lib-v1.40.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.8.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.8.1/bazel-lib-v2.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.0/bazel-lib-v2.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.16.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.16.0/bazel-lib-v2.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.7.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.7.2/bazel-lib-v2.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.14.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.14.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.14.0/bazel-lib-v2.14.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.11.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.11.0/bazel-lib-v2.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.28.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.28.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.28.0/bazel-lib-v1.28.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.13.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.13.0/bazel-lib-v2.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v2.0.1/bazel-lib-v2.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/bazel-lib/releases/download/v1.39.0/bazel-lib-v1.39.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_bazel_lib---2.9.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-2.9.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_gazelle_prebuilt---0.0.18",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "aspect-gazelle-prebuilt-v0.0.18",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/aspect-gazelle/releases/download/prebuilt-v0.0.18/aspect-gazelle-prebuilt-v0.0.18.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_aws---0.8.3",
@@ -21425,15 +21750,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_cypress/releases/download/v0.7.2/rules_cypress-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_esbuild---0.21.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_esbuild-0.21.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_esbuild---0.26.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21441,6 +21757,15 @@ starlark_repository.archive(
     strip_prefix = "rules_esbuild-0.26.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.26.0/rules_esbuild-v0.26.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_esbuild---0.21.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_esbuild-0.21.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_jasmine---2.0.4",
@@ -21461,31 +21786,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_jest/releases/download/v0.25.2/rules_jest-v0.25.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.0.2",
+    name = "bzl.aspect_rules_js---2.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.0.2",
+    strip_prefix = "rules_js-2.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---3.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-3.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.1.2/rules_js-v3.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.40.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---1.42.0",
@@ -21506,15 +21813,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.8/rules_js-v2.3.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.3.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21524,40 +21822,22 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.5/rules_js-v2.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.4.0",
+    name = "bzl.aspect_rules_js---2.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.4.0",
+    strip_prefix = "rules_js-2.1.3",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.5.0",
+    name = "bzl.aspect_rules_js---2.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.5.0",
+    strip_prefix = "rules_js-2.6.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---3.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-3.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.0/rules_js-v2.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.0.0",
@@ -21569,6 +21849,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.0/rules_js-v2.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.34.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21576,6 +21865,69 @@ starlark_repository.archive(
     strip_prefix = "rules_js-2.3.3",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.3.3/rules_js-v2.3.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.0.2/rules_js-v2.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---3.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-3.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.1/rules_js-v3.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---3.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-3.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.1.2/rules_js-v3.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.6.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.6.2",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---1.40.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-1.40.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.40.0/rules_js-v1.40.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.4.0/rules_js-v2.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_js---2.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_js-2.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.7.0/rules_js-v2.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js---2.9.2",
@@ -21605,33 +21957,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.1/rules_js-v1.34.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.1.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.1.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.3/rules_js-v2.1.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.6.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.6.2",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.6.2/rules_js-v2.6.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_js---1.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-1.34.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v1.34.0/rules_js-v1.34.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_js---3.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21641,13 +21966,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_js/releases/download/v3.0.3/rules_js-v3.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_js---2.1.2",
+    name = "bzl.aspect_rules_js---2.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_js-2.1.2",
+    strip_prefix = "rules_js-2.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.1.2/rules_js-v2.1.2.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_js/releases/download/v2.5.0/rules_js-v2.5.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_js_rust_wasm_bindgen---0.0.2",
@@ -21656,6 +21981,15 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/UebelAndre/aspect_rules_js_rust_wasm_bindgen/releases/download/0.0.2/aspect_rules_js_rust_wasm_bindgen-0.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.aspect_rules_lint---0.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_lint-0.12.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_lint---1.0.0-rc4",
@@ -21674,15 +22008,6 @@ starlark_repository.archive(
     strip_prefix = "rules_lint-2.6.0",
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/rules_lint/releases/download/v2.6.0/rules_lint-v2.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.aspect_rules_lint---0.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_lint-0.12.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_lint/releases/download/v0.12.0/rules_lint-v0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_py---1.8.4",
@@ -21739,6 +22064,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_terser/releases/download/v2.1.0/rules_terser-v2.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_rules_ts---3.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ts-3.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.7.0/rules_ts-v3.7.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21757,15 +22091,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.8.10/rules_ts-v3.8.10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.aspect_rules_ts---3.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21775,13 +22100,13 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.6.0/rules_ts-v3.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aspect_rules_ts---3.7.0",
+    name = "bzl.aspect_rules_ts---3.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_ts-3.7.0",
+    strip_prefix = "rules_ts-3.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.7.0/rules_ts-v3.7.0.tar.gz"],
+    urls = ["https://github.com/aspect-build/rules_ts/releases/download/v3.4.0/rules_ts-v3.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.aspect_rules_webpack---0.17.1",
@@ -21793,6 +22118,15 @@ starlark_repository.archive(
     urls = ["https://github.com/aspect-build/rules_webpack/releases/download/v0.17.1/rules_webpack-v0.17.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.aspect_tools_telemetry---0.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tools_telemetry-0.3.3",
+    type = "tar.gz",
+    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.3.3/tools_telemetry-v0.3.3.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.aspect_tools_telemetry---0.2.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -21801,14 +22135,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.2.8/tools_telemetry-v0.2.8.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.aspect_tools_telemetry---0.3.3",
+starlark_repository.local(
+    name = "bzl.assimp---6.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tools_telemetry-0.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/aspect-build/tools_telemetry/releases/download/v0.3.3/tools_telemetry-v0.3.3.tar.gz"],
+    path = "data/bazel-central-registry/modules/assimp/6.0.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.assimp---5.4.3.bcr.3",
@@ -21823,13 +22155,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/assimp/5.4.3.bcr.6/overlay",
-)
-starlark_repository.local(
-    name = "bzl.assimp---6.0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/assimp/6.0.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.at-spi2-core---2.58.2",
@@ -21855,13 +22180,13 @@ starlark_repository.archive(
     urls = ["https://github.com/alexeagle/awk.bzl/releases/download/v0.2.3/awk.bzl-v0.2.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.aws-in-a-box---0.0.69",
+    name = "bzl.aws-in-a-box---0.0.73",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "aws-in-a-box-0.0.69",
+    strip_prefix = "aws-in-a-box-0.0.73",
     type = "tar.gz",
-    urls = ["https://github.com/dzbarsky/aws-in-a-box/releases/download/v0.0.69/aws-in-a-box-v0.0.69.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/aws-in-a-box/releases/download/v0.0.73/aws-in-a-box-v0.0.73.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.aws-lc---1.67.0.bcr.1",
@@ -22004,40 +22329,13 @@ starlark_repository.archive(
     urls = ["https://github.com/buildbuddy-io/bazel_env.bzl/releases/download/v0.7.2/bazel_env.bzl-v0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.32.0",
+    name = "bzl.bazel_features---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.32.0",
+    strip_prefix = "bazel_features-1.1.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.27.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.27.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.27.0/bazel_features-v1.27.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.43.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.43.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.4.1",
@@ -22049,85 +22347,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.4.1/bazel_features-v1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.1",
+    name = "bzl.bazel_features---1.28.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.1",
+    strip_prefix = "bazel_features-1.28.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.18.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.38.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.38.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.38.0/bazel_features-v1.38.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.20.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.20.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.1.1/bazel_features-v1.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.47.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.47.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.1/bazel_features-v1.47.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.44.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.30.0",
@@ -22139,22 +22365,58 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.28.0",
+    name = "bzl.bazel_features---1.43.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.28.0",
+    strip_prefix = "bazel_features-1.43.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.28.0/bazel_features-v1.28.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.43.0/bazel_features-v1.43.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.24.0",
+    name = "bzl.bazel_features---1.47.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.24.0",
+    strip_prefix = "bazel_features-1.47.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.1/bazel_features-v1.47.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.44.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.44.0/bazel_features-v1.44.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.20.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.20.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.20.0/bazel_features-v1.20.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.39.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.13.0",
@@ -22166,60 +22428,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.13.0/bazel_features-v1.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.46.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---0.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-0.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.35.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_features---1.11.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.11.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_features---1.47.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22227,6 +22435,24 @@ starlark_repository.archive(
     strip_prefix = "bazel_features-1.47.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.47.0/bazel_features-v1.47.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.15.0/bazel_features-v1.15.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.24.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.24.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.24.0/bazel_features-v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_features---1.19.0",
@@ -22238,13 +22464,112 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.19.0/bazel_features-v1.19.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_features---1.39.0",
+    name = "bzl.bazel_features---1.18.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel_features-1.39.0",
+    strip_prefix = "bazel_features-1.18.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.39.0/bazel_features-v1.39.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.18.0/bazel_features-v1.18.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.46.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.46.0/bazel_features-v1.46.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v0.1.0/bazel_features-v0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.38.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.38.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.38.0/bazel_features-v1.38.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.0/bazel_features-v1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.35.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.35.0/bazel_features-v1.35.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.9.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.9.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.33.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.33.0/bazel_features-v1.33.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.11.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.11.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.11.0/bazel_features-v1.11.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.27.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.27.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.27.0/bazel_features-v1.27.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_features---1.32.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_features-1.32.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel_features/releases/download/v1.32.0/bazel_features-v1.32.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_gomock---0.2.0",
@@ -22282,13 +22607,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-beta.1/bazel-lib-v3.0.0-beta.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.0",
+    name = "bzl.bazel_lib---3.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.0",
+    strip_prefix = "bazel-lib-3.2.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.0.0-rc.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.0.0-rc.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_lib---3.0.0",
@@ -22309,24 +22643,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.1.0/bazel-lib-v3.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_lib---3.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.2/bazel-lib-v3.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_lib---3.0.0-rc.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-lib-3.0.0-rc.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0-rc.0/bazel-lib-v3.0.0-rc.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_lib---3.3.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22334,6 +22650,15 @@ starlark_repository.archive(
     strip_prefix = "bazel-lib-3.3.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.3.1/bazel-lib-v3.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_lib---3.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-lib-3.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-lib/releases/download/v3.2.0/bazel-lib-v3.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_linux_packages---0.3.1",
@@ -22354,52 +22679,28 @@ starlark_repository.archive(
     urls = ["https://github.com/gregl83/bazel-paq/releases/download/v1.4.1/bazel-paq-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.1",
+    name = "bzl.bazel_skylib---1.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.3.0",
+    name = "bzl.bazel_skylib---1.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.0/bazel-skylib-1.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.2.0",
+    name = "bzl.bazel_skylib---1.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.1.1",
@@ -22410,28 +22711,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.6.1/bazel-skylib-1.6.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_skylib---1.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.2/bazel-skylib-1.8.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.9.0/bazel-skylib-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.0.3",
@@ -22450,12 +22743,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.8.0",
+    name = "bzl.bazel_skylib---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.0/bazel-skylib-1.8.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib---1.4.2",
@@ -22466,12 +22767,36 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_skylib---1.7.0",
+    name = "bzl.bazel_skylib---1.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.8.1/bazel-skylib-1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_skylib---1.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_skylib_gazelle_plugin---1.9.0",
@@ -22490,40 +22815,13 @@ starlark_repository.archive(
     urls = ["https://github.com/Zetten/bazel-sonarqube/releases/download/1.0.6/bazel_sonarqube.1.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_tools---8.7.0",
+    name = "bzl.bazel_tools---9.1.1rc1",
     build_directives = ["gazelle:starlarkrepository_root tools"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-8.7.0",
+    strip_prefix = "bazel-9.1.1rc1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel/archive/refs/tags/8.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_worker_api---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.6/proto",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.6/bazel-worker-api-v0.0.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_worker_api---0.0.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.4/proto",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bazel_worker_api---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.8/proto",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel/archive/refs/tags/9.1.1rc1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazel_worker_api---0.0.1",
@@ -22535,6 +22833,24 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.1/bazel-worker-api-v0.0.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.bazel_worker_api---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.6/proto",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.6/bazel-worker-api-v0.0.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_api---0.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.8/proto",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.bazel_worker_api---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22544,11 +22860,11 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.10/bazel-worker-api-v0.0.10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.4",
+    name = "bzl.bazel_worker_api---0.0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.4/java",
+    strip_prefix = "bazel-worker-api-0.0.4/proto",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
 )
@@ -22562,15 +22878,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.8/bazel-worker-api-v0.0.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.bazel_worker_java---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel-worker-api-0.0.5/java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bazel_worker_java---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22578,6 +22885,24 @@ starlark_repository.archive(
     strip_prefix = "bazel-worker-api-0.0.10/java",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.10/bazel-worker-api-v0.0.10.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.4/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.4/bazel-worker-api-v0.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bazel_worker_java---0.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel-worker-api-0.0.5/java",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-worker-api/releases/download/v0.0.5/bazel-worker-api-v0.0.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bazeldnf---v0.99.2-rc1",
@@ -22649,13 +22974,6 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/bison/3.8.2.bcr.5/overlay",
 )
-starlark_repository.local(
-    name = "bzl.blake3---1.8.2.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/blake3/1.8.2.bcr.1/overlay",
-)
 starlark_repository.archive(
     name = "bzl.blake3---1.5.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -22664,6 +22982,13 @@ starlark_repository.archive(
     strip_prefix = "BLAKE3-1.5.1",
     type = "tar.gz",
     urls = ["https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.5.1.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.blake3---1.8.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/blake3/1.8.2.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.bliss---0.73",
@@ -22711,6 +23036,27 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.algorithm---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.algorithm---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.algorithm/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.algorithm---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22739,46 +23085,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.algorithm/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.algorithm---1.90.0.bcr.1",
+    name = "bzl.boost.align---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.algorithm/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.algorithm---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.algorithm/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.algorithm---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.algorithm/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.align---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.align---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.align---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.align/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.align/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.align---1.83.0.bcr.1",
@@ -22795,18 +23106,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.align/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.align---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.align/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.align---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.align---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.align/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.align---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.align/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.align---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.align/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.any---1.89.0.bcr.2",
@@ -22816,18 +23141,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.any/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.any---1.87.0",
+    name = "bzl.boost.any---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.any/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.any---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.any/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.any/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.any---1.83.0.bcr.2",
@@ -22844,25 +23162,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.any/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.any---1.90.0.bcr.1",
+    name = "bzl.boost.any---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.any/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.any/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.array---1.88.0.bcr.2",
+    name = "bzl.boost.any---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.array/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.array---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.array/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.any/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.array---1.89.0.bcr.1",
@@ -22886,6 +23197,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.array/1.87.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.array---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.array/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.array---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -22900,18 +23218,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.array/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.asio---1.83.0.bcr.4",
+    name = "bzl.boost.array---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.asio/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.asio---1.87.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.asio/1.87.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.array/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.asio---1.89.0.bcr.1",
@@ -22928,11 +23239,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.asio/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.asio---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.asio---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.asio/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.asio---1.87.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.asio/1.87.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.assert---1.88.0.bcr.2",
@@ -22942,18 +23267,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.assert/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.assert---1.89.0.bcr.1",
+    name = "bzl.boost.assert---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.assert---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.assert/1.87.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.assert---1.83.0.bcr.1",
@@ -22979,25 +23297,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.assert/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.assert---1.87.0",
+    name = "bzl.boost.assert---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.assert/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.assign---1.87.0",
+    name = "bzl.boost.assert---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.assign/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.assign---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.assign/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.assert/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.assign---1.89.0.bcr.2",
@@ -23007,18 +23318,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.assign/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.atomic---1.89.0.bcr.2",
+    name = "bzl.boost.assign---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.atomic/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.assign/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.atomic---1.88.0.bcr.2",
+    name = "bzl.boost.assign---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.atomic/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.assign/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.atomic---1.83.0.bcr.1",
@@ -23035,13 +23346,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.atomic/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.atomic---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.atomic/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.atomic---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23049,11 +23353,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.atomic/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.beast---1.90.0.bcr.1",
+    name = "bzl.boost.atomic---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.beast/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.atomic/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.atomic---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.atomic/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.beast---1.89.0.bcr.2",
@@ -23061,6 +23379,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.beast/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.beast---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.beast/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.beast---1.83.0.bcr.4",
@@ -23077,20 +23402,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.bimap/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.bimap---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bimap/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.bimap---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bimap/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.bimap---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23105,18 +23416,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.bimap/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.bind---1.83.0.bcr.1",
+    name = "bzl.boost.bimap---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.bimap/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.bind---1.83.0.bcr.4",
+    name = "bzl.boost.bimap---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.bimap/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.bind---1.87.0",
@@ -23124,20 +23435,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.bind/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.bind---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.bind---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.bind---1.88.0.bcr.2",
@@ -23154,11 +23451,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.bind/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.callable_traits---1.89.0.bcr.2",
+    name = "bzl.boost.bind---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.callable_traits/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.bind---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.bind/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.callable_traits---1.90.0.bcr.1",
@@ -23166,6 +23484,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.callable_traits/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.callable_traits---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.callable_traits/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.charconv---1.90.0.bcr.1",
@@ -23182,11 +23507,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.charconv/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.chrono---1.87.0",
+    name = "bzl.boost.chrono---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.chrono/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.chrono/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.chrono---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.chrono/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.chrono---1.88.0.bcr.2",
@@ -23196,11 +23528,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.chrono/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.chrono---1.89.0.bcr.2",
+    name = "bzl.boost.chrono---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.chrono/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.chrono/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.chrono---1.83.0.bcr.1",
@@ -23217,18 +23549,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.chrono/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.chrono---1.90.0.bcr.1",
+    name = "bzl.boost.circular_buffer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.chrono/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.circular_buffer---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.circular_buffer---1.89.0.bcr.2",
@@ -23238,18 +23563,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.circular_buffer/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.circular_buffer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.circular_buffer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.circular_buffer/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.circular_buffer---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.circular_buffer/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.compat---1.89.0.bcr.2",
@@ -23294,20 +23619,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.concept_check/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.concept_check---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.concept_check---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.concept_check---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23329,6 +23640,20 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.concept_check/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.concept_check---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.concept_check---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.concept_check/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.concept_check---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23336,18 +23661,39 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.concept_check/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.config---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.config/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.config---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.config/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.config---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.config/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.config---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.config/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.config---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.config/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.config---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.config/1.87.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.config---1.83.0.bcr.1",
@@ -23366,25 +23712,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.config/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.config---1.88.0.bcr.2",
+    name = "bzl.boost.container---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.config/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.container/1.83.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.config---1.89.0.bcr.1",
+    name = "bzl.boost.container---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.config/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.config---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.config/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.container/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.container---1.90.0.bcr.1",
@@ -23422,39 +23761,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.container/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.container---1.83.0.bcr.1",
+    name = "bzl.boost.container_hash---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.container---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.container_hash---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.container_hash---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.container_hash---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container_hash/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.container_hash---1.83.0.bcr.1",
@@ -23471,6 +23782,20 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.container_hash/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.container_hash---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.container_hash---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.container_hash---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23478,11 +23803,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.container_hash/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.container_hash---1.90.0.bcr.1",
+    name = "bzl.boost.container_hash---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.container_hash/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.container_hash/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.context---1.90.0.bcr.1",
@@ -23499,13 +23824,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.context/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.context---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.context/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.context---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23520,39 +23838,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.context/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.context---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.context/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.conversion---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.conversion/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.conversion---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.conversion---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.conversion---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.conversion/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.conversion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.conversion/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.conversion---1.89.0.bcr.1",
@@ -23569,11 +23866,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.conversion/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.core---1.87.0",
+    name = "bzl.boost.conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.core/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.conversion/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.conversion---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.conversion/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.core---1.89.0.bcr.1",
@@ -23606,6 +23924,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.core/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.core---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.core/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.core---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23618,13 +23943,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.core/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.coroutine---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.coroutine/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.coroutine---1.89.0.bcr.2",
@@ -23648,6 +23966,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.coroutine/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.coroutine---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.coroutine/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.coroutine2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23662,18 +23987,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.coroutine2/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.crc---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.crc/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.crc---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.crc/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.crc---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.crc/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.crc---1.90.0.bcr.1",
@@ -23683,39 +24008,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.crc/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.date_time---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.date_time/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.date_time---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.date_time/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.date_time---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.date_time/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.date_time---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.date_time---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.date_time---1.83.0.bcr.1",
@@ -23732,18 +24029,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.date_time/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.describe---1.88.0.bcr.2",
+    name = "bzl.boost.date_time---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.describe/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.describe---1.87.0",
+    name = "bzl.boost.date_time---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.describe/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.date_time/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.date_time---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.date_time/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.describe---1.89.0.bcr.1",
@@ -23760,13 +24071,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.describe/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.describe---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.describe/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.describe---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23781,6 +24085,27 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.describe/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.describe---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.describe---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.describe---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.describe/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.detail---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23793,6 +24118,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.detail/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.detail---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.detail/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.detail---1.89.0.bcr.1",
@@ -23823,11 +24155,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.detail/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.detail---1.90.0.bcr.1",
+    name = "bzl.boost.dll---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.detail/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.dll/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.dll---1.89.0.bcr.2",
@@ -23835,13 +24167,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.dll/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.dll---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.dll/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.dll---1.90.0.bcr.1",
@@ -23865,6 +24190,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.87.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.dynamic_bitset---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.dynamic_bitset---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23879,13 +24211,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.dynamic_bitset---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.dynamic_bitset---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23893,18 +24218,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.dynamic_bitset/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.endian---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.endian/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.endian---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.endian/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.endian---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.endian/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.endian---1.89.0.bcr.2",
@@ -23935,32 +24260,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.endian/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.endian---1.90.0.bcr.1",
+    name = "bzl.boost.endian---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.endian/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.exception---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.exception/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.exception---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.exception/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.exception---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.exception/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.endian/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.exception---1.83.0.bcr.1",
@@ -23977,6 +24281,27 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.exception/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.exception---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.exception/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.exception---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.exception/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.exception---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.exception/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.exception---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -23991,11 +24316,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.exception/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.filesystem---1.89.0.bcr.2",
+    name = "bzl.boost.filesystem---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.filesystem/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.filesystem---1.87.0",
@@ -24012,11 +24337,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.filesystem/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.filesystem---1.90.0.bcr.1",
+    name = "bzl.boost.filesystem---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.filesystem/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.filesystem/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.filesystem---1.88.0.bcr.2",
@@ -24024,20 +24349,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.filesystem/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.foreach---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.foreach/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.foreach---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.foreach/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.foreach---1.83.0.bcr.1",
@@ -24054,6 +24365,20 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.foreach/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.foreach---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.foreach/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.foreach---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.foreach/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.foreach---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24061,18 +24386,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.foreach/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.format---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.format/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.format---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.format/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.format---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.format/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.format---1.83.0.bcr.1",
@@ -24096,11 +24421,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.format/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.function---1.90.0.bcr.1",
+    name = "bzl.boost.function---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.function---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.function---1.89.0.bcr.1",
@@ -24117,13 +24449,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.function/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.function---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.function---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24131,18 +24456,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.function/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.function---1.83.0.bcr.1",
+    name = "bzl.boost.function---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.function/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.function---1.83.0.bcr.4",
+    name = "bzl.boost.function---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.function/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.function_types---1.88.0.bcr.2",
@@ -24150,20 +24475,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.function_types/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.function_types---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.function_types---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.function_types---1.87.0",
@@ -24194,6 +24505,34 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.function_types/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.function_types---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.function_types---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.function_types/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.functional---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.functional---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24215,13 +24554,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.functional/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.functional---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.functional/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.functional---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24229,32 +24561,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.functional/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.functional---1.89.0.bcr.1",
+    name = "bzl.boost.functional---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.functional---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.functional/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.fusion---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.fusion/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.fusion---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.fusion/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.functional/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.fusion---1.88.0.bcr.2",
@@ -24264,18 +24575,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.fusion/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.fusion---1.89.0.bcr.1",
+    name = "bzl.boost.fusion---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.fusion---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.fusion/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.fusion---1.83.0.bcr.1",
@@ -24292,11 +24596,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.fusion/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.geometry---1.89.0.bcr.2",
+    name = "bzl.boost.fusion---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.geometry/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.fusion---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.fusion/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.geometry---1.90.0.bcr.1",
@@ -24306,32 +24624,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.geometry/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.geometry---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.geometry/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.geometry---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.geometry/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.graph---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.graph/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.graph---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.graph/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.graph---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.graph/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.graph---1.83.0.bcr.1",
@@ -24348,11 +24652,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.graph/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.hash2---1.89.0.bcr.2",
+    name = "bzl.boost.graph---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.hash2/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.graph/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.graph---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.graph/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.graph---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.graph/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.hash2---1.90.0.bcr.1",
@@ -24362,18 +24680,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.hash2/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.heap---1.90.0.bcr.1",
+    name = "bzl.boost.hash2---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.heap/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.heap---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.heap/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.hash2/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.heap---1.83.0",
@@ -24390,11 +24701,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.heap/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.heap---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.heap/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.heap---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.heap/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.histogram---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.histogram/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.histogram---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.histogram/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.hof---1.89.0.bcr.2",
@@ -24432,11 +24764,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.icl/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.integer---1.90.0.bcr.1",
+    name = "bzl.boost.integer---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.integer/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.integer/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.integer---1.83.0.bcr.1",
@@ -24453,13 +24785,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.integer/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.integer---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.integer/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.integer---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24474,18 +24799,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.integer/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.integer---1.88.0.bcr.2",
+    name = "bzl.boost.integer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.integer/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.integer/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.interprocess---1.83.0.bcr.4",
+    name = "bzl.boost.integer---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.interprocess/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.integer/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.interprocess---1.89.0.bcr.2",
@@ -24495,13 +24820,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.interprocess/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.interprocess---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.interprocess/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.interprocess---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24509,39 +24827,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.interprocess/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.intrusive---1.87.0",
+    name = "bzl.boost.interprocess---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.intrusive/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.intrusive---1.90.0.bcr.1",
+    name = "bzl.boost.interprocess---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.intrusive/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.intrusive---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.intrusive/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.intrusive---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.intrusive/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.intrusive---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.intrusive/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.interprocess/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.intrusive---1.83.0.bcr.1",
@@ -24558,18 +24855,60 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.intrusive/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.intrusive---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.intrusive/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.intrusive---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.intrusive/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.intrusive---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.intrusive/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.intrusive---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.intrusive/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.intrusive---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.intrusive/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.io---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.io---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.io---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.io/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.io---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.io/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.io---1.89.0.bcr.1",
@@ -24586,6 +24925,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.io/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.io---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.io/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.io---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24593,18 +24939,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.io/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.io---1.83.0.bcr.1",
+    name = "bzl.boost.iostreams---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.io---1.83.0.bcr.4",
+    name = "bzl.boost.iostreams---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.io/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.iostreams/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.iostreams---1.87.0",
@@ -24628,13 +24974,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.iostreams/1.90.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.iostreams---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.iostreams/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.iostreams---1.83.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24649,11 +24988,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.iostreams/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.iostreams---1.89.0.bcr.2",
+    name = "bzl.boost.iterator---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.iostreams/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.iterator/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.iterator---1.90.0.bcr.1",
@@ -24675,13 +25014,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.iterator/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.iterator---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.iterator/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.iterator---1.88.0.bcr.2",
@@ -24712,18 +25044,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.json/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.json---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.json/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.json---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.json/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.json---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.json/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.lambda---1.87.0",
@@ -24747,13 +25079,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lambda/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.lambda---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lambda/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.lambda---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24761,11 +25086,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lambda/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.lambda2---1.90.0.bcr.1",
+    name = "bzl.boost.lambda---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lambda2/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.lambda/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.lambda2---1.89.0.bcr.2",
@@ -24775,11 +25100,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lambda2/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.leaf---1.89.0.bcr.2",
+    name = "bzl.boost.lambda2---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.leaf/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.lambda2/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.leaf---1.90.0.bcr.1",
@@ -24789,18 +25114,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.leaf/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.lexical_cast---1.87.0",
+    name = "bzl.boost.leaf---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.lexical_cast---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.leaf/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.lexical_cast---1.89.0.bcr.1",
@@ -24817,11 +25135,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lexical_cast/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.lexical_cast---1.90.0.bcr.1",
+    name = "bzl.boost.lexical_cast---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.lexical_cast---1.83.0.bcr.1",
@@ -24838,18 +25163,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lexical_cast/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.lexical_cast---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.lexical_cast/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.locale---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.locale/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.lockfree---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.lockfree/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.lockfree---1.89.0.bcr.2",
@@ -24859,11 +25184,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.lockfree/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.log---1.90.0.bcr.1",
+    name = "bzl.boost.lockfree---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.log/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.lockfree/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.log---1.89.0.bcr.2",
@@ -24873,11 +25198,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.log/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.log---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.log/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.logic---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.logic/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.logic---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.logic/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.logic---1.90.0.bcr.1",
@@ -24887,11 +25226,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.logic/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.logic---1.83.0.bcr.4",
+    name = "bzl.boost.math---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.logic/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.math/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.math---1.90.0.bcr.1",
@@ -24915,25 +25254,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.math/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.math---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.math/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.math---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.math/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.move---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.move/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.move---1.89.0.bcr.1",
@@ -24950,20 +25275,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.move/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.move---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.move/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.move---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.move/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.move---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -24976,6 +25287,27 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.move/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.move---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.move/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.move---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.move/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.move---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.move/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.mp11---1.89.0.bcr.1",
@@ -24992,13 +25324,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.mp11/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.mp11---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.mp11/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.mp11---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25013,11 +25338,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.mp11/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.mp11---1.90.0.bcr.1",
+    name = "bzl.boost.mp11---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.mp11/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.mp11/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.mp11---1.88.0.bcr.2",
@@ -25025,6 +25350,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.mp11/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mp11---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mp11/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.mpl---1.90.0.bcr.1",
@@ -25076,18 +25408,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.mpl/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.mqtt5---1.89.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.mqtt5/1.89.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.mqtt5---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.mqtt5/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.mqtt5---1.89.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.mqtt5/1.89.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.multi_array---1.89.0.bcr.2",
@@ -25097,13 +25429,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.multi_array/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.multi_array---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.multi_array/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.multi_array---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25111,25 +25436,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.multi_array/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.multi_index---1.87.0",
+    name = "bzl.boost.multi_array---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.multi_index/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.multi_index---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.multi_index/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.multi_index---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.multi_index/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.multi_array/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.multi_index---1.83.0.bcr.1",
@@ -25146,18 +25457,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.multi_index/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.multi_index---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multi_index---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multi_index/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.multi_index---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.multi_index/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.multiprecision---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.multiprecision/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.multiprecision---1.87.0",
@@ -25179,6 +25504,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.multiprecision/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.multiprecision---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.multiprecision/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.multiprecision---1.90.0.bcr.1",
@@ -25223,13 +25555,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.numeric_conversion---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.numeric_conversion---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25251,11 +25576,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.numeric_interval---1.89.0",
+    name = "bzl.boost.numeric_conversion---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.numeric_interval/1.89.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.numeric_conversion/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.numeric_interval---1.90.0.bcr.1",
@@ -25265,6 +25590,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.numeric_interval/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.numeric_interval---1.89.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.numeric_interval/1.89.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.numeric_ublas---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25272,18 +25604,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.numeric_ublas/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.optional---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.optional/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.optional---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.optional/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.optional---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.optional/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.optional---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.optional/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.optional---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.optional/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.optional---1.89.0.bcr.1",
@@ -25307,20 +25653,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.optional/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.optional---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.optional/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.optional---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.optional/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.outcome---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25340,13 +25672,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.parameter/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.parameter---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.parameter/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.parameter---1.83.0.bcr.1",
@@ -25370,6 +25695,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.parameter/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.parameter---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.parameter/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.pfr---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25391,11 +25723,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.pfr/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.phoenix---1.90.0.bcr.1",
+    name = "bzl.boost.phoenix---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.phoenix/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.phoenix/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.phoenix---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.phoenix/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.phoenix---1.87.0",
@@ -25403,6 +25742,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.phoenix/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.phoenix---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.phoenix/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.phoenix---1.83.0.bcr.1",
@@ -25426,20 +25772,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.phoenix/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.phoenix---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.phoenix/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.phoenix---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.phoenix/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.pin_version---1.89.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25447,11 +25779,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.pin_version/1.89.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.polygon---1.83.0.bcr.4",
+    name = "bzl.boost.polygon---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.polygon/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.polygon/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.polygon---1.90.0.bcr.1",
@@ -25461,11 +25793,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.polygon/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.polygon---1.89.0.bcr.2",
+    name = "bzl.boost.polygon---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.polygon/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.polygon/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.pool---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.pool/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.pool---1.88.0.bcr.2",
@@ -25510,13 +25849,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.pool/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.pool---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.pool/1.87.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.predef---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25529,6 +25861,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.predef/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.predef---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.predef/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.predef---1.89.0.bcr.1",
@@ -25545,13 +25891,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.predef/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.predef---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.predef/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.predef---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25559,25 +25898,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.predef/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.predef---1.87.0",
+    name = "bzl.boost.preprocessor---1.89.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.predef/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.preprocessor/1.89.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.preprocessor---1.88.0.bcr.2",
+    name = "bzl.boost.preprocessor---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.preprocessor/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.preprocessor/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.preprocessor---1.87.0",
+    name = "bzl.boost.preprocessor---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.preprocessor/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.preprocessor/1.90.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.preprocessor---1.83.0.bcr.1",
@@ -25596,32 +25935,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.preprocessor/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.preprocessor---1.90.0.bcr.1",
+    name = "bzl.boost.preprocessor---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.preprocessor/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.preprocessor/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.preprocessor---1.89.0.bcr.1",
+    name = "bzl.boost.preprocessor---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.preprocessor/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.preprocessor---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.preprocessor/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.process---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.process/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.preprocessor/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.process---1.90.0.bcr.1",
@@ -25638,11 +25963,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.process/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.program_options---1.89.0.bcr.2",
+    name = "bzl.boost.process---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.program_options/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.process/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.program_options---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.program_options/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.program_options---1.83.0.bcr.2",
@@ -25659,11 +25998,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.program_options/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.program_options---1.90.0.bcr.1",
+    name = "bzl.boost.program_options---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.program_options/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.program_options/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.program_options---1.87.0",
@@ -25671,27 +26010,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.program_options/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.program_options---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.program_options/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.property_map---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.property_map/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.property_map---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.property_map/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.property_map---1.83.0.bcr.1",
@@ -25708,6 +26026,20 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.property_map/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.property_map---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_map---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_map/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.property_map---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25715,11 +26047,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.property_map/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.property_tree---1.88.0.bcr.2",
+    name = "bzl.boost.property_tree---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.property_tree/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.property_tree/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.property_tree---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.property_tree/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.property_tree---1.87.0",
@@ -25727,13 +26066,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.property_tree/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.property_tree---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.property_tree/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.property_tree---1.83.0.bcr.1",
@@ -25750,11 +26082,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.property_tree/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.property_tree---1.90.0.bcr.1",
+    name = "bzl.boost.property_tree---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.property_tree/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.property_tree/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.proto---1.87.0",
@@ -25762,6 +26094,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.proto/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.proto---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.proto/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.proto---1.83.0.bcr.1",
@@ -25785,20 +26131,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.proto/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.proto---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.proto/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.proto---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.proto/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.proto---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25813,18 +26145,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.ptr_container/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.ptr_container---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.ptr_container/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.ptr_container---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.ptr_container/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.ptr_container---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ptr_container/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.ptr_container---1.87.0",
@@ -25848,13 +26180,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.python/1.83.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.qvm---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.qvm/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.qvm---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25862,11 +26187,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.qvm/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.qvm---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.qvm/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.qvm---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.qvm/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.random---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.random/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.random---1.90.0.bcr.1",
@@ -25881,13 +26220,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.random/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.random---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.random/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.random---1.83.0.bcr.1",
@@ -25911,32 +26243,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.random/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.range---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.range/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.range---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.range---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.range---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.range/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.range---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.range---1.83.0.bcr.1",
@@ -25960,6 +26278,34 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.range/1.87.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.range---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.range---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.range/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.ratio---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.ratio---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.ratio/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.ratio---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -25981,39 +26327,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.ratio/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.ratio---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.ratio/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.ratio---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.ratio/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.ratio---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.ratio/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.rational---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.rational/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.rational---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.rational/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.rational---1.87.0",
@@ -26037,11 +26355,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.rational/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.rational---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.rational---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.rational/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.regex---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.regex/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.regex---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.regex/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.regex---1.83.0.bcr.1",
@@ -26079,11 +26418,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.regex/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.regex---1.88.0.bcr.2",
+    name = "bzl.boost.scope---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.regex/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.scope/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.scope---1.87.0",
@@ -26107,18 +26446,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.scope/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.scope---1.88.0.bcr.2",
+    name = "bzl.boost.scope_exit---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.scope/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.scope_exit---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.scope_exit/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.scope_exit/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.scope_exit---1.90.0.bcr.1",
@@ -26128,11 +26460,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.scope_exit/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.scope_exit---1.83.0.bcr.4",
+    name = "bzl.boost.scope_exit---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.scope_exit/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.scope_exit/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.serialization---1.90.0.bcr.1",
@@ -26140,6 +26472,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.serialization/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.serialization---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.serialization/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.serialization---1.83.0.bcr.1",
@@ -26156,11 +26495,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.serialization/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.serialization---1.87.0",
+    name = "bzl.boost.serialization---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.serialization/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.serialization/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.serialization---1.89.0.bcr.2",
@@ -26170,18 +26509,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.serialization/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.serialization---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.serialization/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.signals2---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.signals2/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.signals2---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.signals2/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.signals2---1.89.0.bcr.2",
@@ -26191,11 +26530,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.signals2/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.signals2---1.90.0.bcr.1",
+    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.signals2/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.smart_ptr---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.smart_ptr---1.89.0.bcr.1",
@@ -26226,32 +26579,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.smart_ptr/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.smart_ptr---1.88.0.bcr.2",
+    name = "bzl.boost.sort---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.smart_ptr---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.smart_ptr---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.smart_ptr/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.sort---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.sort/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.sort/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.sort---1.89.0.bcr.2",
@@ -26261,18 +26593,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.sort/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.sort---1.83.0.bcr.4",
+    name = "bzl.boost.sort---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.sort/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.spirit---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.spirit/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.sort/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.spirit---1.90.0.bcr.1",
@@ -26280,27 +26605,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.spirit/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.spirit---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.spirit---1.83.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.spirit---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.spirit---1.89.0.bcr.2",
@@ -26324,6 +26628,34 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.spirit/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.spirit---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.spirit/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.spirit---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.spirit---1.83.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.spirit---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.spirit/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.stacktrace---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26344,12 +26676,28 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.stacktrace/1.89.0.bcr.2/overlay",
 )
-starlark_repository.local(
-    name = "bzl.boost.static_assert---1.90.0.bcr.1",
+starlark_repository.archive(
+    name = "bzl.boost.static_assert---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.static_assert/1.90.0.bcr.1/overlay",
+    strip_prefix = "static_assert-boost-1.83.0",
+    type = "tar.gz",
+    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.83.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.static_assert---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.static_assert---1.87.0",
@@ -26373,27 +26721,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.static_assert/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.static_assert---1.88.0.bcr.2",
+    name = "bzl.boost.static_assert---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.static_assert/1.88.0.bcr.2/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.boost.static_assert---1.83.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "static_assert-boost-1.83.0",
-    type = "tar.gz",
-    urls = ["https://github.com/boostorg/static_assert/archive/refs/tags/boost-1.83.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/boost.static_assert/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.static_assert---1.83.0.bcr.4",
+    name = "bzl.boost.static_string---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.static_assert/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.static_string/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.static_string---1.89.0.bcr.2",
@@ -26410,25 +26749,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.static_string/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.static_string---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.static_string/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.system---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.system/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.system---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.system/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.system---1.83.0.bcr.1",
@@ -26443,6 +26768,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.system/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.system---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.system/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.system---1.89.0.bcr.1",
@@ -26466,25 +26798,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.system/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.test---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.test/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.test---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.test/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.test---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.test/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.test---1.90.0.bcr.1",
@@ -26494,11 +26812,39 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.test/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.thread---1.87.0",
+    name = "bzl.boost.test---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.thread/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.test/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.test---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.test/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.thread---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.thread/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.thread---1.83.0.bcr.1",
@@ -26522,25 +26868,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.thread/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.thread---1.89.0.bcr.2",
+    name = "bzl.boost.thread---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.thread/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.thread---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.thread/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.thread---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.thread/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.thread/1.87.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.throw_exception---1.83.0.bcr.1",
@@ -26573,18 +26905,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.throw_exception/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.throw_exception---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.throw_exception/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.throw_exception---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.throw_exception/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.throw_exception---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.throw_exception/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.throw_exception---1.90.0.bcr.1",
@@ -26622,11 +26954,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.timer/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.tokenizer---1.87.0",
+    name = "bzl.boost.tokenizer---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tokenizer/1.87.0/overlay",
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tokenizer---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.tokenizer---1.90.0.bcr.1",
@@ -26643,18 +26982,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.tokenizer/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.tokenizer---1.83.0.bcr.1",
+    name = "bzl.boost.tokenizer---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.tokenizer---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tokenizer/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.tokenizer/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.tokenizer---1.89.0.bcr.1",
@@ -26678,20 +27010,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.tti/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.tti---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tti/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.tti---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tti/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.tti---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26706,25 +27024,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.tti/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.tuple---1.88.0.bcr.2",
+    name = "bzl.boost.tti---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tuple/1.88.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.tti/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.tuple---1.89.0.bcr.1",
+    name = "bzl.boost.tti---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.tuple---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.tti/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.tuple---1.90.0.bcr.1",
@@ -26748,6 +27059,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.tuple/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.tuple---1.88.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.88.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.tuple---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26755,18 +27073,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.tuple/1.87.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.tuple---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.tuple---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.tuple/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.type_index---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.type_index/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.type_index---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.type_index/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.type_index---1.88.0.bcr.2",
@@ -26781,6 +27106,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.type_index/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.type_index---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.type_index/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.type_index---1.83.0.bcr.1",
@@ -26802,6 +27134,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.type_traits/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.type_traits---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.type_traits/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.type_traits---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.type_traits/1.89.0.bcr.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.boost.type_traits---1.83.0.bcr.1",
@@ -26832,20 +27178,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.type_traits/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.type_traits---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.type_traits/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.type_traits---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.type_traits/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.typeof---1.87.0",
@@ -26883,13 +27215,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.typeof/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.typeof---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.typeof/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.typeof---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -26897,11 +27222,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.typeof/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.units---1.89.0.bcr.2",
+    name = "bzl.boost.typeof---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.units/1.89.0.bcr.2/overlay",
+    path = "data/bazel-central-registry/modules/boost.typeof/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.units---1.90.0.bcr.1",
@@ -26911,25 +27236,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.units/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.units---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.units/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.units---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.units/1.83.0.bcr.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.unordered---1.88.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.unordered/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.unordered---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.unordered/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.unordered---1.87.0",
@@ -26939,18 +27257,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.unordered/1.87.0/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.unordered---1.83.0.bcr.1",
+    name = "bzl.boost.unordered---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.unordered---1.83.0.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.4/overlay",
+    path = "data/bazel-central-registry/modules/boost.unordered/1.88.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.unordered---1.89.0.bcr.1",
@@ -26967,18 +27278,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.unordered/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.unordered---1.83.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.83.0.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.83.0.bcr.4/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.unordered---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.unordered/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.url---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.url/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.url---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.url/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.url---1.83.0.bcr.4",
@@ -26988,11 +27313,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.url/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.url---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.url/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.utility---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.utility/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.utility---1.89.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.utility---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.utility---1.87.0",
@@ -27016,20 +27362,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.utility/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.utility---1.89.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.utility---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.utility/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.utility---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27044,13 +27376,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.uuid/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.uuid---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.uuid/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.uuid---1.83.0.bcr.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27058,11 +27383,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.uuid/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.variant---1.90.0.bcr.1",
+    name = "bzl.boost.uuid---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.variant/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.uuid/1.89.0.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant---1.89.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.variant---1.87.0",
@@ -27070,6 +27402,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.variant/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.variant---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.variant---1.83.0.bcr.1",
@@ -27093,13 +27432,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.variant/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.variant---1.89.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.variant/1.89.0.bcr.2/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.variant---1.88.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27112,13 +27444,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.variant2/1.88.0.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.variant2---1.87.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.variant2/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.variant2---1.89.0.bcr.1",
@@ -27142,6 +27467,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.variant2/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.variant2---1.87.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.variant2/1.87.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.variant2---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27156,13 +27488,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.variant2/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.vmd---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.vmd/1.90.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.boost.vmd---1.89.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27170,18 +27495,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.vmd/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.winapi---1.87.0",
+    name = "bzl.boost.vmd---1.90.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.winapi/1.87.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.boost.winapi---1.90.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.winapi/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.vmd/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.winapi---1.88.0.bcr.2",
@@ -27205,6 +27523,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.winapi/1.89.0.bcr.2/overlay",
 )
 starlark_repository.local(
+    name = "bzl.boost.winapi---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.winapi/1.90.0.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.boost.winapi---1.83.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27219,11 +27544,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/boost.winapi/1.83.0.bcr.4/overlay",
 )
 starlark_repository.local(
-    name = "bzl.boost.xpressive---1.90.0.bcr.1",
+    name = "bzl.boost.winapi---1.87.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/boost.xpressive/1.90.0.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/boost.winapi/1.87.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.xpressive---1.87.0",
@@ -27231,6 +27556,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/boost.xpressive/1.87.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.boost.xpressive---1.90.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/boost.xpressive/1.90.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.boost.xpressive---1.83.0.bcr.1",
@@ -27263,85 +27595,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/archive/2db0eb3f96a5756298dcd7f9319e56a98585bd10.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20241024.0",
+    name = "bzl.boringssl---0.20250818.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20241024.0/",
+    strip_prefix = "boringssl-0.20250818.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260413.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260413.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20251110.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20251110.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20251110.0/boringssl-0.20251110.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20260508.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20260508.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20260508.0/boringssl-0.20260508.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.0.0-20230215-5c22014",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
-    type = "zip",
-    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20251002.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20251002.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20251002.0/boringssl-0.20251002.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20250212.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250212.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250212.0/boringssl-0.20250212.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20251124.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20251124.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250818.0/boringssl-0.20250818.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20260327.0",
@@ -27353,24 +27613,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20260327.0/boringssl-0.20260327.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20250311.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250311.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250311.0/boringssl-0.20250311.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.boringssl---0.20250818.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250818.0/",
-    type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250818.0/boringssl-0.20250818.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.boringssl---0.20240930.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27380,13 +27622,40 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20240930.0/boringssl-0.20240930.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20250514.0",
+    name = "bzl.boringssl---0.20260413.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20250514.0/",
+    strip_prefix = "boringssl-0.20260413.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20250514.0/boringssl-0.20250514.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260413.0/boringssl-0.20260413.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20240913.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20240913.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20260526.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20260526.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20260526.0/boringssl-0.20260526.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20230215-5c22014",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-5c22014ca513807ed03c657e8ede076164663979",
+    type = "zip",
+    urls = ["https://github.com/google/boringssl/archive/5c22014ca513807ed03c657e8ede076164663979.zip"],
 )
 starlark_repository.archive(
     name = "bzl.boringssl---0.20241209.0",
@@ -27398,13 +27667,76 @@ starlark_repository.archive(
     urls = ["https://github.com/google/boringssl/releases/download/0.20241209.0/boringssl-0.20241209.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.boringssl---0.20240913.0",
+    name = "bzl.boringssl---0.20250212.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "boringssl-0.20240913.0/",
+    strip_prefix = "boringssl-0.20250212.0/",
     type = "tar.gz",
-    urls = ["https://github.com/google/boringssl/releases/download/0.20240913.0/boringssl-0.20240913.0.tar.gz"],
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250212.0/boringssl-0.20250212.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.0.0-20211025-d4f1ab9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-d4f1ab983065e4616319f59c723c7b9870021fae",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/archive/d4f1ab983065e4616319f59c723c7b9870021fae.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20250311.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20250311.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250311.0/boringssl-0.20250311.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20251110.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20251110.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20251110.0/boringssl-0.20251110.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20241024.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20241024.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20241024.0/boringssl-0.20241024.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20250514.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20250514.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20250514.0/boringssl-0.20250514.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20251124.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20251124.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20251124.0/boringssl-0.20251124.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.boringssl---0.20251002.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "boringssl-0.20251002.0/",
+    type = "tar.gz",
+    urls = ["https://github.com/google/boringssl/releases/download/0.20251002.0/boringssl-0.20251002.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.briansmith_ring---0.17.14.bcr.1",
@@ -27412,6 +27744,15 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/briansmith_ring/0.17.14.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.brotli---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "brotli-1.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.brotli---1.2.0",
@@ -27428,15 +27769,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/brotli/1.2.0.bcr.1/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.brotli---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "brotli-1.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.brotli_go---1.2.0",
@@ -27482,32 +27814,6 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/scala-gazelle/releases/download/v0.1.1/scala-gazelle-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---7.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-7.1.2",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.5.1.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---7.3.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27515,15 +27821,6 @@ starlark_repository.archive(
     strip_prefix = "buildifier-prebuilt-7.3.1",
     type = "tar.gz",
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.3.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---6.1.2",
@@ -27535,6 +27832,15 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.1.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27544,13 +27850,39 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---6.4.0",
+    name = "bzl.buildifier_prebuilt---8.5.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/releases/download/8.5.1.2/buildifier-prebuilt.8.5.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---7.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-7.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/7.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.buildifier_prebuilt---8.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "buildifier-prebuilt-8.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildifier_prebuilt---8.2.0",
@@ -27562,13 +27894,13 @@ starlark_repository.archive(
     urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.buildifier_prebuilt---8.0.0",
+    name = "bzl.buildifier_prebuilt---6.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "buildifier-prebuilt-8.0.0",
+    strip_prefix = "buildifier-prebuilt-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/8.0.0.tar.gz"],
+    urls = ["https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.buildozer---8.5.1",
@@ -27610,24 +27942,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/byte_track_eigen/2.1.0.bcr.2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.bzip2---1.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bzip2-1.0.8",
-    type = "tar.gz",
-    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.bzip2---1.0.8.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bzip2-1.0.8",
-    type = "tar.gz",
-    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.bzip2---1.0.8.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27651,6 +27965,24 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/bzip2/1.0.8.bcr.4/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.bzip2---1.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bzip2-1.0.8",
+    type = "tar.gz",
+    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.bzip2---1.0.8.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bzip2-1.0.8",
+    type = "tar.gz",
+    urls = ["https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.bzlparty_rules_quickjs---0.1.0",
@@ -27679,25 +28011,18 @@ starlark_repository.archive(
     urls = ["https://github.com/zaucy/bzlws/releases/download/0.2.0/bzlws-0.2.0.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.c-ares---1.34.5.bcr.1",
+    name = "bzl.c-ares---1.19.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/c-ares/1.19.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.c-ares---1.34.5.bcr.2",
+    name = "bzl.c-ares---1.19.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.c-ares---1.34.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/c-ares/1.34.6/overlay",
+    path = "data/bazel-central-registry/modules/c-ares/1.19.1.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.c-ares---1.15.0",
@@ -27718,18 +28043,25 @@ starlark_repository.archive(
     urls = ["https://github.com/c-ares/c-ares/releases/download/cares-1_16_1/c-ares-1.16.1.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.c-ares---1.19.1",
+    name = "bzl.c-ares---1.34.5.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/c-ares/1.19.1/overlay",
+    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.c-ares---1.19.1.bcr.1",
+    name = "bzl.c-ares---1.34.5.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/c-ares/1.19.1.bcr.1/overlay",
+    path = "data/bazel-central-registry/modules/c-ares/1.34.5.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.c-ares---1.34.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/c-ares/1.34.6/overlay",
 )
 starlark_repository.local(
     name = "bzl.c-blosc2---2.22.0",
@@ -27789,13 +28121,6 @@ starlark_repository.archive(
     urls = ["https://github.com/caseyduquettesc/rules_python_pytest/releases/download/v1.1.1/rules_python_pytest-v1.1.1.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.catch2---3.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/catch2/3.8.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.catch2---3.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27803,11 +28128,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/catch2/3.13.0/overlay",
 )
 starlark_repository.local(
+    name = "bzl.catch2---3.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/catch2/3.8.0/overlay",
+)
+starlark_repository.local(
     name = "bzl.ccd---2.1.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/ccd/2.1.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.ccronexpr---2.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/ccronexpr/2.1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.cctz---2.4",
@@ -27846,6 +28185,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/cel-cpp/archive/refs/tags/v0.15.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.cel-spec---0.25.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cel-spec-0.25.1",
+    type = "tar.gz",
+    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.cel-spec---0.24.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -27862,15 +28210,6 @@ starlark_repository.archive(
     strip_prefix = "cel-spec-0.23.0",
     type = "tar.gz",
     urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.23.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.cel-spec---0.25.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cel-spec-0.25.1",
-    type = "tar.gz",
-    urls = ["https://github.com/google/cel-spec/archive/refs/tags/v0.25.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cel-spec---0.15.0",
@@ -28017,6 +28356,15 @@ starlark_repository.archive(
     urls = ["https://github.com/stackb/closure-templates/releases/download/v1.0.1/closure-templates-v1.0.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.cmake_configure_file---0.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "cmake_configure_file-0.1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.5/cmake_configure_file-v0.1.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28035,22 +28383,13 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.0/cmake_configure_file_v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.3",
+    name = "bzl.cmake_configure_file---0.1.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.3",
+    strip_prefix = "cmake_configure_file-0.1.6",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.3/cmake_configure_file-v0.1.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.7",
-    type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.6/cmake_configure_file-v0.1.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cmake_configure_file---0.1.4",
@@ -28071,22 +28410,22 @@ starlark_repository.archive(
     urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.2/cmake_configure_file-0.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.5",
+    name = "bzl.cmake_configure_file---0.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.5",
+    strip_prefix = "cmake_configure_file-0.1.3",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.5/cmake_configure_file-v0.1.5.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.3/cmake_configure_file-v0.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.cmake_configure_file---0.1.6",
+    name = "bzl.cmake_configure_file---0.1.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "cmake_configure_file-0.1.6",
+    strip_prefix = "cmake_configure_file-0.1.7",
     type = "tar.gz",
-    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.6/cmake_configure_file-v0.1.6.tar.gz"],
+    urls = ["https://github.com/wep21/cmake_configure_file/releases/download/v0.1.7/cmake_configure_file-v0.1.7.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.coacd---1.0.11.bcr.2",
@@ -28128,13 +28467,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/colordiff/1.0.22/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.com_clementguillot_rules_quarkus---0.1.1",
+    name = "bzl.com_clementguillot_rules_quarkus---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_quarkus-0.1.1",
+    strip_prefix = "rules_quarkus-0.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.1.1/rules_quarkus-v0.1.1.tar.gz"],
+    urls = ["https://github.com/clementguillot/rules_quarkus/releases/download/v0.2.0/rules_quarkus-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.com_github_benchsci_rules_nodejs_gazelle---0.8.4",
@@ -28146,15 +28485,6 @@ starlark_repository.archive(
     urls = ["https://github.com/benchsci/rules_nodejs_gazelle/releases/download/v0.8.4/rules_nodejs_gazelle-v0.8.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.com_github_mvukov_rules_ros2---0.0.0-20250612-f0d04fe",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_ros2-f0d04fe57e5174b708ee7256814a627e934aacf4",
-    type = "tar.gz",
-    urls = ["https://github.com/mvukov/rules_ros2/archive/f0d04fe57e5174b708ee7256814a627e934aacf4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.com_github_mvukov_rules_ros2---0.0.0-20260118-78d85ff",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28162,6 +28492,15 @@ starlark_repository.archive(
     strip_prefix = "rules_ros2-78d85ff784d999bcd4dc288b6fd48e41e7710204",
     type = "tar.gz",
     urls = ["https://github.com/mvukov/rules_ros2/archive/78d85ff784d999bcd4dc288b6fd48e41e7710204.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.com_github_mvukov_rules_ros2---0.0.0-20250612-f0d04fe",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_ros2-f0d04fe57e5174b708ee7256814a627e934aacf4",
+    type = "tar.gz",
+    urls = ["https://github.com/mvukov/rules_ros2/archive/f0d04fe57e5174b708ee7256814a627e934aacf4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.com_github_rabbitmq_looking_glass---0.2.1",
@@ -28241,18 +28580,18 @@ starlark_repository.archive(
     urls = ["https://github.com/dallison/co/releases/download/3.3.2/co-3.3.2.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.cpp-httplib---0.41.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/cpp-httplib/0.41.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.cpp-httplib---0.22.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/cpp-httplib/0.22.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.cpp-httplib---0.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/cpp-httplib/0.46.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.cpp-peglib---1.0.1",
@@ -28478,40 +28817,6 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/cunit/2.1.3/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.curl---8.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "curl-8.7.1",
-    type = "tar.gz",
-    urls = ["https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.curl---8.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "curl-8.8.0",
-    type = "tar.gz",
-    urls = ["https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.curl---8.8.0.bcr.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "curl-8.8.0",
-    type = "tar.gz",
-    urls = ["https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.curl---8.8.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/curl/8.8.0.bcr.3/overlay",
-)
 starlark_repository.local(
     name = "bzl.curl---8.11.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -28541,6 +28846,40 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/curl/8.12.0.bcr.1/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.curl---8.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "curl-8.8.0",
+    type = "tar.gz",
+    urls = ["https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.curl---8.8.0.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "curl-8.8.0",
+    type = "tar.gz",
+    urls = ["https://github.com/curl/curl/releases/download/curl-8_8_0/curl-8.8.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.curl---8.8.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/curl/8.8.0.bcr.3/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.curl---8.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "curl-8.7.1",
+    type = "tar.gz",
+    urls = ["https://github.com/curl/curl/releases/download/curl-8_7_1/curl-8.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.cutlass---3.5.1",
@@ -28646,15 +28985,6 @@ starlark_repository.archive(
     urls = ["https://github.com/martis42/depend_on_what_you_use/releases/download/0.16.0/depend_on_what_you_use-0.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.diff.bzl---0.5.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "diff.bzl-0.5.5",
-    type = "tar.gz",
-    urls = ["https://github.com/kormide/diff.bzl/releases/download/v0.5.5/diff.bzl-v0.5.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.diff.bzl---0.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28662,6 +28992,15 @@ starlark_repository.archive(
     strip_prefix = "diff.bzl-0.5.1",
     type = "tar.gz",
     urls = ["https://github.com/kormide/diff.bzl/releases/download/v0.5.1/diff.bzl-v0.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.diff.bzl---0.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "diff.bzl-0.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/kormide/diff.bzl/releases/download/v0.5.5/diff.bzl-v0.5.5.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.diffutils---3.12",
@@ -28749,6 +29088,15 @@ starlark_repository.archive(
     urls = ["https://github.com/jjmaestro/bazel_download_archives/releases/download/v0.1.0/bazel_download_archives-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.download_utils---1.2.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "download_utils-v1.2.3",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.2.3/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.download_utils---1.0.0-beta.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28756,15 +29104,6 @@ starlark_repository.archive(
     strip_prefix = "download_utils-v1.0.0-beta.4",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.0-beta.4/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.download_utils---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "download_utils-v1.0.1",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.download_utils---1.2.0",
@@ -28776,13 +29115,13 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.2.0/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.download_utils---1.2.3",
+    name = "bzl.download_utils---1.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "download_utils-v1.2.3",
+    strip_prefix = "download_utils-v1.0.1",
     type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.2.3/downloads/src.tar.gz"],
+    urls = ["https://gitlab.arm.com/bazel/download_utils/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.download_utils---1.0.0-beta.2",
@@ -28840,6 +29179,36 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/egl-registry/0.0.0-20250527/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.eigen---3.4.0.bcr.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "eigen-3.4.0",
+    type = "zip",
+    urls = ["https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip"],
+)
+starlark_repository.local(
+    name = "bzl.eigen---3.4.0.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.0.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---3.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.eigen---3.4.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/eigen/3.4.1.bcr.1/overlay",
+)
+starlark_repository.archive(
     name = "bzl.eigen---3.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28858,20 +29227,6 @@ starlark_repository.archive(
     urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip"],
 )
 starlark_repository.local(
-    name = "bzl.eigen---3.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/eigen/3.4.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.eigen---3.4.1.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/eigen/3.4.1.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.eigen---5.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28884,22 +29239,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/eigen/5.0.1.bcr.1/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.eigen---3.4.0.bcr.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "eigen-3.4.0",
-    type = "zip",
-    urls = ["https://github.com/eigen-mirror/eigen/archive/refs/tags/3.4.0.zip"],
-)
-starlark_repository.local(
-    name = "bzl.eigen---3.4.0.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/eigen/3.4.0.bcr.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.elemental2---1.3.2",
@@ -28979,15 +29318,6 @@ starlark_repository.archive(
     urls = ["https://github.com/EngFlow/engflowapis/releases/download/2025.07.24-06.20.24/engflowapis-2025.07.24-06.20.24.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20241214-918efc9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-918efc9df33d27b5a3850332d408a3684a4de8ca",
-    type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/918efc9df33d27b5a3850332d408a3684a4de8ca.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20251105-4a2b9a3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -28995,15 +29325,6 @@ starlark_repository.archive(
     strip_prefix = "data-plane-api-4a2b9a30628e95e0cfe985c45c10adc8a6b1643b",
     type = "tar.gz",
     urls = ["https://github.com/envoyproxy/data-plane-api/archive/4a2b9a30628e95e0cfe985c45c10adc8a6b1643b.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.envoy_api---0.0.0-20250128-4de3c74",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "data-plane-api-4de3c74cf21a9958c1cf26d8993c55c6e0d28b49",
-    type = "tar.gz",
-    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4de3c74cf21a9958c1cf26d8993c55c6e0d28b49.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20251216-6ef568c",
@@ -29015,6 +29336,15 @@ starlark_repository.archive(
     urls = ["https://github.com/envoyproxy/data-plane-api/archive/6ef568cf4a67362849911d1d2a546fd9f35db2ff.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.envoy_api---0.0.0-20241214-918efc9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "data-plane-api-918efc9df33d27b5a3850332d408a3684a4de8ca",
+    type = "tar.gz",
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/918efc9df33d27b5a3850332d408a3684a4de8ca.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.envoy_api---0.0.0-20260130-84e8436",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29022,6 +29352,15 @@ starlark_repository.archive(
     strip_prefix = "data-plane-api-84e84367f2560cdb47b9bb78fd3e615feb80c3e4",
     type = "tar.gz",
     urls = ["https://github.com/envoyproxy/data-plane-api/archive/84e84367f2560cdb47b9bb78fd3e615feb80c3e4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.envoy_api---0.0.0-20250128-4de3c74",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "data-plane-api-4de3c74cf21a9958c1cf26d8993c55c6e0d28b49",
+    type = "tar.gz",
+    urls = ["https://github.com/envoyproxy/data-plane-api/archive/4de3c74cf21a9958c1cf26d8993c55c6e0d28b49.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.envoy_toolshed---0.3.25",
@@ -29200,6 +29539,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/flann/1.9.2/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.flatbuffers---25.9.23",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "flatbuffers-25.9.23",
+    type = "tar.gz",
+    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.flatbuffers---25.12.19",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29216,15 +29564,6 @@ starlark_repository.archive(
     strip_prefix = "flatbuffers-25.2.10",
     type = "tar.gz",
     urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.2.10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.flatbuffers---25.9.23",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "flatbuffers-25.9.23",
-    type = "tar.gz",
-    urls = ["https://github.com/google/flatbuffers/archive/refs/tags/v25.9.23.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.flex---2.6.4.bcr.2",
@@ -29254,21 +29593,44 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/flip/1.6/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.fmt---10.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-10.1.1",
-    type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
-)
 starlark_repository.local(
     name = "bzl.fmt---11.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/fmt/11.1.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.fmt---12.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fmt/12.0.0/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.fmt---8.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-8.1.1",
+    type = "tar.gz",
+    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.fmt---10.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "fmt-10.2.1",
+    type = "zip",
+    urls = ["https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip"],
+)
+starlark_repository.local(
+    name = "bzl.fmt---11.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/fmt/11.1.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.fmt---12.1.0",
@@ -29284,37 +29646,14 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/fmt/11.2.0/overlay",
 )
-starlark_repository.local(
-    name = "bzl.fmt---11.1.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/fmt/11.1.4/overlay",
-)
-starlark_repository.local(
-    name = "bzl.fmt---12.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/fmt/12.0.0/overlay",
-)
 starlark_repository.archive(
-    name = "bzl.fmt---10.2.1",
+    name = "bzl.fmt---10.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "fmt-10.2.1",
+    strip_prefix = "fmt-10.1.1",
     type = "zip",
-    urls = ["https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.fmt---8.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "fmt-8.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
+    urls = ["https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip"],
 )
 starlark_repository.local(
     name = "bzl.folly---2025.01.13.00.bcr.5",
@@ -29406,6 +29745,13 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/freertos/11.1.0.bcr.3/overlay",
 )
+starlark_repository.local(
+    name = "bzl.freetype---2.14.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/freetype/2.14.1/overlay",
+)
 starlark_repository.archive(
     name = "bzl.freetype---2.13.3",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -29421,13 +29767,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/freetype/2.13.3.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.freetype---2.14.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/freetype/2.14.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.fremtind_rules_vitest---0.2.1",
@@ -29489,6 +29828,20 @@ starlark_repository.archive(
     urls = ["https://github.com/vivkin/gason/archive/c9c4aa6.tar.gz"],
 )
 starlark_repository.local(
+    name = "bzl.gawk---5.3.2.bcr.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.7/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gawk---5.3.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.gawk---5.3.2.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29502,59 +29855,14 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.3/overlay",
 )
-starlark_repository.local(
-    name = "bzl.gawk---5.3.2.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.gawk---5.3.2.bcr.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gawk/5.3.2.bcr.7/overlay",
-)
 starlark_repository.archive(
-    name = "bzl.gazelle---0.43.0",
+    name = "bzl.gazelle---0.29.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
+    strip_prefix = "bazel-gazelle-0.29.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.41.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.41.0/bazel-gazelle-v0.41.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.45.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.51.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.51.0/bazel-gazelle-v0.51.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.38.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.42.0",
@@ -29565,92 +29873,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.42.0/bazel-gazelle-v0.42.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.50.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.34.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.39.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.40.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.47.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.47.0/bazel-gazelle-v0.47.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gazelle---0.37.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.37.0/bazel-gazelle-v0.37.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.30.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.46.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.gazelle---0.36.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle---0.35.0",
@@ -29661,13 +29889,124 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gazelle---0.29.0",
+    name = "bzl.gazelle---0.33.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bazel-gazelle-0.29.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/archive/refs/tags/v0.29.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.33.0/bazel-gazelle-v0.33.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.41.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.41.0/bazel-gazelle-v0.41.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.30.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.30.0/bazel-gazelle-v0.30.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.43.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.43.0/bazel-gazelle-v0.43.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.38.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.38.0/bazel-gazelle-v0.38.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.44.0/bazel-gazelle-v0.44.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.40.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.40.0/bazel-gazelle-v0.40.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.51.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.51.0/bazel-gazelle-v0.51.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.34.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.47.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.47.0/bazel-gazelle-v0.47.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.46.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.46.0/bazel-gazelle-v0.46.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.50.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.50.0/bazel-gazelle-v0.50.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.39.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.39.1/bazel-gazelle-v0.39.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.45.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/bazel-gazelle/releases/download/v0.45.0/bazel-gazelle-v0.45.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gazelle---0.36.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gazelle_cc---0.5.0",
@@ -29807,15 +30146,6 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/glew/2.3.1/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.glfw---3.3.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "glfw-3.3.9",
-    type = "zip",
-    urls = ["https://github.com/glfw/glfw/releases/download/3.3.9/glfw-3.3.9.zip"],
-)
 starlark_repository.local(
     name = "bzl.glfw---3.4.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -29829,6 +30159,15 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/glfw/3.4.0.bcr.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.glfw---3.3.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "glfw-3.3.9",
+    type = "zip",
+    urls = ["https://github.com/glfw/glfw/releases/download/3.3.9/glfw-3.3.9.zip"],
 )
 starlark_repository.local(
     name = "bzl.glib---2.82.2.bcr.4",
@@ -29889,15 +30228,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/glog/archive/refs/tags/v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.glog---0.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "glog-0.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.glog---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29914,6 +30244,15 @@ starlark_repository.archive(
     strip_prefix = "glog-0.7.1",
     type = "tar.gz",
     urls = ["https://github.com/google/glog/archive/refs/tags/v0.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.glog---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "glog-0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.glpk---5.0.bcr.4",
@@ -29937,20 +30276,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/glu/9.0.3/overlay",
 )
 starlark_repository.local(
-    name = "bzl.gmp---6.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gmp/6.2.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.gmp---6.2.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/gmp/6.2.0.bcr.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.gmp---6.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -29963,6 +30288,20 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/gmp/6.3.0.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gmp---6.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gmp/6.2.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.gmp---6.2.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/gmp/6.2.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.gonzojive_protobuf_javascript---3.21.5.esm",
@@ -29983,22 +30322,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/bazel-common/releases/download/0.0.1/bazel-common-0.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.4",
+    name = "bzl.google_benchmark---1.8.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.4",
+    strip_prefix = "benchmark-1.8.3",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.5",
-    type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.2",
@@ -30010,13 +30340,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.8.3",
+    name = "bzl.google_benchmark---1.9.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.8.3",
+    strip_prefix = "benchmark-1.9.4",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_benchmark---1.9.2",
@@ -30028,6 +30358,15 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.2.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.google_benchmark---1.9.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "benchmark-1.9.5",
+    type = "tar.gz",
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.google_benchmark---1.8.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30037,13 +30376,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.google_benchmark---1.9.4",
+    name = "bzl.google_benchmark---1.8.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "benchmark-1.9.4",
+    strip_prefix = "benchmark-1.8.4",
     type = "tar.gz",
-    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz"],
+    urls = ["https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.google_cloud_cpp---3.0.0-rc1",
@@ -30064,11 +30403,11 @@ starlark_repository.archive(
     urls = ["https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v3.5.0.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    name = "bzl.googleapis---0.0.0-20260422-20ac242a",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20250703-f9d6fe4a/overlay",
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260422-20ac242a/overlay",
 )
 starlark_repository.local(
     name = "bzl.googleapis---0.0.0-20260223-edfe7983",
@@ -30076,20 +30415,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260223-edfe7983/overlay",
-)
-starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20251003-2193a2bf",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20251003-2193a2bf/overlay",
-)
-starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20260422-20ac242a",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260422-20ac242a/overlay",
 )
 starlark_repository.archive(
     name = "bzl.googleapis---0.0.0-20240326-1c8d509c5",
@@ -30108,34 +30433,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260325-8b491c86/overlay",
 )
 starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20241220-5e258e33",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20241220-5e258e33/overlay",
-)
-starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20241220-5e258e33.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20260130-c0fcb356",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260130-c0fcb356/overlay",
-)
-starlark_repository.local(
-    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260402-c8ca5bce/overlay",
-)
-starlark_repository.local(
     name = "bzl.googleapis---0.0.0-20260525-ef19b7b7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30151,14 +30448,47 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/googleapis/googleapis/archive/fe8ba054ad4f7eca946c2d14a63c3f07c0b586a0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.googleapis-cc---1.1.5",
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20260402-c8ca5bce",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-cc",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260402-c8ca5bce/overlay",
+)
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20251003-2193a2bf",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20251003-2193a2bf/overlay",
+)
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20260130-c0fcb356",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20260130-c0fcb356/overlay",
+)
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20250703-f9d6fe4a",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20250703-f9d6fe4a/overlay",
+)
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20241220-5e258e33",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20241220-5e258e33/overlay",
+)
+starlark_repository.local(
+    name = "bzl.googleapis---0.0.0-20241220-5e258e33.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/googleapis/0.0.0-20241220-5e258e33.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.googleapis-cc---1.0.0",
@@ -30170,11 +30500,11 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis-go---1.1.5",
+    name = "bzl.googleapis-cc---1.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-go",
+    strip_prefix = "googleapis-cc",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
@@ -30188,11 +30518,11 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis-grpc-cc---1.1.5",
+    name = "bzl.googleapis-go---1.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-grpc-cc",
+    strip_prefix = "googleapis-go",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
@@ -30206,20 +30536,20 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.googleapis-grpc-cc---1.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-grpc-cc",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.googleapis-grpc-java---1.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     strip_prefix = "googleapis-grpc-java",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.googleapis-java---1.1.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-java",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
@@ -30233,11 +30563,11 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis-python---1.1.5",
+    name = "bzl.googleapis-java---1.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-python",
+    strip_prefix = "googleapis-java",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
@@ -30251,11 +30581,11 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googleapis-rules-registry---1.1.5",
+    name = "bzl.googleapis-python---1.1.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googleapis-rules-registry",
+    strip_prefix = "googleapis-python",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
@@ -30267,6 +30597,15 @@ starlark_repository.archive(
     strip_prefix = "googleapis-rules-registry",
     type = "tar.gz",
     urls = ["https://github.com/fmeum/googleapis-rules-registry/releases/download/v1.0.0/googleapis-rules-registry-v1.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.googleapis-rules-registry---1.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "googleapis-rules-registry",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/googleapis-rules-registry/releases/download/v1.1.5/googleapis-rules-registry-v1.1.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googleapis-upb---1.1.5",
@@ -30287,22 +30626,22 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.16.0",
+    name = "bzl.googletest---1.14.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.16.0",
+    strip_prefix = "googletest-1.14.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.16.0.bcr.1",
+    name = "bzl.googletest---1.14.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.16.0",
+    strip_prefix = "googletest-1.14.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.googletest---1.17.0",
@@ -30341,39 +30680,30 @@ starlark_repository.archive(
     urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.14.0",
+    name = "bzl.googletest---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.14.0",
+    strip_prefix = "googletest-1.16.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.googletest---1.14.0.bcr.1",
+    name = "bzl.googletest---1.16.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "googletest-1.14.0",
+    strip_prefix = "googletest-1.16.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"],
+    urls = ["https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gotopt2---2.5.1",
+    name = "bzl.gotopt2---2.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/filmil/gotopt2/releases/download/v2.5.1/gotopt2-v2.5.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.gperf---3.1.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gperf-3.1",
-    type = "tar.gz",
-    urls = ["https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"],
+    urls = ["https://github.com/filmil/gotopt2/releases/download/v2.7.1/gotopt2-v2.7.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.gperf---3.1",
@@ -30384,6 +30714,15 @@ starlark_repository.archive(
     strip_prefix = "gperf-3.1",
     type = "tar.gz",
     urls = ["http://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gperf---3.1.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gperf-3.1",
+    type = "tar.gz",
+    urls = ["https://ftp.gnu.org/pub/gnu/gperf/gperf-3.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gperftools---2.18.1",
@@ -30416,6 +30755,24 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/greatest/1.5.0/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.grpc---1.73.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.73.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.41.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.41.0",
+    type = "zip",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.grpc---1.66.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30425,13 +30782,49 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.66.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.70.1",
+    name = "bzl.grpc---1.69.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
+    strip_prefix = "grpc-1.69.0",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.72.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.72.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.72.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.68.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.68.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.74.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.74.1",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc---1.81.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-1.81.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.81.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.74.0",
@@ -30441,22 +30834,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-1.74.0",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.76.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.76.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.grpc---1.76.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/grpc/1.76.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.grpc---1.80.0",
@@ -30477,67 +30854,29 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.56.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.68.0",
+    name = "bzl.grpc---1.76.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.68.0",
+    strip_prefix = "grpc-1.76.0",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.68.0.tar.gz"],
+    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.76.0.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.grpc---1.76.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/grpc/1.76.0.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.grpc---1.69.0",
+    name = "bzl.grpc---1.70.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.69.0",
+    strip_prefix = "grpc-b73dbd94df4bd9f9362d16b76f34e4c7c2358409",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.69.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.74.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.74.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.74.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.81.0-pre1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.81.0-pre1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.81.0-pre1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.73.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.73.1",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.73.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.72.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.72.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.72.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc---1.41.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-1.41.0",
-    type = "zip",
-    urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.41.0.zip"],
+    urls = ["https://github.com/grpc/grpc/archive/b73dbd94df4bd9f9362d16b76f34e4c7c2358409.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-httpjson-transcoding---0.0.0-20230607-ff41eb3",
@@ -30549,15 +30888,6 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/grpc-httpjson-transcoding/archive/ff41eb3fc9209e6197595b54f7addfa244c0bdb6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc-java---1.66.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.66.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.grpc-java---1.67.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30565,15 +30895,6 @@ starlark_repository.archive(
     strip_prefix = "grpc-java-1.67.1",
     type = "tar.gz",
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.67.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.grpc-java---1.69.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.69.0",
-    type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-java---1.71.0",
@@ -30585,6 +30906,24 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.71.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.grpc-java---1.62.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.62.2",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.62.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.grpc-java---1.69.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "grpc-java-1.69.0",
+    type = "tar.gz",
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.69.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.grpc-java---1.78.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30594,13 +30933,13 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.78.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.grpc-java---1.62.2",
+    name = "bzl.grpc-java---1.66.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "grpc-java-1.62.2",
+    strip_prefix = "grpc-java-1.66.0",
     type = "tar.gz",
-    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.62.2.tar.gz"],
+    urls = ["https://github.com/grpc/grpc-java/archive/refs/tags/v1.66.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.grpc-proto---0.0.0-20240627-ec30f58",
@@ -30731,15 +31070,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-math---9.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-math-gz-math9_9.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-math---8.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30747,6 +31077,15 @@ starlark_repository.archive(
     strip_prefix = "gz-math-gz-math8_8.1.1",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math8_8.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-math---9.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-math-gz-math9_9.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-math/archive/refs/tags/gz-math9_9.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-msgs---12.0.1",
@@ -30803,15 +31142,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-rendering/archive/refs/tags/gz-rendering10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-sensors---10.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-sensors-gz-sensors10_10.0.1",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-sensors---10.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30819,6 +31149,15 @@ starlark_repository.archive(
     strip_prefix = "gz-sensors-gz-sensors10_10.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-sensors---10.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-sensors-gz-sensors10_10.0.1",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-sensors/archive/refs/tags/gz-sensors10_10.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gz-sim---10.3.0",
@@ -30848,15 +31187,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/gz-transport/archive/refs/tags/gz-transport15_15.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.gz-utils---3.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gz-utils-gz-utils3_3.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/tags/gz-utils3_3.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.gz-utils---4.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30864,6 +31194,15 @@ starlark_repository.archive(
     strip_prefix = "gz-utils-gz-utils4_4.0.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/gz-utils/archive/refs/tags/gz-utils4_4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.gz-utils---3.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gz-utils-gz-utils3_3.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/gz-utils/archive/refs/tags/gz-utils3_3.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.gzgz_rules_sass---1.0.4",
@@ -30882,18 +31221,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/happly/0.0.20240207/overlay",
 )
 starlark_repository.local(
-    name = "bzl.harfbuzz---14.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/harfbuzz/14.1.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.harfbuzz---11.0.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/harfbuzz/11.0.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.harfbuzz---14.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/harfbuzz/14.1.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.hdrhistogram_c---0.11.9",
@@ -30905,6 +31244,15 @@ starlark_repository.archive(
     urls = ["https://github.com/HdrHistogram/HdrHistogram_c/archive/refs/tags/0.11.9.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.helly25_bashtest---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bashtest-0.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.helly25_bashtest---0.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -30914,13 +31262,13 @@ starlark_repository.archive(
     urls = ["https://github.com/helly25/bashtest/releases/download/0.1.0/bashtest-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.helly25_bashtest---0.2.0",
+    name = "bzl.helly25_bzl---0.4.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "bashtest-0.2.0",
+    strip_prefix = "bzl-0.4.2",
     type = "tar.gz",
-    urls = ["https://github.com/helly25/bashtest/releases/download/0.2.0/bashtest-0.2.0.tar.gz"],
+    urls = ["https://github.com/helly25/bzl/releases/download/0.4.2/bzl-0.4.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.helly25_bzl---0.3.1",
@@ -30967,12 +31315,12 @@ starlark_repository.archive(
     urls = ["https://github.com/FBorowiec/hermetic_clang_toolchain/releases/download/v1.0.1/hermetic_clang_toolchain-1.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.hermetic_launcher---0.0.8",
+    name = "bzl.hermetic_launcher---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.8/hermetic_launcher-v0.0.8.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.9/hermetic_launcher-v0.0.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.hermetic_launcher---0.0.5",
@@ -30990,21 +31338,20 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/malt3/hermetic-launcher/releases/download/v0.0.3/hermetic_launcher-v0.0.3.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.hermetic_launcher---0.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.8/hermetic_launcher-v0.0.8.tar.gz"],
+)
 starlark_repository.local(
     name = "bzl.hfsm2---2.10.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/hfsm2/2.10.0/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.highs---1.14.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "HiGHS",
-    type = "tar.gz",
-    urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.14.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highs---1.11.0",
@@ -31016,13 +31363,13 @@ starlark_repository.archive(
     urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.11.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.highway---1.2.0",
+    name = "bzl.highs---1.14.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "highway-1.2.0",
+    strip_prefix = "HiGHS",
     type = "tar.gz",
-    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
+    urls = ["https://github.com/ERGO-Code/HiGHS/releases/download/v1.14.0/source-archive.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highway---1.3.0.bcr.1",
@@ -31032,6 +31379,15 @@ starlark_repository.archive(
     strip_prefix = "highway-1.3.0",
     type = "tar.gz",
     urls = ["https://github.com/google/highway/releases/download/1.3.0/highway-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.highway---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "highway-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/highway/releases/download/1.2.0/highway-1.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.highwayhash---0.0.0-20240305-5ad3bf8",
@@ -31090,12 +31446,14 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.95.4.tar.gz"],
 )
-starlark_repository.local(
-    name = "bzl.iceoryx2---0.6.1",
+starlark_repository.archive(
+    name = "bzl.iceoryx2---0.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/iceoryx2/0.6.1/overlay",
+    strip_prefix = "iceoryx2-0.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/eclipse-iceoryx/iceoryx2/archive/refs/tags/v0.9.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.icestorm---1.1",
@@ -31289,6 +31647,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/jemalloc/5.3.0-bcr.alpha.5/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.jq.bzl---0.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "jq.bzl-0.6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.jq.bzl---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31314,15 +31681,6 @@ starlark_repository.archive(
     strip_prefix = "jq.bzl-0.4.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.4.0/jq.bzl-v0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.jq.bzl---0.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jq.bzl-0.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/jq.bzl/releases/download/v0.6.1/jq.bzl-v0.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsinterop_base---1.2.0-RC1",
@@ -31420,15 +31778,6 @@ starlark_repository.archive(
     urls = ["https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.jsonnet---0.21.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "jsonnet-v0.21.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/jsonnet/releases/download/v0.21.0/jsonnet-v0.21.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.jsonnet---0.22.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31438,13 +31787,13 @@ starlark_repository.archive(
     urls = ["https://github.com/google/jsonnet/releases/download/v0.22.0/jsonnet-v0.22.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.jsonnet_go---0.21.0",
+    name = "bzl.jsonnet---0.21.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "go-jsonnet-v0.21.0",
+    strip_prefix = "jsonnet-v0.21.0",
     type = "tar.gz",
-    urls = ["https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet-v0.21.0.tar.gz"],
+    urls = ["https://github.com/google/jsonnet/releases/download/v0.21.0/jsonnet-v0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jsonnet_go---0.22.0",
@@ -31454,6 +31803,15 @@ starlark_repository.archive(
     strip_prefix = "go-jsonnet-v0.22.0",
     type = "tar.gz",
     urls = ["https://github.com/google/go-jsonnet/releases/download/v0.22.0/go-jsonnet-v0.22.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.jsonnet_go---0.21.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "go-jsonnet-v0.21.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet-v0.21.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.jwt-cpp---0.7.0.bcr.1",
@@ -31619,6 +31977,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libde265/1.0.18/overlay",
 )
 starlark_repository.local(
+    name = "bzl.libdeflate---1.23",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libdeflate/1.23/overlay",
+)
+starlark_repository.local(
     name = "bzl.libdeflate---1.25",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31626,11 +31991,11 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libdeflate/1.25/overlay",
 )
 starlark_repository.local(
-    name = "bzl.libdeflate---1.23",
+    name = "bzl.libdwarf---0.12.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libdeflate/1.23/overlay",
+    path = "data/bazel-central-registry/modules/libdwarf/0.12.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.libdwarf---2.2.0",
@@ -31645,13 +32010,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libdwarf/2.2.0.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.libdwarf---0.12.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libdwarf/0.12.0.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.libedlib---1.2.7",
@@ -31861,15 +32219,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libpcap/1.10.5.bcr.3/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.libpfm---4.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "libpfm-4.13.0",
-    type = "tar.gz",
-    urls = ["https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.libpfm---4.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -31879,20 +32228,13 @@ starlark_repository.archive(
     urls = ["https://sourceforge.net/projects/perfmon2/files/libpfm4/libpfm-4.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.libpfm---4.11.0.bcr.2",
+    name = "bzl.libpfm---4.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "libpfm-4.11.0",
+    strip_prefix = "libpfm-4.13.0",
     type = "tar.gz",
-    urls = ["https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.11.0.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.libpng---1.6.44",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libpng/1.6.44/overlay",
+    urls = ["https://downloads.sourceforge.net/project/perfmon2/libpfm4/libpfm-4.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libpng---1.6.41",
@@ -31904,11 +32246,11 @@ starlark_repository.archive(
     urls = ["https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.41.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.libpng---1.6.54",
+    name = "bzl.libpng---1.6.44",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libpng/1.6.54/overlay",
+    path = "data/bazel-central-registry/modules/libpng/1.6.44/overlay",
 )
 starlark_repository.local(
     name = "bzl.libpng---1.6.53",
@@ -31918,20 +32260,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libpng/1.6.53/overlay",
 )
 starlark_repository.local(
+    name = "bzl.libpng---1.6.54",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libpng/1.6.54/overlay",
+)
+starlark_repository.local(
     name = "bzl.libpng---1.6.50.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libpng/1.6.50.bcr.1/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.libprotobuf-mutator---1.5.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "libprotobuf-mutator-1.5",
-    type = "tar.gz",
-    urls = ["https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.libprotobuf-mutator---1.3",
@@ -31941,6 +32281,15 @@ starlark_repository.archive(
     strip_prefix = "libprotobuf-mutator-1.3",
     type = "tar.gz",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.libprotobuf-mutator---1.5.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "libprotobuf-mutator-1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/google/libprotobuf-mutator/archive/refs/tags/v1.5.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.librdkafka---2.8.0.bcr.1",
@@ -31955,6 +32304,15 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/librdkafka/2.8.0.bcr.2/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.libsl3---1.2.53001",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "libsl3-1.2.53001",
+    type = "tar.gz",
+    urls = ["https://github.com/a4z/libsl3/archive/refs/tags/v1.2.53001.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.libsodium---1.0.19",
@@ -31985,18 +32343,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libtiff/4.7.1/overlay",
 )
 starlark_repository.local(
-    name = "bzl.libunwind---1.8.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libunwind/1.8.3/overlay",
-)
-starlark_repository.local(
     name = "bzl.libunwind---1.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libunwind/1.8.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libunwind---1.8.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libunwind/1.8.3/overlay",
 )
 starlark_repository.archive(
     name = "bzl.liburing---2.5",
@@ -32008,13 +32366,6 @@ starlark_repository.archive(
     urls = ["https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.liburing---2.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/liburing/2.10/overlay",
-)
-starlark_repository.local(
     name = "bzl.liburing---2.14",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32022,11 +32373,25 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/liburing/2.14/overlay",
 )
 starlark_repository.local(
+    name = "bzl.liburing---2.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/liburing/2.10/overlay",
+)
+starlark_repository.local(
     name = "bzl.libusb---1.0.28",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libusb/1.0.28/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libuuid---2.41.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libuuid/2.41.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libuuid---2.39.3.bcr.1",
@@ -32036,13 +32401,6 @@ starlark_repository.archive(
     strip_prefix = "util-linux-2.39.3",
     type = "tar.gz",
     urls = ["https://github.com/util-linux/util-linux/archive/refs/tags/v2.39.3.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.libuuid---2.41.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libuuid/2.41.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.libuv---1.48.0",
@@ -32075,18 +32433,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libwebm/1.0.0.32/overlay",
 )
 starlark_repository.local(
-    name = "bzl.libwebp---1.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libwebp/1.5.0/overlay",
-)
-starlark_repository.local(
     name = "bzl.libwebp---1.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libwebp/1.6.0/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libwebp---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libwebp/1.5.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.libwebsockets---4.5.2",
@@ -32208,13 +32566,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/libxinerama/1.1.5/overlay",
 )
 starlark_repository.local(
-    name = "bzl.libxml2---2.15.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/libxml2/2.15.3/overlay",
-)
-starlark_repository.local(
     name = "bzl.libxml2---2.14.4.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32236,6 +32587,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/libxml2/2.15.1.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.libxml2---2.15.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/libxml2/2.15.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.libxml2-go---0.0.0-20250331-c934e3f.bcr.1",
@@ -32477,15 +32835,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/lz4/1.10.0.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.lz4-erlang---1.9.2.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "lz4-erlang-1.9.2.5",
-    type = "tar.gz",
-    urls = ["https://github.com/rabbitmq/lz4-erlang/releases/download/v1.9.2.5/lz4-erlang-1.9.2.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.lz4-erlang---1.9.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32494,26 +32843,21 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/rabbitmq/lz4-erlang/releases/download/v1.9.4.0/lz4-erlang-1.9.4.0.tar.gz"],
 )
+starlark_repository.archive(
+    name = "bzl.lz4-erlang---1.9.2.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "lz4-erlang-1.9.2.5",
+    type = "tar.gz",
+    urls = ["https://github.com/rabbitmq/lz4-erlang/releases/download/v1.9.2.5/lz4-erlang-1.9.2.5.tar.gz"],
+)
 starlark_repository.local(
     name = "bzl.lzo---2.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/lzo/2.10/overlay",
-)
-starlark_repository.local(
-    name = "bzl.m4---1.4.20.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/m4/1.4.20.bcr.3/overlay",
-)
-starlark_repository.local(
-    name = "bzl.m4---1.4.20.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/m4/1.4.20.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.m4---1.4.21",
@@ -32528,6 +32872,27 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/m4/1.4.21.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.m4---1.4.21.bcr.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/m4/1.4.21.bcr.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.m4---1.4.20.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/m4/1.4.20.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.m4---1.4.20.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/m4/1.4.20.bcr.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.magic_enum---0.9.7",
@@ -32546,15 +32911,6 @@ starlark_repository.archive(
     urls = ["https://github.com/Neargye/magic_enum/releases/download/v0.9.8/magic_enum-v0.9.8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.maliput---1.15.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "maliput-1.15.0",
-    type = "tar.gz",
-    urls = ["https://github.com/maliput/maliput/releases/download/1.15.0/maliput-1.15.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.maliput---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32562,6 +32918,15 @@ starlark_repository.archive(
     strip_prefix = "maliput-1.16.0",
     type = "tar.gz",
     urls = ["https://github.com/maliput/maliput/releases/download/1.16.0/maliput-1.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.maliput---1.15.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "maliput-1.15.0",
+    type = "tar.gz",
+    urls = ["https://github.com/maliput/maliput/releases/download/1.15.0/maliput-1.15.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.maliput_geopackage---0.5.0",
@@ -32768,6 +33133,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.7.1.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.nanoflann---1.3.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/nanoflann/1.3.2/overlay",
+)
 starlark_repository.archive(
     name = "bzl.nanoflann---1.5.5",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -32776,13 +33148,6 @@ starlark_repository.archive(
     strip_prefix = "nanoflann-1.5.5",
     type = "tar.gz",
     urls = ["https://github.com/jlblancoc/nanoflann/archive/refs/tags/v1.5.5.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.nanoflann---1.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/nanoflann/1.3.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.nanopb---0.4.9.1.bcr.3",
@@ -32891,22 +33256,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/ninjatracing/0.0.0-a669e3644cf2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.12.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
-)
-starlark_repository.archive(
     name = "bzl.nlohmann_json---3.11.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -32923,20 +33272,36 @@ starlark_repository.archive(
     urls = ["https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.nlohmann_json---3.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
-)
-starlark_repository.archive(
     name = "bzl.nlohmann_json---3.11.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
     urls = ["https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.12.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.nlohmann_json---3.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
 )
 starlark_repository.local(
     name = "bzl.nlopt---2.10.1.bcr1",
@@ -33006,15 +33371,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/ode/0.16.6.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.ofiuco---0.3.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "ofiuco-0.3.7",
-    type = "tar.gz",
-    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.ofiuco---0.9.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33022,6 +33378,15 @@ starlark_repository.archive(
     strip_prefix = "ofiuco-0.9.1",
     type = "tar.gz",
     urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.9.1/ofiuco-0.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.ofiuco---0.3.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "ofiuco-0.3.7",
+    type = "tar.gz",
+    urls = ["https://github.com/oxidase/ofiuco/releases/download/v0.3.7/ofiuco-0.3.7.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.ogg---1.3.5.bcr.2",
@@ -33059,6 +33424,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/onednn/2.7.3/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.onetbb---2022.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "oneTBB-2022.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.onetbb---2021.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33073,15 +33447,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/onetbb/2022.2.0/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.onetbb---2022.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "oneTBB-2022.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.onetbb---2022.3.0",
@@ -33241,15 +33606,6 @@ starlark_repository.archive(
     urls = ["https://github.com/openconfig/gnoi/archive/refs/tags/v0.6.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.openconfig_gnsi---1.9.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "gnsi-1.9.1",
-    type = "tar.gz",
-    urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.openconfig_gnsi---1.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33257,6 +33613,15 @@ starlark_repository.archive(
     strip_prefix = "gnsi-1.9.0",
     type = "tar.gz",
     urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.openconfig_gnsi---1.9.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "gnsi-1.9.1",
+    type = "tar.gz",
+    urls = ["https://github.com/openconfig/gnsi/archive/refs/tags/v1.9.1.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.opencv---4.13.0.bcr.2",
@@ -33273,18 +33638,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/opencv/4.13.0.bcr.5/overlay",
 )
 starlark_repository.local(
-    name = "bzl.openexr---3.4.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openexr/3.4.10/overlay",
-)
-starlark_repository.local(
     name = "bzl.openexr---3.3.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openexr/3.3.3.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openexr---3.4.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openexr/3.4.10/overlay",
 )
 starlark_repository.local(
     name = "bzl.openfhe---1.4.2.bcr.2",
@@ -33310,18 +33675,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/opengl-registry/0.0.0-20250707/overlay",
 )
 starlark_repository.local(
+    name = "bzl.openjph---0.27.3.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openjph/0.27.3.bcr.1/overlay",
+)
+starlark_repository.local(
     name = "bzl.openjph---0.26.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openjph/0.26.3.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openjph---0.27.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openjph/0.27.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.openmp---21.1.5.bcr.2",
@@ -33336,34 +33701,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openssh/9.9p1.bcr.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openssl---3.5.5.bcr.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.0/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openssl---3.5.5.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.1/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openssl---3.5.5.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.3/overlay",
-)
-starlark_repository.local(
-    name = "bzl.openssl---3.5.5.bcr.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.4/overlay",
 )
 starlark_repository.local(
     name = "bzl.openssl---3.5.4.bcr.0",
@@ -33400,23 +33737,33 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/openssl/3.3.1.bcr.9/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.19.0",
+starlark_repository.local(
+    name = "bzl.openssl---3.5.5.bcr.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.19.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.0/overlay",
 )
-starlark_repository.archive(
-    name = "bzl.opentelemetry-cpp---1.14.2",
+starlark_repository.local(
+    name = "bzl.openssl---3.5.5.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-cpp-1.14.2",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openssl---3.5.5.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.openssl---3.5.5.bcr.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/openssl/3.5.5.bcr.4/overlay",
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.27.0",
@@ -33446,6 +33793,24 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.24.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.opentelemetry-cpp---1.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-cpp-1.19.0",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.opentelemetry-cpp---1.14.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-cpp-1.14.2",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.14.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.opentelemetry-cpp---1.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33455,13 +33820,13 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.16.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.3.1",
+    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.3.1",
+    strip_prefix = "opentelemetry-proto-1.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.3.1.tar.gz"],
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.1.0",
@@ -33473,6 +33838,15 @@ starlark_repository.archive(
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.1.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.opentelemetry-proto---1.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "opentelemetry-proto-1.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.3.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.opentelemetry-proto---1.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33480,15 +33854,6 @@ starlark_repository.archive(
     strip_prefix = "opentelemetry-proto-1.5.0",
     type = "tar.gz",
     urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.opentelemetry-proto---1.4.0.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "opentelemetry-proto-1.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v1.4.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.opentelemetry-proto---1.8.0",
@@ -33543,6 +33908,14 @@ starlark_repository.local(
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/orocos-kdl/1.5.3/overlay",
 )
+starlark_repository.archive(
+    name = "bzl.osqp---0.6.3.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/osqp/osqp/releases/download/v0.6.3/osqp-v0.6.3-src.tar.gz"],
+)
 starlark_repository.local(
     name = "bzl.osqp---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -33556,14 +33929,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/osqp/1.0.0.bcr.2/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.osqp---0.6.3.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/osqp/osqp/releases/download/v0.6.3/osqp-v0.6.3-src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.osqp-cpp---0.0.0-20231004-4343373.bcr.2",
@@ -33618,24 +33983,6 @@ starlark_repository.archive(
     urls = ["https://github.com/p4lang/p4runtime/releases/download/v1.5.0/p4runtime-1.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.package_metadata---0.0.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.5/metadata",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.5/supply-chain-v0.0.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.package_metadata---0.0.10",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.10/metadata",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.10/supply-chain-v0.0.10.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.package_metadata---0.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33643,15 +33990,6 @@ starlark_repository.archive(
     strip_prefix = "supply-chain-0.0.2/metadata",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.2/supply-chain-v0.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.package_metadata---0.0.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.7/metadata",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.7/supply-chain-v0.0.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.package_metadata---0.0.3",
@@ -33670,6 +34008,33 @@ starlark_repository.archive(
     strip_prefix = "supply-chain-0.0.6/metadata",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.package_metadata---0.0.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.7/metadata",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.7/supply-chain-v0.0.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.package_metadata---0.0.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.5/metadata",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.5/supply-chain-v0.0.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.package_metadata---0.0.10",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "supply-chain-0.0.10/metadata",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.10/supply-chain-v0.0.10.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.paho.mqtt.c---1.3.14",
@@ -33773,15 +34138,6 @@ starlark_repository.archive(
     urls = ["https://github.com/PCRE2Project/pcre2/archive/refs/tags/pcre2-10.43.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pcre2---10.46-DEV",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pcre2-b3ecb621bd0c38c7dd91d395608283cc4e849042",
-    type = "tar.gz",
-    urls = ["https://github.com/PCRE2Project/pcre2/archive/b3ecb621bd0c38c7dd91d395608283cc4e849042.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pcre2---10.47",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33789,6 +34145,15 @@ starlark_repository.archive(
     strip_prefix = "pcre2-10.47",
     type = "tar.gz",
     urls = ["https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pcre2---10.46-DEV",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pcre2-b3ecb621bd0c38c7dd91d395608283cc4e849042",
+    type = "tar.gz",
+    urls = ["https://github.com/PCRE2Project/pcre2/archive/b3ecb621bd0c38c7dd91d395608283cc4e849042.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.pegtl---3.2.8",
@@ -33814,15 +34179,6 @@ starlark_repository.archive(
     urls = ["https://github.com/tzaeschke/phtree-cpp/releases/download/v1.7.0/phtree-cpp-v1.7.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.pico-sdk---2.2.2-develop.bcr.20260420-79b38e95",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pico-sdk-79b38e9543116e9be524388ae4650393e6453026",
-    type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/pico-sdk/archive/79b38e9543116e9be524388ae4650393e6453026.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pico-sdk---2.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -33831,13 +34187,13 @@ starlark_repository.archive(
     urls = ["https://github.com/raspberrypi/pico-sdk/releases/download/2.1.0/pico-sdk-2.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
+    name = "bzl.pico-sdk---2.2.2-develop.bcr.20260420-79b38e95",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "picotool-d1a8d35da3f622cf228c0a17e9b7a4295d5282d0",
+    strip_prefix = "pico-sdk-79b38e9543116e9be524388ae4650393e6453026",
     type = "tar.gz",
-    urls = ["https://github.com/raspberrypi/picotool/archive/d1a8d35da3f622cf228c0a17e9b7a4295d5282d0.tar.gz"],
+    urls = ["https://github.com/raspberrypi/pico-sdk/archive/79b38e9543116e9be524388ae4650393e6453026.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.picotool---2.1.0",
@@ -33855,6 +34211,15 @@ starlark_repository.archive(
     strip_prefix = "picotool-2.2.0",
     type = "tar.gz",
     urls = ["https://github.com/raspberrypi/picotool/releases/download/2.2.0/picotool-2.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.picotool---2.2.1-develop.bcr.20260407-d1a8d35",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "picotool-d1a8d35da3f622cf228c0a17e9b7a4295d5282d0",
+    type = "tar.gz",
+    urls = ["https://github.com/raspberrypi/picotool/archive/d1a8d35da3f622cf228c0a17e9b7a4295d5282d0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.pict---3.7.4",
@@ -33903,36 +34268,12 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/pkg-config/0.29.2.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.platforms---0.0.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.platforms---0.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.9",
@@ -33943,20 +34284,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.9/platforms-0.0.9.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.platforms---0.0.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.platforms---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.platforms---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms---0.0.7",
@@ -33975,12 +34316,36 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.platforms---0.0.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/1.1.0/platforms-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.platforms---0.0.11",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.11/platforms-0.0.11.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.platforms---0.0.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/platforms/releases/download/0.0.4/platforms-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.platforms_contrib---0.2.3",
@@ -34073,15 +34438,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/ppp/2.5.2.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.pre-commit---1.0.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pre-commit-v1.0.9",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/pre-commit/-/releases/v1.0.9/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pre-commit---1.0.10",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34089,6 +34445,15 @@ starlark_repository.archive(
     strip_prefix = "pre-commit-v1.0.10",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/pre-commit/-/releases/v1.0.10/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pre-commit---1.0.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pre-commit-v1.0.9",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/pre-commit/-/releases/v1.0.9/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pre-commit-hooks---1.3.1",
@@ -34189,40 +34554,22 @@ starlark_repository.archive(
     urls = ["https://github.com/grpc-ecosystem/proto-converter/archive/d77ff301f48bf2e7a0f8935315e847c1a8e00017.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---27.2",
+    name = "bzl.protobuf---30.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.2",
+    strip_prefix = "protobuf-30.1",
     type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---27.0",
+    name = "bzl.protobuf---33.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.2",
+    strip_prefix = "protobuf-33.5",
     type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---3.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-3.19.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---30.0",
@@ -34233,12 +34580,14 @@ starlark_repository.archive(
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.0/protobuf-30.0.zip"],
 )
-starlark_repository.local(
-    name = "bzl.protobuf---34.0.bcr.1",
+starlark_repository.archive(
+    name = "bzl.protobuf---33.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/protobuf/34.0.bcr.1/overlay",
+    strip_prefix = "protobuf-33.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---32.0",
@@ -34248,51 +34597,6 @@ starlark_repository.archive(
     strip_prefix = "protobuf-32.0",
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protobuf-32.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---31.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---31.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-31.0",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---24.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-24.4",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---35.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-35.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protobuf-35.0.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.1",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protobuf-27.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---33.4",
@@ -34313,13 +34617,13 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.6.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.1",
+    name = "bzl.protobuf---27.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.1",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
+    strip_prefix = "protobuf-27.5",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---34.1",
@@ -34331,6 +34635,15 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.1/protobuf-34.1.bazel.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.protobuf---31.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.1",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protobuf-31.1.zip"],
+)
+starlark_repository.archive(
     name = "bzl.protobuf---26.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34338,6 +34651,31 @@ starlark_repository.archive(
     strip_prefix = "protobuf-26.0",
     type = "zip",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v26.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---24.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-24.4",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protobuf-24.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---27.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.2",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.2/protobuf-27.2.zip"],
+)
+starlark_repository.local(
+    name = "bzl.protobuf---34.0.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/protobuf/34.0.bcr.1/overlay",
 )
 starlark_repository.archive(
     name = "bzl.protobuf---30.2",
@@ -34349,6 +34687,42 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protobuf-30.2.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.protobuf---27.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-27.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---31.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-31.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protobuf-31.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---35.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-35.0",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v35.0/protobuf-35.0.bazel.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---3.19.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-3.19.0",
+    type = "zip",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.0.zip"],
+)
+starlark_repository.archive(
     name = "bzl.protobuf---34.0-rc1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34358,31 +34732,13 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v34.0-rc1.1/protobuf-34.0-rc1.1.bazel.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---33.5",
+    name = "bzl.protobuf---33.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.5",
+    strip_prefix = "protobuf-33.1",
     type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.5/protobuf-33.5.bazel.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---33.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-33.0",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.0/protobuf-33.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protobuf---27.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-27.5",
-    type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.5/protobuf-27.5.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.1/protobuf-33.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf---32.1",
@@ -34394,13 +34750,22 @@ starlark_repository.archive(
     urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v32.1/protobuf-32.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.protobuf---30.1",
+    name = "bzl.protobuf---27.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "protobuf-30.1",
+    strip_prefix = "protobuf-27.1",
     type = "zip",
-    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v30.1/protobuf-30.1.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.1/protobuf-27.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.protobuf---33.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protobuf-33.2",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protobuf-33.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protobuf-matchers---0.1.1",
@@ -34417,15 +34782,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/inazarenko/protobuf-matchers/releases/download/v0.1.2/protobuf-matchers-v0.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.protoc-gen-validate---1.3.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "protoc-gen-validate-1.3.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.3.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.protoc-gen-validate---1.2.1.bcr.1",
@@ -34449,6 +34805,15 @@ starlark_repository.archive(
     strip_prefix = "protoc-gen-validate-1.0.4",
     type = "tar.gz",
     urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.0.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.protoc-gen-validate---1.3.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "protoc-gen-validate-1.3.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/protoc-gen-validate/archive/refs/tags/v1.3.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.protothreads---0.1.6",
@@ -34541,15 +34906,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_abseil/releases/download/v202402.0/pybind11_abseil-202402.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---3.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-3.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.11.1.bzl.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34557,6 +34913,15 @@ starlark_repository.archive(
     strip_prefix = "pybind11_bazel-2.11.1.bzl.2",
     type = "zip",
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1.bzl.2/pybind11_bazel-2.11.1.bzl.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---3.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-3.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.0/pybind11_bazel-3.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.13.6",
@@ -34568,15 +34933,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.13.6/pybind11_bazel-2.13.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_bazel---2.11.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_bazel-2.11.1",
-    type = "zip",
-    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.zip"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_bazel---2.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34584,6 +34940,15 @@ starlark_repository.archive(
     strip_prefix = "pybind11_bazel-2.12.0",
     type = "zip",
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.12.0/pybind11_bazel-2.12.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_bazel---2.11.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_bazel-2.11.1",
+    type = "zip",
+    urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v2.11.1/pybind11_bazel-2.11.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.pybind11_bazel---3.0.1",
@@ -34595,15 +34960,6 @@ starlark_repository.archive(
     urls = ["https://github.com/pybind/pybind11_bazel/releases/download/v3.0.1/pybind11_bazel-3.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "pybind11_protobuf-f02a2b7653bc50eb5119d125842a3870db95d251",
-    type = "tar.gz",
-    urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.pybind11_protobuf---0.0.0-20240524-1d7a729",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34611,6 +34967,15 @@ starlark_repository.archive(
     strip_prefix = "pybind11_protobuf-1d7a7296604537db5f6ace2ddafd1d08c967ec63",
     type = "tar.gz",
     urls = ["https://github.com/pybind/pybind11_protobuf/archive/1d7a7296604537db5f6ace2ddafd1d08c967ec63.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.pybind11_protobuf---0.0.0-20250210-f02a2b7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "pybind11_protobuf-f02a2b7653bc50eb5119d125842a3870db95d251",
+    type = "tar.gz",
+    urls = ["https://github.com/pybind/pybind11_protobuf/archive/f02a2b7653bc50eb5119d125842a3870db95d251.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.pystring---1.1.4",
@@ -34657,11 +35022,11 @@ starlark_repository.archive(
     urls = ["https://github.com/nayuki/QR-Code-generator/archive/refs/tags/v1.8.0.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.quickjs-ng---0.13.0",
+    name = "bzl.quickjs-ng---0.15.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/quickjs-ng/0.13.0/overlay",
+    path = "data/bazel-central-registry/modules/quickjs-ng/0.15.0/overlay",
 )
 starlark_repository.archive(
     name = "bzl.quill---11.1.0",
@@ -34729,13 +35094,6 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/emil-e/rapidcheck/archive/ff6af6fc683159deb51c543b065eba14dfcf329b.tar.gz"],
 )
-starlark_repository.local(
-    name = "bzl.rapidjson---1.1.0.bcr.20250205",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/rapidjson/1.1.0.bcr.20250205/overlay",
-)
 starlark_repository.archive(
     name = "bzl.rapidjson---1.1.0.bcr.20241007",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -34744,6 +35102,13 @@ starlark_repository.archive(
     strip_prefix = "rapidjson-858451e5b7d1c56cf8f6d58f88cf958351837e53",
     type = "tar.gz",
     urls = ["https://github.com/Tencent/rapidjson/archive/858451e5b7d1c56cf8f6d58f88cf958351837e53.tar.gz"],
+)
+starlark_repository.local(
+    name = "bzl.rapidjson---1.1.0.bcr.20250205",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/rapidjson/1.1.0.bcr.20250205/overlay",
 )
 starlark_repository.local(
     name = "bzl.rapidyaml---0.12.1",
@@ -34813,15 +35178,6 @@ starlark_repository.archive(
     urls = ["https://github.com/jvolkman/re.bzl/releases/download/v0.3.1/re.bzl-v0.3.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2021-09-01",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2021-09-01",
-    type = "zip",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
-)
-starlark_repository.archive(
     name = "bzl.re2---2025-11-05",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34849,24 +35205,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2023-09-01/re2-2023-09-01.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.re2---2024-07-02",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-07-02",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.re2---2024-07-02.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "re2-2024-07-02",
-    type = "zip",
-    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
-)
-starlark_repository.archive(
     name = "bzl.re2---2025-08-12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34885,6 +35223,33 @@ starlark_repository.archive(
     urls = ["https://github.com/google/re2/releases/download/2025-08-12/re2-2025-08-12.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.re2---2024-07-02",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2024-07-02",
+    type = "zip",
+    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2024-07-02.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2024-07-02",
+    type = "zip",
+    urls = ["https://github.com/google/re2/releases/download/2024-07-02/re2-2024-07-02.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.re2---2021-09-01",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "re2-2021-09-01",
+    type = "zip",
+    urls = ["https://github.com/google/re2/archive/refs/tags/2021-09-01.zip"],
+)
+starlark_repository.archive(
     name = "bzl.readerwriterqueue---1.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -34894,18 +35259,18 @@ starlark_repository.archive(
     urls = ["https://github.com/cameron314/readerwriterqueue/archive/refs/tags/v1.0.6.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.readline---8.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/readline/8.3/overlay",
-)
-starlark_repository.local(
     name = "bzl.readline---8.3.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/readline/8.3.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.readline---8.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/readline/8.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.redis---8.6.2",
@@ -35050,24 +35415,6 @@ starlark_repository.archive(
     urls = ["https://github.com/michaeljs1990/rules_abs/releases/download/0.1.0/rules_abs-0.1.0.tar"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android---0.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_android---0.7.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.7.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_android---0.6.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35075,15 +35422,6 @@ starlark_repository.archive(
     strip_prefix = "rules_android-0.6.4",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.4/rules_android-v0.6.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_android---0.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_android-0.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android---0.6.6",
@@ -35095,13 +35433,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.6.6/rules_android-v0.6.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_android_ndk---0.1.5",
+    name = "bzl.rules_android---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_android_ndk-0.1.5",
+    strip_prefix = "rules_android-0.1.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.5/rules_android_ndk-v0.1.5.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android---0.7.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.7.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.2/rules_android-v0.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android---0.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android-0.7.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android/releases/download/v0.7.1/rules_android-v0.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_android_ndk---0.1.3",
@@ -35111,6 +35467,15 @@ starlark_repository.archive(
     strip_prefix = "rules_android_ndk-0.1.3",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.3/rules_android_ndk-v0.1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_android_ndk---0.1.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_android_ndk-0.1.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.5/rules_android_ndk-v0.1.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_angular---0.1.0",
@@ -35140,12 +35505,76 @@ starlark_repository.archive(
     urls = ["https://github.com/lalten/rules_appimage/releases/download/v1.20.0/rules_appimage-v1.20.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_apple---4.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.2/rules_apple.4.5.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---4.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_apple---4.5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.3/rules_apple.4.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_apple---3.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple---4.5.0",
@@ -35164,76 +35593,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.1.0/rules_apple.4.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_apple---3.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.13.0/rules_apple.3.13.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.0/rules_apple.4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.0/rules_apple.3.5.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_apple---4.3.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.3.3/rules_apple.4.3.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.5.2/rules_apple.4.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.4.0/rules_apple.4.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---4.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/4.0.1/rules_apple.4.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_apple---3.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_apple/releases/download/3.16.0/rules_apple.3.16.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_apple_linker---0.7.0",
@@ -35262,22 +35627,13 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/rules_auto_dotnet/releases/download/v0.3.5/rules_auto_dotnet-v0.3.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_autoconf---0.0.14",
+    name = "bzl.rules_autoconf---0.0.15",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_autoconf-0.0.14",
+    strip_prefix = "rules_autoconf-0.0.15",
     type = "tar.gz",
-    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.14/rules_autoconf-v0.0.14.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_autoconf---0.0.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_autoconf-0.0.9",
-    type = "tar.gz",
-    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.9/rules_autoconf-v0.0.9.tar.gz"],
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.15/rules_autoconf-v0.0.15.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_autoconf---0.0.16",
@@ -35289,13 +35645,22 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.16/rules_autoconf-v0.0.16.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_autoconf---0.0.15",
+    name = "bzl.rules_autoconf---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_autoconf-0.0.15",
+    strip_prefix = "rules_autoconf-0.0.9",
     type = "tar.gz",
-    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.15/rules_autoconf-v0.0.15.tar.gz"],
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.9/rules_autoconf-v0.0.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_autoconf---0.0.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_autoconf-0.0.14",
+    type = "tar.gz",
+    urls = ["https://github.com/dzbarsky/rules_autoconf/releases/download/v0.0.14/rules_autoconf-v0.0.14.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_batch---0.0.1",
@@ -35314,14 +35679,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.37.1/rules_bazel_integration_test.v0.37.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_bison---0.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.3/rules_bison-v0.3.tar.xz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_bison---0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35336,6 +35693,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.4/rules_bison-v0.4.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_bison---0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_bison/releases/download/v0.3/rules_bison-v0.3.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_browsers---0.4.0",
@@ -35355,15 +35720,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bfreis/rules_bsx/releases/download/v1.0.1/rules_bsx-v1.0.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_buf---0.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_buf-0.5.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.4/rules_buf-0.5.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_buf---0.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35371,6 +35727,15 @@ starlark_repository.archive(
     strip_prefix = "rules_buf-0.3.0",
     type = "tar.gz",
     urls = ["https://github.com/bufbuild/rules_buf/archive/refs/tags/v0.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_buf---0.5.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_buf-0.5.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bufbuild/rules_buf/releases/download/v0.5.4/rules_buf-0.5.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_buf---0.1.1",
@@ -35400,15 +35765,6 @@ starlark_repository.archive(
     urls = ["https://github.com/yuyawk/rules_build_error/releases/download/0.11.0/rules_build_error-0.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_bzip2---1.0.0-beta.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_bzip2-v1.0.0-beta.6",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_bzip2/-/releases/v1.0.0-beta.6/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_bzip2---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35416,6 +35772,15 @@ starlark_repository.archive(
     strip_prefix = "rules_bzip2-v1.0.0",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/rules_bzip2/-/releases/v1.0.0/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_bzip2---1.0.0-beta.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_bzip2-v1.0.0-beta.6",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/rules_bzip2/-/releases/v1.0.0-beta.6/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_c_proto---0.1.0",
@@ -35426,94 +35791,12 @@ starlark_repository.archive(
     urls = ["https://github.com/JalonWong/rules_c_proto/releases/download/v0.1.0/rules_c_proto-v0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.2",
+    name = "bzl.rules_cc---0.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.12",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.12",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.15",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.15",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.3/rules_cc-0.1.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.11",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.11",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.11/rules_cc-0.0.11.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.1.5",
@@ -35525,31 +35808,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.16",
+    name = "bzl.rules_cc---0.2.19",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.16",
+    strip_prefix = "rules_cc-0.2.19",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.19/rules_cc-0.2.19.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.14",
+    name = "bzl.rules_cc---0.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.14",
+    strip_prefix = "rules_cc-0.1.3",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.3/rules_cc-0.1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.2.0",
@@ -35561,74 +35835,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.0/rules_cc-0.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.3",
+    name = "bzl.rules_cc---0.0.9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.3",
+    strip_prefix = "rules_cc-0.0.9",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.3/rules_cc-0.2.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.13",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.13",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.2/rules_cc-0.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.1.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.1.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.17",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.17",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.17/rules_cc-0.2.17.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.0.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.9",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.9",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.0.6",
@@ -35640,13 +35853,49 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc---0.2.18",
+    name = "bzl.rules_cc---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_cc-0.2.18",
+    strip_prefix = "rules_cc-0.0.8",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.8/rules_cc-0.0.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.13",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.13",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.13/rules_cc-0.2.13.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.0/rules_cc-0.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.11",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.11/rules_cc-0.0.11.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.3/rules_cc-0.2.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc---0.1.1",
@@ -35658,6 +35907,51 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.1/rules_cc-0.1.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.14",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.14",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.14/rules_cc-0.2.14.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.4/rules_cc-0.1.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.8",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.8",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.8/rules_cc-0.2.8.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.17",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.17",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.17/rules_cc-0.2.17.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.2/rules_cc-0.2.2.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_cc---0.2.11",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35667,12 +35961,124 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.11/rules_cc-0.2.11.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.8.0",
+    name = "bzl.rules_cc---0.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.8.0/rules_cc_autoconf-0.8.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.1/rules_cc-0.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.18",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.18",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.18/rules_cc-0.2.18.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.16",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.16",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.16/rules_cc-0.2.16.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.1/rules_cc-0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.0.12",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.0.12",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.12/rules_cc-0.0.12.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.4/rules_cc-0.2.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.1.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.9",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.9/rules_cc-0.2.9.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc---0.2.15",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cc-0.2.15",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.2.15/rules_cc-0.2.15.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.7.15",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.7.15/rules_cc_autoconf-0.7.15.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.2/rules_cc_autoconf-0.10.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.12.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.12.1/rules_cc_autoconf-0.12.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.1/rules_cc_autoconf-0.10.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.10.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.3/rules_cc_autoconf-0.10.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.5.3",
@@ -35681,30 +36087,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.3/rules_cc_autoconf-0.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.0/rules_cc_autoconf-0.10.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.5.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.4/rules_cc_autoconf-0.5.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.11.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.11.2/rules_cc_autoconf-0.11.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.5.6",
@@ -35723,44 +36105,12 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.7.14/rules_cc_autoconf-0.7.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.5.5",
+    name = "bzl.rules_cc_autoconf---0.10.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.5/rules_cc_autoconf-0.5.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.3/rules_cc_autoconf-0.10.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.2/rules_cc_autoconf-0.10.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.10.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.1/rules_cc_autoconf-0.10.1.tar.gz"],
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.10.0/rules_cc_autoconf-0.10.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_autoconf---0.11.0",
@@ -35771,12 +36121,36 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.11.0/rules_cc_autoconf-0.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_cc_autoconf---0.7.15",
+    name = "bzl.rules_cc_autoconf---0.5.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.7.15/rules_cc_autoconf-0.7.15.tar.gz"],
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.4/rules_cc_autoconf-0.5.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.9.0/rules_cc_autoconf-0.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.8.0/rules_cc_autoconf-0.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cc_autoconf---0.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_cc_autoconf/releases/download/0.5.5/rules_cc_autoconf-0.5.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cc_hdrs_map---0.31.1",
@@ -35858,6 +36232,15 @@ starlark_repository.archive(
     urls = ["https://github.com/nya3jp/rules_contest/releases/download/v0.9.3/rules_contest-0.9.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_coreutils---1.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_coreutils-v1.0.2",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.2/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_coreutils---1.0.0-beta.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -35865,15 +36248,6 @@ starlark_repository.archive(
     strip_prefix = "rules_coreutils-v1.0.0-beta.6",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.0-beta.6/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_coreutils---1.0.0-beta.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_coreutils-v1.0.0-beta.8",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.0-beta.8/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_coreutils---1.0.1",
@@ -35885,13 +36259,13 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_coreutils---1.0.2",
+    name = "bzl.rules_coreutils---1.0.0-beta.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_coreutils-v1.0.2",
+    strip_prefix = "rules_coreutils-v1.0.0-beta.8",
     type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.2/downloads/src.tar.gz"],
+    urls = ["https://gitlab.arm.com/bazel/rules_coreutils/-/releases/v1.0.0-beta.8/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cpan---1.1.0",
@@ -35901,15 +36275,6 @@ starlark_repository.archive(
     strip_prefix = "rules_cpan-1.1.0",
     type = "tar.gz",
     urls = ["https://github.com/lalten/rules_cpan/releases/download/v1.1.0/rules_cpan-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_cuda---0.2.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_cuda-v0.2.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.2.4/rules_cuda-v0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cuda---0.3.0-beta1",
@@ -35928,6 +36293,15 @@ starlark_repository.archive(
     strip_prefix = "rules_cuda-v0.3.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.3.0/rules_cuda-v0.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_cuda---0.2.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_cuda-v0.2.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_cuda/releases/download/v0.2.4/rules_cuda-v0.2.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_cue---0.18.0",
@@ -35957,22 +36331,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_d/releases/download/v0.10.1/rules_d-v0.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_dart---0.2.2",
+    name = "bzl.rules_dart---0.4.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_dart-0.2.2",
+    strip_prefix = "rules_dart-0.4.3",
     type = "tar.gz",
-    urls = ["https://github.com/aran/rules_dart/releases/download/v0.2.2/rules_dart-v0.2.2.tar.gz"],
+    urls = ["https://github.com/aran/rules_dart/releases/download/v0.4.3/rules_dart-v0.4.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_dart_proto---0.2.2",
+    name = "bzl.rules_dart_proto---0.4.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_dart_proto-0.2.2",
+    strip_prefix = "rules_dart_proto-0.4.3",
     type = "tar.gz",
-    urls = ["https://github.com/aran/rules_dart_proto/releases/download/v0.2.2/rules_dart_proto-v0.2.2.tar.gz"],
+    urls = ["https://github.com/aran/rules_dart_proto/releases/download/v0.4.3/rules_dart_proto-v0.4.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_detekt---0.8.1.13",
@@ -36099,15 +36473,6 @@ starlark_repository.archive(
     urls = ["https://github.com/kczulko/rules_elm/releases/download/v1.1.1/rules_elm-1.1.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_erlang---3.16.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_erlang-3.16.0",
-    type = "tar.gz",
-    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.16.0/rules_erlang-3.16.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_erlang---3.11.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36135,6 +36500,23 @@ starlark_repository.archive(
     urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.11.1/rules_erlang-3.11.1.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_erlang---3.16.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_erlang-3.16.0",
+    type = "tar.gz",
+    urls = ["https://github.com/rabbitmq/rules_erlang/releases/download/3.16.0/rules_erlang-3.16.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_flex---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_flex---0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36151,12 +36533,22 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4/rules_flex-v0.4.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_flex---0.4.1",
+    name = "bzl.rules_foreign_cc---0.13.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_flex/releases/download/v0.4.1/rules_flex-v0.4.1.tar.xz"],
+    strip_prefix = "rules_foreign_cc-0.13.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.13.0/rules_foreign_cc-0.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_foreign_cc---0.12.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_foreign_cc-0.12.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_foreign_cc---0.9.0",
@@ -36177,24 +36569,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.10.1/rules_foreign_cc-0.10.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_foreign_cc---0.12.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_foreign_cc-0.12.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_foreign_cc---0.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_foreign_cc-0.13.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_foreign_cc/releases/download/0.13.0/rules_foreign_cc-0.13.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_formatjs---0.6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36204,15 +36578,6 @@ starlark_repository.archive(
     urls = ["https://github.com/formatjs/rules_formatjs/releases/download/v0.6.0/rules_formatjs-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_fuzzing---0.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_fuzzing-v0.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_fuzzing/releases/download/v0.6.0/rules_fuzzing-v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_fuzzing---0.5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36220,6 +36585,15 @@ starlark_repository.archive(
     strip_prefix = "rules_fuzzing-0.5.2",
     type = "zip",
     urls = ["https://github.com/bazelbuild/rules_fuzzing/releases/download/v0.5.2/rules_fuzzing-0.5.2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_fuzzing---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_fuzzing-v0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_fuzzing/releases/download/v0.6.0/rules_fuzzing-v0.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_gazebo---0.0.2",
@@ -36276,12 +36650,76 @@ starlark_repository.archive(
     urls = ["https://github.com/iocat/rules_gleam/releases/download/v0.1.14/rules_gleam-v0.1.14.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc1",
+    name = "bzl.rules_go---0.42.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.54.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.39.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.54.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.58.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.48.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.1/rules_go-v0.48.1.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.51.0-rc2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_go---0.57.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "zip",
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.39.1",
@@ -36300,36 +36738,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.49.0/rules_go-v0.49.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.48.0",
+    name = "bzl.rules_go---0.50.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.48.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.1/rules_go-v0.48.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.45.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.54.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.59.0",
@@ -36348,12 +36762,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.43.0/rules_go-v0.43.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.58.3",
+    name = "bzl.rules_go---0.41.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.52.0",
@@ -36364,22 +36778,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.50.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip"],
-)
-starlark_repository.archive(
     name = "bzl.rules_go---0.60.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36388,20 +36786,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.60.0/rules_go-v0.60.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.42.0",
+    name = "bzl.rules_go---0.61.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.54.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.54.1/rules_go-v0.54.1.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.61.0/rules_go-v0.61.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_go---0.53.0",
@@ -36420,36 +36810,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.46.0/rules_go-v0.46.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.39.0",
+    name = "bzl.rules_go---0.45.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.39.0/rules_go-v0.39.0.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.45.1/rules_go-v0.45.1.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.51.0-rc2",
+    name = "bzl.rules_go---0.48.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc2/rules_go-v0.51.0-rc2.zip"],
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_go---0.41.0",
+    name = "bzl.rules_go---0.51.0-rc1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_go---0.57.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "zip",
-    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_go/releases/download/v0.51.0-rc1/rules_go-v0.51.0-rc1.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_graalvm---0.11.1",
@@ -36470,15 +36852,6 @@ starlark_repository.archive(
     urls = ["https://github.com/HunterLarco/rules_graphql/releases/download/v0.1.3/rules_graphql-v0.1.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_gzip---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_gzip-v1.0.0",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_gzip/-/releases/v1.0.0/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_gzip---1.0.0-beta.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36486,6 +36859,15 @@ starlark_repository.archive(
     strip_prefix = "rules_gzip-v1.0.0-beta.6",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/rules_gzip/-/releases/v1.0.0-beta.6/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_gzip---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_gzip-v1.0.0",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/rules_gzip/-/releases/v1.0.0/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_haskell---1.0",
@@ -36497,13 +36879,13 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_haskell/releases/download/v1.0/rules_haskell-1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_heir---0.0.5",
+    name = "bzl.rules_heir---0.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_heir-v0.0.5",
+    strip_prefix = "rules_heir-0.0.6",
     type = "tar.gz",
-    urls = ["https://github.com/j2kun/rules_heir/releases/download/v0.0.5/rules_heir-v0.0.5.tar.gz"],
+    urls = ["https://github.com/j2kun/rules_heir/releases/download/0.0.6/rules_heir-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_helm---0.27.0",
@@ -36580,84 +36962,12 @@ starlark_repository.archive(
     urls = ["https://github.com/dzbarsky/rules_itest/releases/download/v0.0.52/rules_itest-v0.0.52.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_java---6.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.0.0/rules_java-6.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---5.3.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.15.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---9.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---6.1.0",
@@ -36668,12 +36978,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.1.0/rules_java-6.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---9.0.3",
+    name = "bzl.rules_java---8.15.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.1/rules_java-8.15.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.6.0",
@@ -36684,28 +36994,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.0/rules_java-8.6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---7.6.5",
+    name = "bzl.rules_java---7.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---6.5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---8.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.1.0/rules_java-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---7.4.0",
@@ -36716,28 +37010,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.4.0/rules_java-7.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.8.0",
+    name = "bzl.rules_java---8.5.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_java---7.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.5.1/rules_java-8.5.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.11.0",
@@ -36748,20 +37026,44 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.11.0/rules_java-8.11.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---6.4.0",
+    name = "bzl.rules_java---9.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.6.1/rules_java-9.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---5.5.0",
+    name = "bzl.rules_java---9.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.3.0/rules_java-9.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.1/rules_java-8.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---5.3.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.3.5/rules_java-5.3.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.9.0",
@@ -36780,12 +37082,52 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.2.0/rules_java-7.2.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_java---8.6.1",
+    name = "bzl.rules_java---8.15.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---5.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/5.5.0/rules_java-5.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---9.0.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/9.0.3/rules_java-9.0.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.3.0/rules_java-6.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.7.0/rules_java-8.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.8.0/rules_java-8.8.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_java---8.13.0",
@@ -36794,6 +37136,46 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.13.0/rules_java-8.13.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---8.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/8.6.1/rules_java-8.6.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/4.0.0/rules_java-4.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.5/rules_java-7.6.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---6.4.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/6.4.0/rules_java-6.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_java---7.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_java/releases/download/7.6.1/rules_java-7.6.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jni---0.11.1",
@@ -36838,13 +37220,13 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_jupyter/releases/download/0.7.2/rules_jupyter-0.7.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.1",
+    name = "bzl.rules_jvm_external---6.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.1",
+    strip_prefix = "rules_jvm_external-6.5",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---4.4.2",
@@ -36856,31 +37238,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/refs/tags/4.4.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.7",
+    name = "bzl.rules_jvm_external---6.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.7",
+    strip_prefix = "rules_jvm_external-6.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.6",
+    name = "bzl.rules_jvm_external---6.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.6",
+    strip_prefix = "rules_jvm_external-6.8",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---5.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-5.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.8/rules_jvm_external-6.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_jvm_external---6.1",
@@ -36901,6 +37274,42 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.9/rules_jvm_external-6.9.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.6/rules_jvm_external-6.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---6.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-6.7",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.7/rules_jvm_external-6.7.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_jvm_external---5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_jvm_external-5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.1/rules_jvm_external-5.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_jvm_external---5.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -36919,40 +37328,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.3/rules_jvm_external-6.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.5",
+    name = "bzl.rules_jvm_external---5.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.5",
+    strip_prefix = "rules_jvm_external-5.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.5/rules_jvm_external-6.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/7.0/rules_jvm_external-7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/6.0/rules_jvm_external-6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_jvm_external---6.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_jvm_external-6.8",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_jvm_external/releases/download/6.8/rules_jvm_external-6.8.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/releases/download/5.2/rules_jvm_external-5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kconfig---0.4.0",
@@ -36979,28 +37361,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.0/rules_kotlin-v1.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_kotlin---1.9.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_kotlin---2.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.0/rules_kotlin-v2.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_kotlin---2.3.20",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kotlin---2.1.3",
@@ -37011,12 +37377,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.1.3/rules_kotlin-v2.1.3.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_kotlin---1.9.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.6/rules_kotlin-v1.9.6.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_kotlin---2.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.2.2/rules_kotlin-v2.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_kotlin---2.3.20",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v2.3.20/rules_kotlin-v2.3.20.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_kustomize---0.5.3",
@@ -37026,6 +37408,14 @@ starlark_repository.archive(
     strip_prefix = "rules_kustomize-0.5.3",
     type = "tar.gz",
     urls = ["https://github.com/seh/rules_kustomize/releases/download/v0.5.3/vcs-archive-v0.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_libusb---0.1.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://storage.googleapis.com/pigweed-bazel-tarballs/rules_libusb-8745211641617303569-f5c0af2f037b6e8405b4158b5e3041675da8e522.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_libusb---0.1.0-rc2",
@@ -37044,12 +37434,12 @@ starlark_repository.archive(
     urls = ["https://github.com/pigweed-project/rules_libusb/releases/download/v0.1.0-rc2/rules_libusb-8720113729935528369-7f91dc339a79292ab8aa5ca127572e54b0b586e8.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_libusb---0.1.0-rc1",
+    name = "bzl.rules_license---0.0.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://storage.googleapis.com/pigweed-bazel-tarballs/rules_libusb-8745211641617303569-f5c0af2f037b6e8405b4158b5e3041675da8e522.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_license---1.0.0",
@@ -37060,20 +37450,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_license---0.0.4",
+    name = "bzl.rules_license---0.0.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.4/rules_license-0.0.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_license---0.0.8",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_license---0.0.7",
@@ -37084,12 +37466,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_license---0.0.3",
+    name = "bzl.rules_license---0.0.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_license/releases/download/0.0.8/rules_license-0.0.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.2.4",
@@ -37098,22 +37480,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.4/rules_m4-v0.2.4.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_m4---0.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_m4---0.2.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.xz",
-    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.5/rules_m4-v0.2.5.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_m4---0.3",
@@ -37132,12 +37498,28 @@ starlark_repository.archive(
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3/rules_m4-v0.3.tar.xz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_m4---0.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.3.1/rules_m4-v0.3.1.tar.xz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_m4---0.2.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.xz",
     urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.3/rules_m4-v0.2.3.tar.xz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_m4---0.2.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.xz",
+    urls = ["https://github.com/jmillikin/rules_m4/releases/download/v0.2.5/rules_m4-v0.2.5.tar.xz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mayhem---0.8.9",
@@ -37174,20 +37556,20 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/rules_mojo/0.8.0/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.rules_multirun---0.13.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/keith/rules_multirun/releases/download/0.13.0/rules_multirun.0.13.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_multirun---0.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/keith/rules_multirun/releases/download/0.9.0/rules_multirun.0.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_multirun---0.13.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/keith/rules_multirun/releases/download/0.13.0/rules_multirun.0.13.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_multitool---1.9.0",
@@ -37199,13 +37581,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.9.0/rules_multitool-1.9.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---1.11.1",
+    name = "bzl.rules_multitool---0.11.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-1.11.1",
+    strip_prefix = "rules_multitool-0.11.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_multitool/releases/download/v1.11.1/rules_multitool-1.11.1.tar.gz"],
+    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_multitool---0.4.0",
@@ -37226,13 +37608,13 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v1.0.0/rules_multitool-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_multitool---0.11.0",
+    name = "bzl.rules_multitool---1.11.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_multitool-0.11.0",
+    strip_prefix = "rules_multitool-1.11.1",
     type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_multitool/releases/download/v0.11.0/rules_multitool-0.11.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_multitool/releases/download/v1.11.1/rules_multitool-1.11.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_mypy---0.41.0",
@@ -37278,21 +37660,13 @@ starlark_repository.archive(
     urls = ["https://github.com/tweag/rules_nixpkgs/releases/download/v0.13.0/rules_nixpkgs-0.13.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---5.8.2",
+    name = "bzl.rules_nodejs---6.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.3.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.3.3",
@@ -37304,40 +37678,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.3/rules_nodejs-v6.3.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.0",
+    name = "bzl.rules_nodejs---6.7.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.0",
+    strip_prefix = "rules_nodejs-6.7.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.0/rules_nodejs-v6.3.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.2.0",
+    name = "bzl.rules_nodejs---6.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.2.0",
+    strip_prefix = "rules_nodejs-6.4.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.4.0/rules_nodejs-v6.4.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.5.0",
+    name = "bzl.rules_nodejs---6.3.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.5.0",
+    strip_prefix = "rules_nodejs-6.3.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---5.5.3",
@@ -37356,22 +37721,30 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-core-5.8.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.7.4",
+    name = "bzl.rules_nodejs---5.8.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.7.4",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.4/rules_nodejs-v6.7.4.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.2/rules_nodejs-core-5.8.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.5.2",
+    name = "bzl.rules_nodejs---6.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.5.2",
+    strip_prefix = "rules_nodejs-6.5.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.0/rules_nodejs-v6.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/v6.2.0/rules_nodejs-v6.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_nodejs---6.7.3",
@@ -37383,13 +37756,22 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.7.3/rules_nodejs-v6.7.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_nodejs---6.3.4",
+    name = "bzl.rules_nodejs---6.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_nodejs-6.3.4",
+    strip_prefix = "rules_nodejs-6.3.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.4/rules_nodejs-v6.3.4.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.3.2/rules_nodejs-v6.3.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_nodejs---6.5.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_nodejs-6.5.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_nodejs/releases/download/v6.5.2/rules_nodejs-v6.5.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_objc---0.0.1",
@@ -37399,24 +37781,6 @@ starlark_repository.archive(
     strip_prefix = "rules_objc-0.0.1.brc2",
     type = "tar.gz",
     urls = ["https://github.com/kekxv/rules_objc/archive/refs/tags/v0.0.1.brc2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_oci---1.7.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-1.7.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_oci---1.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_oci-1.6.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_oci---2.2.0",
@@ -37435,6 +37799,24 @@ starlark_repository.archive(
     strip_prefix = "rules_oci-2.3.0",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v2.3.0/rules_oci-v2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_oci---1.7.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-1.7.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_oci---1.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_oci-1.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_openscad---0.1",
@@ -37464,30 +37846,12 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/rules_patchelf/-/releases/v1.0.1/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_perl---1.1.0",
+    name = "bzl.rules_perl---0.6.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_perl---0.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.4.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_perl---0.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.2.0",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_perl/archive/refs/tags/0.2.0.zip"],
+    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/0.6.7/rules_perl-0.6.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---1.0.0",
@@ -37496,23 +37860,6 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.0.0/rules_perl-1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_perl---0.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_perl-0.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_perl---0.6.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/0.6.7/rules_perl-0.6.7.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_perl---0.2.4",
@@ -37524,12 +37871,47 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.2.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_perl---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_perl-0.4.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_perl---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.0/rules_perl-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_perl---0.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_perl-0.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_perl/archive/refs/tags/0.5.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_perl---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_perl/releases/download/1.1.1/rules_perl-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_perl---0.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_perl-0.2.0",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_perl/archive/refs/tags/0.2.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pex---0.1.1",
@@ -37549,28 +37931,28 @@ starlark_repository.archive(
     urls = ["https://github.com/bookingcom/rules_pitest/releases/download/v0.0.2/rules_mylang-v0.0.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_pkg---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pkg---0.9.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pkg---1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg---0.7.0",
@@ -37581,12 +37963,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pkg---1.2.0",
+    name = "bzl.rules_pkg---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.2.0/rules_pkg-1.2.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/1.1.0/rules_pkg-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pkg_providers---0.0.1",
@@ -37623,15 +38005,6 @@ starlark_repository.archive(
     urls = ["https://github.com/mrmeku/rules_playwright/releases/download/v0.5.3/rules_playwright-v0.5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pmd---0.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "bazel_rules_pmd-0.4.1",
-    type = "tar.gz",
-    urls = ["https://github.com/buildfoundation/bazel_rules_pmd/releases/download/v0.4.1/bazel_rules_pmd-v0.4.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pmd---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -37639,6 +38012,15 @@ starlark_repository.archive(
     strip_prefix = "bazel_rules_pmd-0.4.0",
     type = "tar.gz",
     urls = ["https://github.com/buildfoundation/bazel_rules_pmd/releases/download/v0.4.0/bazel_rules_pmd-v0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pmd---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "bazel_rules_pmd-0.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/buildfoundation/bazel_rules_pmd/releases/download/v0.4.1/bazel_rules_pmd-v0.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_poetry---0.3.6",
@@ -37685,31 +38067,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---6.0.0",
+    name = "bzl.rules_proto---7.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-6.0.0",
+    strip_prefix = "rules_proto-7.0.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---4.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-4.0.0",
-    type = "zip",
-    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_proto---6.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-6.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---5.3.0-21.7",
@@ -37721,13 +38085,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto---7.0.2",
+    name = "bzl.rules_proto---6.0.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto-7.0.2",
+    strip_prefix = "rules_proto-6.0.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto---4.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-4.0.0",
+    type = "zip",
+    urls = ["https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_proto---6.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_proto-6.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto---6.0.0-rc1",
@@ -37739,13 +38121,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_proto/releases/download/6.0.0-rc1/rules_proto-6.0.0-rc1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto_grpc---5.0.0",
+    name = "bzl.rules_proto_grpc---5.0.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto_grpc-5.0.0",
+    strip_prefix = "rules_proto_grpc-5.0.1",
     type = "tar.gz",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.0/rules_proto_grpc-5.0.0.tar.gz"],
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.1/rules_proto_grpc-5.0.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc---5.8.0",
@@ -37757,13 +38139,13 @@ starlark_repository.archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.8.0/rules_proto_grpc-5.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_proto_grpc---5.0.1",
+    name = "bzl.rules_proto_grpc---5.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_proto_grpc-5.0.1",
+    strip_prefix = "rules_proto_grpc-5.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.1/rules_proto_grpc-5.0.1.tar.gz"],
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.0.0/rules_proto_grpc-5.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_proto_grpc_buf---5.8.0",
@@ -37883,15 +38265,6 @@ starlark_repository.archive(
     urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/releases/download/5.8.0/rules_proto_grpc_swift-5.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_pycross---0.8.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_pycross-0.8.2",
-    type = "tar.gz",
-    urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.2/rules_pycross-v0.8.2.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_pycross---0.8.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -37899,6 +38272,15 @@ starlark_repository.archive(
     strip_prefix = "rules_pycross-0.8.1",
     type = "tar.gz",
     urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.1/rules_pycross-v0.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_pycross---0.8.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_pycross-0.8.2",
+    type = "tar.gz",
+    urls = ["https://github.com/jvolkman/rules_pycross/releases/download/v0.8.2/rules_pycross-v0.8.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_pydeps---0.5.0",
@@ -37910,13 +38292,48 @@ starlark_repository.archive(
     urls = ["https://github.com/theoremlp/rules_pydeps/releases/download/v0.5.0/rules_pydeps-0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---1.2.0",
+    name = "bzl.rules_python---0.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.2.0/rules_python-1.2.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---0.10.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-0.10.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.0/rules_python-1.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.5.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.5.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.3/rules_python-1.5.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_python---2.0.1",
@@ -37926,6 +38343,132 @@ starlark_repository.archive(
     strip_prefix = "rules_python-2.0.1",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/2.0.1/rules_python-2.0.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.7.0/rules_python-1.7.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---2.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-2.0.2",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/2.0.2/rules_python-2.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.9.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.9.0/rules_python-1.9.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.8.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.0/rules_python-1.8.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.3.0/rules_python-1.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.8.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.8.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.4/rules_python-1.8.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.0.0/rules_python-1.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.1/rules_python-1.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.8.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.1/rules_python-1.8.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.2.0/rules_python-1.2.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.9.0-rc1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.9.0-rc1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.9.0-rc1/rules_python-1.9.0-rc1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.8.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.8.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.3/rules_python-1.8.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_python---1.6.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_python-1.6.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.6.3/rules_python-1.6.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_python---1.6.0",
@@ -37946,105 +38489,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.40.0/rules_python-0.40.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_python---0.10.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-0.10.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.0.0/rules_python-1.0.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.5.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.5.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.3/rules_python-1.5.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.5.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.5.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.0/rules_python-1.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/1.1.0/rules_python-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.9.0/rules_python-1.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.9.0-rc1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.9.0-rc1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.9.0-rc1/rules_python-1.9.0-rc1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.8.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.1/rules_python-1.8.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.7.0/rules_python-1.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.8.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.8.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.3/rules_python-1.8.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.8.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.8.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.4/rules_python-1.8.4.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_python---1.8.5",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38052,68 +38496,6 @@ starlark_repository.archive(
     strip_prefix = "rules_python-1.8.5",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.5/rules_python-1.8.5.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.6.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.6.3",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.6.3/rules_python-1.6.3.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---0.4.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.4.0/rules_python-0.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---2.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-2.0.2",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/2.0.2/rules_python-2.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.5.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.1/rules_python-1.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.3.0/rules_python-1.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.8.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.8.0/rules_python-1.8.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_python---1.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_python-1.4.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.4.1/rules_python-1.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_python_gazelle_plugin---2.0.2",
@@ -38134,13 +38516,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_python/releases/download/1.5.1/rules_python-1.5.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_qemu---0.1.1",
+    name = "bzl.rules_qemu---0.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_qemu-0.1.1",
+    strip_prefix = "rules_qemu-0.2.0",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.1.1/rules_qemu-v0.1.1.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/rules_qemu/releases/download/v0.2.0/rules_qemu-v0.2.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_qt---0.0.6",
@@ -38152,20 +38534,20 @@ starlark_repository.archive(
     urls = ["https://github.com/Vertexwahn/rules_qt6/releases/download/0.0.6/rules_qt6-0.0.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_req_compile---1.1.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/req-compile/releases/download/1.1.0/rules_req_compile-1.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_req_compile---1.1.3",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/req-compile/releases/download/1.1.3/rules_req_compile-1.1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_req_compile---1.1.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/req-compile/releases/download/1.1.0/rules_req_compile-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_robolectric---4.14.1.2",
@@ -38186,24 +38568,6 @@ starlark_repository.archive(
     urls = ["https://github.com/robolectric/robolectric-bazel/releases/download/v4.16.1/robolectric-bazel-v4.16.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.68",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.68",
-    type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rs---0.0.82",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_rs-0.0.82",
-    type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.82/rules_rs-v0.0.82.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_rs---0.0.73",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38211,6 +38575,24 @@ starlark_repository.archive(
     strip_prefix = "rules_rs-0.0.73",
     type = "tar.gz",
     urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.73/rules_rs-v0.0.73.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rs---0.0.83",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_rs-0.0.83",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.83/rules_rs-v0.0.83.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rs---0.0.68",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_rs-0.0.68",
+    type = "tar.gz",
+    urls = ["https://github.com/hermeticbuild/rules_rs/releases/download/v0.0.68/rules_rs-v0.0.68.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_ruby---0.26.0",
@@ -38231,22 +38613,6 @@ starlark_repository.archive(
     urls = ["https://github.com/hermeticbuild/rules_runfiles_group/releases/download/v0.0.1-rc.5/rules_runfiles_group-v0.0.1-rc.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.66.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.66.0/rules_rust-0.66.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rust---0.62.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.62.0/rules_rust-0.62.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_rust---0.65.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38263,20 +38629,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.59.2/rules_rust-0.59.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.51.0",
+    name = "bzl.rules_rust---0.45.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rust---0.61.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.61.0/rules_rust-0.61.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.45.1/rules_rust-v0.45.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust---0.67.0",
@@ -38295,6 +38653,14 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.70.0/rules_rust-0.70.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_rust---0.62.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.62.0/rules_rust-0.62.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_rust---0.68.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38311,12 +38677,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.69.0/rules_rust-0.69.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_rust---0.45.1",
+    name = "bzl.rules_rust---0.66.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.45.1/rules_rust-v0.45.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.66.0/rules_rust-0.66.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rust---0.51.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.51.0/rules_rust-v0.51.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_bindgen---0.59.2",
@@ -38326,15 +38700,6 @@ starlark_repository.archive(
     strip_prefix = "extensions/bindgen",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.59.2/rules_rust-0.59.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_rust_bindgen---0.61.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "extensions/bindgen",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.61.0/rules_rust-0.61.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_bindgen---0.67.0",
@@ -38353,6 +38718,15 @@ starlark_repository.archive(
     strip_prefix = "extensions/bindgen",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.70.0/rules_rust-0.70.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_rust_bindgen---0.68.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "extensions/bindgen",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.68.1/rules_rust-0.68.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_rust_mdbook---0.70.0",
@@ -38461,22 +38835,22 @@ starlark_repository.archive(
     urls = ["https://github.com/Ryang20718/rules_s5/releases/download/v0.0.13/rules_s5-0.0.13.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.0.0",
+    name = "bzl.rules_sbom---0.6.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.0.0",
+    strip_prefix = "rules_sbom-0.6.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
+    urls = ["https://github.com/rtbot-dev/rules_sbom/releases/download/v0.6.1/rules_sbom-0.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.1.3",
+    name = "bzl.rules_scala---7.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.1.3",
+    strip_prefix = "rules_scala-7.2.2",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.3/rules_scala-v7.1.3.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.1.5",
@@ -38488,13 +38862,31 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.5/rules_scala-v7.1.5.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_scala---7.2.2",
+    name = "bzl.rules_scala---7.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "rules_scala-7.2.2",
+    strip_prefix = "rules_scala-7.0.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.2/rules_scala-v7.2.2.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.0.0/rules_scala-v7.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.2.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.2.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.2.5/rules_scala-v7.2.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_scala---7.1.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_scala-7.1.3",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/rules_scala/releases/download/v7.1.3/rules_scala-v7.1.3.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_scala---7.2.4",
@@ -38541,6 +38933,15 @@ starlark_repository.archive(
     urls = ["https://github.com/filmil/rules_shar/releases/download/v1.0.7/rules_shar-v1.0.7.zip"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_shell---0.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.6.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_shell---0.7.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38577,6 +38978,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_shell/releases/download/v0.8.0/rules_shell-v0.8.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.rules_shell---0.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_shell-0.3.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.rules_shell---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38586,15 +38996,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_shell---0.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.6.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.6.1/rules_shell-v0.6.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_shell---0.4.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38602,15 +39003,6 @@ starlark_repository.archive(
     strip_prefix = "rules_shell-0.4.1",
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_shell---0.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_shell-0.3.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_shellcheck---0.6.2",
@@ -38673,60 +39065,12 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/rules_squashfs/-/releases/v1.0.0-alpha.4/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---3.6.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_swift---3.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.5.0/rules_swift.3.5.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.3.0/rules_swift.2.3.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---1.18.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.0.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---2.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_swift---3.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.6.1",
@@ -38737,12 +39081,36 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.1/rules_swift.3.6.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift---2.0.0",
+    name = "bzl.rules_swift---3.4.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.4.1/rules_swift.3.4.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.3.0/rules_swift.2.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.1.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.1.1/rules_swift.2.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---1.18.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---3.3.0",
@@ -38751,6 +39119,30 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.3.0/rules_swift.3.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---2.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/2.0.0/rules_swift.2.0.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.0.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift---3.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.6.0/rules_swift.3.6.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift---1.14.0",
@@ -38777,20 +39169,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/rules_swift/releases/download/3.1.2/rules_swift.3.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_swift_package_manager---1.17.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.17.1/rules_swift_package_manager.v1.17.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_swift_package_manager---1.15.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.15.0/rules_swift_package_manager.v1.15.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_swift_package_manager---1.18.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/cgrindel/rules_swift_package_manager/releases/download/v1.18.1/rules_swift_package_manager.v1.18.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_swift_package_manager---1.9.0",
@@ -38837,12 +39229,12 @@ starlark_repository.archive(
     urls = ["https://github.com/chickenandpork/rules_synology/releases/download/v0.2.3/rules_synology-v0.2.3.tar.xz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_systemrdl---0.2.0",
+    name = "bzl.rules_systemrdl---0.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_systemrdl/releases/download/0.2.0/rules_systemrdl-0.2.0.tar.gz"],
+    urls = ["https://github.com/hw-bzl/rules_systemrdl/releases/download/0.3.0/rules_systemrdl-0.3.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_tar---1.0.1",
@@ -38923,15 +39315,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/rules_uv/releases/download/v0.89.2/rules_uv-0.89.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_uv---0.44.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_uv-0.44.0",
-    type = "tar.gz",
-    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_uv---0.21.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -38939,6 +39322,15 @@ starlark_repository.archive(
     strip_prefix = "rules_uv-0.21.0",
     type = "tar.gz",
     urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.21.0/rules_uv-0.21.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_uv---0.44.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_uv-0.44.0",
+    type = "tar.gz",
+    urls = ["https://github.com/theoremlp/rules_uv/releases/download/v0.44.0/rules_uv-0.44.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_venv---0.15.0",
@@ -38949,28 +39341,12 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.15.0/rules_venv-0.15.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_venv---0.19.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.19.0/rules_venv-0.19.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_venv---0.16.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.16.0/rules_venv-0.16.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.rules_venv---0.17.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_venv---0.7.0",
@@ -38981,12 +39357,28 @@ starlark_repository.archive(
     urls = ["https://github.com/periareon/rules_venv/releases/download/0.7.0/rules_venv-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_verilator---0.3.3.bcr.1",
+    name = "bzl.rules_venv---0.19.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/0.3.3.bcr.1/rules_verilator-0.3.3.bcr.1.tar.gz"],
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.19.0/rules_venv-0.19.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_venv---0.17.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/periareon/rules_venv/releases/download/0.17.0/rules_venv-0.17.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_verilator---1.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/hw-bzl/rules_verilator/releases/download/1.0.0/rules_verilator-1.0.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_verilator---0.1.0",
@@ -38998,14 +39390,6 @@ starlark_repository.archive(
     urls = ["https://github.com/MrAMS/bazel_rules_verilator/releases/download/v0.1.0/bazel_rules_verilator-0.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_verilog---1.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_verilog/releases/download/1.1.1/rules_verilog-1.1.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_verilog---1.1.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39015,12 +39399,20 @@ starlark_repository.archive(
     urls = ["https://github.com/hw-bzl/bazel_rules_verilog/releases/download/v1.1.0/bazel_rules_verilog-1.1.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_vhdl---0.1.1",
+    name = "bzl.rules_verilog---1.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/hw-bzl/rules_vhdl/releases/download/0.1.1/rules_vhdl-0.1.1.tar.gz"],
+    urls = ["https://github.com/hw-bzl/rules_verilog/releases/download/1.1.1/rules_verilog-1.1.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_vhdl---0.1.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/hw-bzl/rules_vhdl/releases/download/0.1.2/rules_vhdl-0.1.2.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.rules_vivado---0.1.1",
@@ -39147,15 +39539,6 @@ starlark_repository.archive(
     urls = ["https://github.com/aherrmann/rules_zig/releases/download/v0.12.1/rules_zig-0.12.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.rules_zstd---1.0.0-beta.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "rules_zstd-v1.0.0-beta.7",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/rules_zstd/-/releases/v1.0.0-beta.7/downloads/src.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.rules_zstd---1.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39163,6 +39546,15 @@ starlark_repository.archive(
     strip_prefix = "rules_zstd-v1.0.0",
     type = "tar.gz",
     urls = ["https://gitlab.arm.com/bazel/rules_zstd/-/releases/v1.0.0/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.rules_zstd---1.0.0-beta.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "rules_zstd-v1.0.0-beta.7",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/rules_zstd/-/releases/v1.0.0-beta.7/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.ruy---0.0.0-20200416-9f53ba4",
@@ -39240,15 +39632,6 @@ starlark_repository.archive(
     urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.1.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.sdformat---16.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "sdformat-sdformat16_16.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.sdformat---15.3.0.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39256,6 +39639,15 @@ starlark_repository.archive(
     strip_prefix = "sdformat-sdformat15_15.3.0",
     type = "tar.gz",
     urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat15_15.3.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.sdformat---16.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "sdformat-sdformat16_16.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/gazebosim/sdformat/archive/refs/tags/sdformat16_16.0.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.sdl2---2.32.0.bcr.beta.5",
@@ -39279,18 +39671,18 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/seastar/26.03.0-20260302212502-e639df376395/overlay",
 )
 starlark_repository.local(
-    name = "bzl.sed---4.9.bcr.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/sed/4.9.bcr.3/overlay",
-)
-starlark_repository.local(
     name = "bzl.sed---4.9.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/sed/4.9.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sed---4.9.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sed/4.9.bcr.3/overlay",
 )
 starlark_repository.local(
     name = "bzl.sed---4.9.bcr.5",
@@ -39355,6 +39747,15 @@ starlark_repository.archive(
     urls = ["https://github.com/apache/skywalking-data-collect-protocol/archive/refs/tags/v10.3.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.snappy---1.2.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "snappy-1.2.0",
+    type = "tar.gz",
+    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.snappy---1.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39371,15 +39772,6 @@ starlark_repository.archive(
     strip_prefix = "snappy-1.2.2",
     type = "tar.gz",
     urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.snappy---1.2.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "snappy-1.2.0",
-    type = "tar.gz",
-    urls = ["https://github.com/google/snappy/archive/refs/tags/1.2.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.sockpp---1.0.0-20260101-b8e19c8",
@@ -39445,13 +39837,6 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"],
 )
-starlark_repository.local(
-    name = "bzl.spdlog---1.17.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/spdlog/1.17.0/overlay",
-)
 starlark_repository.archive(
     name = "bzl.spdlog---1.10.0",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -39462,11 +39847,11 @@ starlark_repository.archive(
     urls = ["https://github.com/gabime/spdlog/archive/refs/tags/v1.10.0.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.spdlog---1.15.2",
+    name = "bzl.spdlog---1.17.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/spdlog/1.15.2/overlay",
+    path = "data/bazel-central-registry/modules/spdlog/1.17.0/overlay",
 )
 starlark_repository.local(
     name = "bzl.spdlog---1.15.3",
@@ -39474,6 +39859,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/spdlog/1.15.3/overlay",
+)
+starlark_repository.local(
+    name = "bzl.spdlog---1.15.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/spdlog/1.15.2/overlay",
 )
 starlark_repository.archive(
     name = "bzl.sphinxdocs---2.0.2",
@@ -39510,27 +39902,6 @@ starlark_repository.archive(
     urls = ["https://github.com/sqids/sqids-bazel/releases/download/v0.1.0/sqids-bazel-v0.1.0.tar.gz"],
 )
 starlark_repository.local(
-    name = "bzl.sqlite3---3.50.2",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/sqlite3/3.50.2/overlay",
-)
-starlark_repository.local(
-    name = "bzl.sqlite3---3.50.3",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/sqlite3/3.50.3/overlay",
-)
-starlark_repository.local(
-    name = "bzl.sqlite3---3.49.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/sqlite3/3.49.1/overlay",
-)
-starlark_repository.local(
     name = "bzl.sqlite3---3.51.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39552,20 +39923,32 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/sqlite3/3.53.1/overlay",
 )
 starlark_repository.local(
+    name = "bzl.sqlite3---3.50.2",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.50.2/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite3---3.49.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.49.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.sqlite3---3.50.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/sqlite3/3.50.3/overlay",
+)
+starlark_repository.local(
     name = "bzl.sqlite_orm---1.9.1.bcr.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/sqlite_orm/1.9.1.bcr.1/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.squashfs-tools---4.6.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "squashfs-tools-4.6.1/squashfs-tools",
-    type = "tar.gz",
-    urls = ["https://github.com/plougher/squashfs-tools/archive/refs/tags/4.6.1.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.squashfs-tools---4.7.5",
@@ -39580,6 +39963,15 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/squashfs-tools/4.7.4/overlay",
+)
+starlark_repository.archive(
+    name = "bzl.squashfs-tools---4.6.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "squashfs-tools-4.6.1/squashfs-tools",
+    type = "tar.gz",
+    urls = ["https://github.com/plougher/squashfs-tools/archive/refs/tags/4.6.1.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.squashfuse---0.5.2",
@@ -39598,14 +39990,6 @@ starlark_repository.archive(
     urls = ["https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.8.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.8.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.stardoc---0.6.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39614,12 +39998,12 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.5.0",
+    name = "bzl.stardoc---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.5.3",
@@ -39630,12 +40014,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.3/stardoc-0.5.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.7.1",
+    name = "bzl.stardoc---0.5.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.8.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.5.6",
@@ -39644,6 +40036,14 @@ starlark_repository.archive(
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.6/stardoc-0.5.6.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.stardoc---0.5.1",
@@ -39662,28 +40062,20 @@ starlark_repository.archive(
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.5.4/stardoc-0.5.4.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.stardoc---0.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.0/stardoc-0.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.stardoc---0.8.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.1/stardoc-0.8.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.stardoc---0.7.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     type = "tar.gz",
     urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.7.2/stardoc-0.7.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.stardoc---0.8.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/bazelbuild/stardoc/releases/download/0.8.0/stardoc-0.8.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.stb---0.0.0-20251026-f1c79c0",
@@ -39726,6 +40118,13 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/dallison/subspace/releases/download/2.8.0/subspace-2.8.0.tar.gz"],
 )
+starlark_repository.local(
+    name = "bzl.suitesparse---7.10.1.bcr.3",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/suitesparse/7.10.1.bcr.3/overlay",
+)
 starlark_repository.archive(
     name = "bzl.suitesparse---7.6.0.bcr.2",
     build_directives = ["gazelle:starlarkrepository_root"],
@@ -39735,12 +40134,14 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.6.0.tar.gz"],
 )
-starlark_repository.local(
-    name = "bzl.suitesparse---7.10.1.bcr.3",
+starlark_repository.archive(
+    name = "bzl.supply-chain-go---0.0.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/suitesparse/7.10.1.bcr.3/overlay",
+    strip_prefix = "supply-chain-0.0.6/lib/supplychain-go",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.supply-chain-go---0.0.10",
@@ -39750,15 +40151,6 @@ starlark_repository.archive(
     strip_prefix = "supply-chain-0.0.10/lib/supplychain-go",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.10/supply-chain-v0.0.10.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.supply-chain-go---0.0.6",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "supply-chain-0.0.6/lib/supplychain-go",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/supply-chain/releases/download/v0.0.6/supply-chain-v0.0.6.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.supply_chain_tools---0.0.1",
@@ -39838,6 +40230,24 @@ starlark_repository.archive(
     urls = ["https://github.com/dduan/TOMLDecoder/archive/refs/tags/0.4.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.swift_argument_parser---1.7.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "swift-argument-parser-1.7.1",
+    type = "tar.gz",
+    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.7.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.swift_argument_parser---1.7.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "swift-argument-parser-1.7.0",
+    type = "tar.gz",
+    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.7.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.swift_argument_parser---1.3.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39854,24 +40264,6 @@ starlark_repository.archive(
     strip_prefix = "swift-argument-parser-1.3.1",
     type = "tar.gz",
     urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.3.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.swift_argument_parser---1.7.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-argument-parser-1.7.0",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.7.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.swift_argument_parser---1.7.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "swift-argument-parser-1.7.1",
-    type = "tar.gz",
-    urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.7.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.swift_bep_parser---0.0.6",
@@ -39923,15 +40315,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/swig/4.3.0.bcr.2/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.swxmlhash---8.1.0.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "SWXMLHash-8.1.0",
-    type = "tar.gz",
-    urls = ["https://github.com/drmohundro/SWXMLHash/archive/refs/tags/8.1.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.swxmlhash---7.0.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -39939,6 +40322,15 @@ starlark_repository.archive(
     strip_prefix = "SWXMLHash-7.0.2",
     type = "tar.gz",
     urls = ["https://github.com/drmohundro/SWXMLHash/archive/refs/tags/7.0.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.swxmlhash---8.1.0.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "SWXMLHash-8.1.0",
+    type = "tar.gz",
+    urls = ["https://github.com/drmohundro/SWXMLHash/archive/refs/tags/8.1.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.symengine---0.12.0",
@@ -39969,58 +40361,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/systemd/260.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.6.0",
+    name = "bzl.tar.bzl---0.10.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.6.0",
+    strip_prefix = "tar.bzl-0.10.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.9.0",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.5.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.5.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.10.4",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.10.4",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.4/tar.bzl-v0.10.4.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.tar.bzl---0.5.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.5.5",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.5/tar.bzl-v0.5.5.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.1/tar.bzl-v0.10.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tar.bzl---0.10.5",
@@ -40032,6 +40379,15 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.5/tar.bzl-v0.10.5.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.tar.bzl---0.10.4",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.10.4",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.4/tar.bzl-v0.10.4.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.tar.bzl---0.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40041,20 +40397,49 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.7.0/tar.bzl-v0.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tar.bzl---0.10.1",
+    name = "bzl.tar.bzl---0.9.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "tar.bzl-0.10.1",
+    strip_prefix = "tar.bzl-0.9.0",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.10.1/tar.bzl-v0.10.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.9.0/tar.bzl-v0.9.0.tar.gz"],
 )
-starlark_repository.local(
-    name = "bzl.tcl_lang---9.0.2.bcr.1",
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.2.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/tcl_lang/9.0.2.bcr.1/overlay",
+    strip_prefix = "tar.bzl-0.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.2.1/tar.bzl-v0.2.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.5.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.5/tar.bzl-v0.5.5.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.5.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.5.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.5.1/tar.bzl-v0.5.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tar.bzl---0.6.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tar.bzl-0.6.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/tar.bzl/releases/download/v0.6.0/tar.bzl-v0.6.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.tcl_lang---8.6.16",
@@ -40069,6 +40454,13 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/tcl_lang/8.6.16.bcr.1/overlay",
+)
+starlark_repository.local(
+    name = "bzl.tcl_lang---9.0.2.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/tcl_lang/9.0.2.bcr.1/overlay",
 )
 starlark_repository.local(
     name = "bzl.tclap---1.2.5.bcr.1",
@@ -40140,15 +40532,6 @@ starlark_repository.archive(
     urls = ["https://storage.googleapis.com/rime-public/mirror/thrax-1.3.9.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.tink_cc---2.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tink-cc-2.3.0",
-    type = "zip",
-    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.3.0/tink-cc-2.3.0.zip"],
-)
-starlark_repository.archive(
     name = "bzl.tink_cc---2.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40156,6 +40539,15 @@ starlark_repository.archive(
     strip_prefix = "tink-cc-2.7.0",
     type = "zip",
     urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.7.0/tink-cc-2.7.0.zip"],
+)
+starlark_repository.archive(
+    name = "bzl.tink_cc---2.3.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tink-cc-2.3.0",
+    type = "zip",
+    urls = ["https://github.com/tink-crypto/tink-cc/releases/download/v2.3.0/tink-cc-2.3.0.zip"],
 )
 starlark_repository.archive(
     name = "bzl.tinyformat---2.3.0",
@@ -40197,6 +40589,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/tinyxml/2.6.2/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.tinyxml2---10.0.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tinyxml2-10.0.0",
+    type = "tar.gz",
+    urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.tinyxml2---9.0.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40211,15 +40612,6 @@ starlark_repository.local(
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/tinyxml2/11.0.0/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.tinyxml2---10.0.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tinyxml2-10.0.0",
-    type = "tar.gz",
-    urls = ["https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.tl-expected---1.3.1",
@@ -40236,15 +40628,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/tl-optional/1.1.0/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.toml.bzl---0.4.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toml.bzl-0.4.1",
-    type = "tar.gz",
-    urls = ["https://github.com/jvolkman/toml.bzl/releases/download/v0.4.1/toml.bzl-v0.4.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.toml.bzl---0.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40254,6 +40637,15 @@ starlark_repository.archive(
     urls = ["https://github.com/jvolkman/toml.bzl/releases/download/v0.3.0/toml.bzl-v0.3.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.toml.bzl---0.4.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toml.bzl-0.4.1",
+    type = "tar.gz",
+    urls = ["https://github.com/jvolkman/toml.bzl/releases/download/v0.4.1/toml.bzl-v0.4.1.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.tomlplusplus---3.4.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40261,15 +40653,6 @@ starlark_repository.archive(
     strip_prefix = "tomlplusplus-3.4.0",
     type = "tar.gz",
     urls = ["https://github.com/marzer/tomlplusplus/archive/refs/tags/v3.4.0.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.toolchain_utils---1.3.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "toolchain_utils-v1.3.0",
-    type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.3.0/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchain_utils---1.0.2",
@@ -40290,6 +40673,15 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.0.0-beta.18/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.toolchain_utils---1.0.0-beta.9",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchain_utils-v1.0.0-beta.9",
+    type = "tar.gz",
+    urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.0.0-beta.9/downloads/src.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.toolchain_utils---1.2.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40299,13 +40691,13 @@ starlark_repository.archive(
     urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.2.0/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchain_utils---1.0.0-beta.9",
+    name = "bzl.toolchain_utils---1.3.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "toolchain_utils-v1.0.0-beta.9",
+    strip_prefix = "toolchain_utils-v1.3.0",
     type = "tar.gz",
-    urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.0.0-beta.9/downloads/src.tar.gz"],
+    urls = ["https://gitlab.arm.com/bazel/toolchain_utils/-/releases/v1.3.0/downloads/src.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.toolchains_arm_gnu---1.1.0",
@@ -40335,6 +40727,15 @@ starlark_repository.archive(
     urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/releases/download/v0.0.4/buildbuddy-toolchain-v0.0.4.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.toolchains_llvm---1.5.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "toolchains_llvm-v1.5.0",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.5.0/toolchains_llvm-v1.5.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.toolchains_llvm---1.7.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40344,13 +40745,13 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/toolchains_llvm/releases/download/v1.7.0/toolchains_llvm-v1.7.0.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.toolchains_llvm_bootstrapped---0.2.3",
+    name = "bzl.toolchains_llvm_bootstrapped---0.5.7",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "toolchains_llvm_bootstrapped-0.2.3",
+    strip_prefix = "toolchains_llvm_bootstrapped-0.5.7",
     type = "tar.gz",
-    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.2.3/toolchains_llvm_bootstrapped-0.2.3.tar.gz"],
+    urls = ["https://github.com/cerisier/toolchains_llvm_bootstrapped/releases/download/0.5.7/toolchains_llvm_bootstrapped-0.5.7.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.toolchains_musl---0.1.27.bcr.1",
@@ -40421,15 +40822,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/toybox/0.8.12.bcr.1/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.tree-sitter-bazel---0.26.5",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "tree-sitter-bazel-0.26.5",
-    type = "tar.gz",
-    urls = ["https://github.com/zadlg/tree-sitter-bazel/releases/download/v0.26.5/tree-sitter.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.tree-sitter-bazel---0.24.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40437,6 +40829,15 @@ starlark_repository.archive(
     strip_prefix = "tree-sitter-bazel-0.24.4",
     type = "tar.gz",
     urls = ["https://github.com/zadlg/tree-sitter-bazel/releases/download/v0.24.4/tree-sitter.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.tree-sitter-bazel---0.26.5",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "tree-sitter-bazel-0.26.5",
+    type = "tar.gz",
+    urls = ["https://github.com/zadlg/tree-sitter-bazel/releases/download/v0.26.5/tree-sitter.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.tree-sitter-c-bazel---0.23.4",
@@ -40520,15 +40921,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/universal-robots-client-library/2.4.0/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.upb---0.0.0-20230516-61a97ef",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "upb-61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98",
-    type = "tar.gz",
-    urls = ["https://github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.upb---0.0.0-20220923-a547704",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40545,6 +40937,15 @@ starlark_repository.archive(
     strip_prefix = "upb-e7430e66d6e51def2a88f0b66fdab62b0d9492c1",
     type = "tar.gz",
     urls = ["https://github.com/protocolbuffers/upb/archive/e7430e66d6e51def2a88f0b66fdab62b0d9492c1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.upb---0.0.0-20230516-61a97ef",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "upb-61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98",
+    type = "tar.gz",
+    urls = ["https://github.com/protocolbuffers/upb/archive/61a97efa24a5ce01fb8cc73c9d1e6e7060f8ea98.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.urdfdom---2.3.4.bcr.1",
@@ -40721,13 +41122,13 @@ starlark_repository.archive(
     urls = ["https://github.com/wheelos/common_msgs/releases/download/0.1.2/common_msgs-0.1.2.zip"],
 )
 starlark_repository.archive(
-    name = "bzl.windows_support---0.1.7",
+    name = "bzl.windows_support---0.1.8",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "windows_support-0.1.7",
+    strip_prefix = "windows_support-0.1.8",
     type = "tar.gz",
-    urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.7/windows_support-v0.1.7.tar.gz"],
+    urls = ["https://github.com/hermeticbuild/windows_support/releases/download/v0.1.8/windows_support-v0.1.8.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.with_cfg.bzl---0.14.6",
@@ -40739,15 +41140,6 @@ starlark_repository.archive(
     urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.6/with_cfg.bzl-v0.14.6.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.with_cfg.bzl---0.14.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "with_cfg.bzl-0.14.1",
-    type = "tar.gz",
-    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.1/with_cfg.bzl-v0.14.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.with_cfg.bzl---0.12.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40755,6 +41147,15 @@ starlark_repository.archive(
     strip_prefix = "with_cfg.bzl-0.12.0",
     type = "tar.gz",
     urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.12.0/with_cfg.bzl-v0.12.0.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.with_cfg.bzl---0.14.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "with_cfg.bzl-0.14.1",
+    type = "tar.gz",
+    urls = ["https://github.com/fmeum/with_cfg.bzl/releases/download/v0.14.1/with_cfg.bzl-v0.14.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.wolfd_bazel_compile_commands---0.5.2",
@@ -40965,14 +41366,6 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/xz/5.4.5.bcr.8/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.yaml-cpp---0.9.0",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    type = "tar.gz",
-    urls = ["https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yaml-cpp---0.8.0",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -40991,6 +41384,14 @@ starlark_repository.archive(
     urls = ["https://github.com/stonier/yaml-cpp/releases/download/0.8.0/yaml-cpp-0.8.0.tar.gz"],
 )
 starlark_repository.archive(
+    name = "bzl.yaml-cpp---0.9.0",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    type = "tar.gz",
+    urls = ["https://github.com/jbeder/yaml-cpp/releases/download/yaml-cpp-0.9.0/yaml-cpp-yaml-cpp-0.9.0.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.yaml.bzl---0.1.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41000,15 +41401,6 @@ starlark_repository.archive(
     urls = ["https://github.com/scottpledger/yaml.bzl/releases/download/v0.1.2/yaml.bzl-v0.1.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yams---6.2.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "Yams-6.2.1",
-    type = "tar.gz",
-    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yams---6.2.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41016,6 +41408,15 @@ starlark_repository.archive(
     strip_prefix = "Yams-6.2.2",
     type = "tar.gz",
     urls = ["https://github.com/jpsim/Yams/releases/download/6.2.2/Yams-6.2.2.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yams---6.2.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "Yams-6.2.1",
+    type = "tar.gz",
+    urls = ["https://github.com/jpsim/Yams/releases/download/6.2.1/yams-6.2.1.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.yoga---2.0.1",
@@ -41032,22 +41433,13 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/yosys/0.64/overlay",
 )
 starlark_repository.archive(
-    name = "bzl.yq.bzl---0.3.6",
+    name = "bzl.yq.bzl---0.1.1",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.3.6",
+    strip_prefix = "yq.bzl-0.1.1",
     type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.6/yq.bzl-v0.3.6.tar.gz"],
-)
-starlark_repository.archive(
-    name = "bzl.yq.bzl---0.3.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.3.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.1/yq.bzl-v0.3.1.tar.gz"],
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz"],
 )
 starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.2",
@@ -41059,15 +41451,6 @@ starlark_repository.archive(
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.2/yq.bzl-v0.3.2.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.yq.bzl---0.1.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "yq.bzl-0.1.1",
-    type = "tar.gz",
-    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.1.1/yq.bzl-v0.1.1.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.yq.bzl---0.3.4",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41075,6 +41458,24 @@ starlark_repository.archive(
     strip_prefix = "yq.bzl-0.3.4",
     type = "tar.gz",
     urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.4/yq.bzl-v0.3.4.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yq.bzl---0.3.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.3.1",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.1/yq.bzl-v0.3.1.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.yq.bzl---0.3.6",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "yq.bzl-0.3.6",
+    type = "tar.gz",
+    urls = ["https://github.com/bazel-contrib/yq.bzl/releases/download/v0.3.6/yq.bzl-v0.3.6.tar.gz"],
 )
 starlark_repository.local(
     name = "bzl.yyjson---0.10.0",
@@ -41138,30 +41539,12 @@ starlark_repository.archive(
     type = "tar.gz",
     urls = ["https://github.com/openzipkin/zipkin-api/archive/refs/tags/1.0.0.tar.gz"],
 )
-starlark_repository.archive(
-    name = "bzl.zlib---1.2.11",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.2.11",
-    type = "zip",
-    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"],
-)
 starlark_repository.local(
     name = "bzl.zlib---1.3.2",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
     languages = ["starlarkrepository"],
     path = "data/bazel-central-registry/modules/zlib/1.3.2/overlay",
-)
-starlark_repository.archive(
-    name = "bzl.zlib---1.2.13",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zlib-1.2.13",
-    type = "zip",
-    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.13.zip"],
 )
 starlark_repository.archive(
     name = "bzl.zlib---1.3",
@@ -41171,6 +41554,15 @@ starlark_repository.archive(
     strip_prefix = "zlib-1.3",
     type = "tar.gz",
     urls = ["https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz"],
+)
+starlark_repository.archive(
+    name = "bzl.zlib---1.2.11",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zlib-1.2.11",
+    type = "zip",
+    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip"],
 )
 starlark_repository.archive(
     name = "bzl.zlib---1.3.1",
@@ -41243,6 +41635,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/zlib/1.3.1.bcr.8/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.zlib---1.2.13",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zlib-1.2.13",
+    type = "zip",
+    urls = ["https://github.com/madler/zlib/archive/refs/tags/v1.2.13.zip"],
+)
+starlark_repository.archive(
     name = "bzl.zlib---1.2.12",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41277,15 +41678,6 @@ starlark_repository.archive(
     urls = ["https://github.com/google/zopfli/archive/refs/tags/zopfli-1.0.3.tar.gz"],
 )
 starlark_repository.archive(
-    name = "bzl.zstd---1.5.5.bcr.1",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    strip_prefix = "zstd-1.5.5",
-    type = "tar.gz",
-    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"],
-)
-starlark_repository.archive(
     name = "bzl.zstd---1.5.6",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41311,6 +41703,15 @@ starlark_repository.local(
     path = "data/bazel-central-registry/modules/zstd/1.5.7.bcr.1/overlay",
 )
 starlark_repository.archive(
+    name = "bzl.zstd---1.5.5.bcr.1",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    strip_prefix = "zstd-1.5.5",
+    type = "tar.gz",
+    urls = ["https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"],
+)
+starlark_repository.archive(
     name = "bzl.zstd-jni---1.5.6-9",
     build_directives = ["gazelle:starlarkrepository_root"],
     build_file_generation = "preserve",
@@ -41318,6 +41719,13 @@ starlark_repository.archive(
     strip_prefix = "zstd-jni-1.5.6-9",
     type = "zip",
     urls = ["https://github.com/luben/zstd-jni/archive/refs/tags/v1.5.6-9.zip"],
+)
+starlark_repository.local(
+    name = "bzl.zstr---1.0.7",
+    build_directives = ["gazelle:starlarkrepository_root"],
+    build_file_generation = "preserve",
+    languages = ["starlarkrepository"],
+    path = "data/bazel-central-registry/modules/zstr/1.0.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.zstr---1.1.0",
@@ -41327,13 +41735,6 @@ starlark_repository.archive(
     strip_prefix = "zstr-1.1.0",
     type = "tar.gz",
     urls = ["https://github.com/mateidavid/zstr/archive/refs/tags/v1.1.0.tar.gz"],
-)
-starlark_repository.local(
-    name = "bzl.zstr---1.0.7",
-    build_directives = ["gazelle:starlarkrepository_root"],
-    build_file_generation = "preserve",
-    languages = ["starlarkrepository"],
-    path = "data/bazel-central-registry/modules/zstr/1.0.7/overlay",
 )
 starlark_repository.archive(
     name = "bzl.zsync3---0.0.3",


### PR DESCRIPTION
Long-lived tabs can't tell when a redeploy lands — the BCR submodule advances or a code push ships and the user reads stale data. Add a Settings dropdown (Off / Notify / Auto-reload, default Notify) that opts into a 5-minute poll, with a pulsing badge over the Bazel logo when the deployed bundle has changed since the tab opened.

Backend:
- New RegistryManifest proto carrying commit_sha, commit_date, branch, and a map<basename, hashed-name> of every content-hashed asset. Captures both BCR data refreshes (commit_sha advances) and code redeploys (any hashed asset name changes).
- releasecompiler emits manifest.pb.gz at the tarball root after every other asset's HashedName is finalized, so the asset_hashes map reflects the final release.
- releaseserver no-cache match extended to include manifest.pb.gz.
- index.html declares <meta name="bcr:manifest-url">.

Runtime:
- New app/bcr/refresh.js (RefreshController): polls manifest.pb.gz every 5 min, diffs against a boot snapshot captured from the inline Registry + <script>/<link>/<meta> tags. Visibility-aware (pauses when the tab is hidden, immediate poll on resume). Cache-busts with ?t=<ms>. Emits a refresh.change event with ChangeKind = data / code / both.
- main.js builds the boot snapshot and instantiates the controller.
- app.js listens for refresh.change, toggles html.bcr-refresh-available; in Auto mode schedules a 3s reload. Click on the indicator (data-action="reload") reloads.
- common.js Application interface gains getRefreshController().

UX:
- Settings page gets the new "Registry Data Refresh" dropdown immediately after Display View Mode. Persisted via localStorage key "refresh-mode".
- Header indicator: octiconSync16 pinned to the logo, hidden by default, pulses (with prefers-reduced-motion override) on change. Uses Primer's --color-accent-emphasis for an "informational" rather than "warning" tone.

Also bumps the BCR data submodule and regenerates
data/generated.MODULE.bazel.