### PR TITLE
fix: restore square right corners on search input when scope buttons are visible

### DIFF
--- a/app/bcr/style.css
+++ b/app/bcr/style.css
@@ -119,7 +119,7 @@ pre code {
  * once the pills are visible; below md the input keeps its natural
  * full border so it doesn't look amputated. */
 @media (min-width: 768px) {
-	.search-scope-fused {
+	.form-control.search-scope-fused {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 		border-right: 0;


### PR DESCRIPTION
PR #517 added `.search-scope-fused` to flatten the input's right edge where it meets the All/Modules/Symbols BtnGroup, but the rule never took effect: bcr.css loads before primer.css in index.html, and primer's `.form-control { border-radius: 6px; border: 1px solid }` has equal specificity (0,1,0), so it wins on cascade order and re-rounds all four corners.

Bump the override to `.form-control.search-scope-fused` (specificity 0,2,0) so it wins regardless of load order. Mobile (<768px) behavior is unchanged — the BtnGroup is still hidden and the input keeps its natural fully-rounded corners.
