### PR TITLE
Quiet progress bars in CI (bcr gazelle extension)

### DIFF
--- a/bazel_tools/deps/go.MODULE.bazel
+++ b/bazel_tools/deps/go.MODULE.bazel
@@ -32,6 +32,7 @@ use_repo(
     "org_golang_google_protobuf",
     "org_golang_x_oauth2",
     "org_golang_x_sync",
+    "org_golang_x_term",
     "org_golang_x_time",
 )
 go_deps.gazelle_override(

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.starlark.net v0.0.0-20260326113308-fadfc96def35
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/term v0.41.0
 	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.11
@@ -49,7 +50,6 @@ require (
 	golang.org/x/mod v0.25.0 // indirect
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/tools/go/vcs v0.1.0-deprecated // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect

--- a/language/bcr/BUILD.bazel
+++ b/language/bcr/BUILD.bazel
@@ -61,7 +61,6 @@ go_library(
         "@com_github_bazelbuild_buildtools//build",
         "@com_github_dominikbraun_graph//:graph",
         "@com_github_google_go_github_v66//github",
-        "@com_github_schollz_progressbar_v3//:progressbar",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/language/bcr/github.go
+++ b/language/bcr/github.go
@@ -11,7 +11,7 @@ import (
 
 	bzpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/registry/v1"
 	"github.com/bazel-contrib/bcr-frontend/pkg/gh"
-	"github.com/schollz/progressbar/v3"
+	"github.com/bazel-contrib/bcr-frontend/pkg/netutil"
 )
 
 func (ext *bcrExtension) configureGithubClient() {
@@ -250,18 +250,7 @@ func (ext *bcrExtension) resolveSourceCommitSHAsForRankedModules(rankedModules r
 	log.Printf("Resolving commit SHAs for %d unique GitHub source URLs from ranked modules...", totalURLs)
 
 	// Create progress bar
-	bar := progressbar.NewOptions(totalURLs,
-		progressbar.OptionSetDescription("Resolving commit SHAs (ranked)"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWidth(40),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "=",
-			SaucerHead:    ">",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
+	bar := netutil.NewProgressBar("Resolving commit SHAs (ranked)", totalURLs)
 
 	// Convert to the format expected by BatchResolveSourceCommits
 	batchInfos := make([]struct {
@@ -417,18 +406,7 @@ func (ext *bcrExtension) resolveSourceCommitSHAsForLatestVersions() {
 	log.Printf("Resolving commit SHAs for %d unique GitHub source URLs from latest versions...", totalURLs)
 
 	// Create progress bar
-	bar := progressbar.NewOptions(totalURLs,
-		progressbar.OptionSetDescription("Resolving commit SHAs"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWidth(40),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "=",
-			SaucerHead:    ">",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
+	bar := netutil.NewProgressBar("Resolving commit SHAs", totalURLs)
 
 	// Convert to the format expected by BatchResolveSourceCommits
 	batchInfos := make([]struct {
@@ -528,18 +506,7 @@ func (ext *bcrExtension) fetchPRAuthors() {
 	batchSize := 500
 	totalFetched := 0
 
-	bar := progressbar.NewOptions(len(prNumbers),
-		progressbar.OptionSetDescription("Fetching PR authors"),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWidth(40),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "=",
-			SaucerHead:    ">",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
+	bar := netutil.NewProgressBar("Fetching PR authors", len(prNumbers))
 
 	for i := 0; i < len(prNumbers); i += batchSize {
 		end := min(i+batchSize, len(prNumbers))

--- a/pkg/netutil/BUILD.bazel
+++ b/pkg/netutil/BUILD.bazel
@@ -2,8 +2,14 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "netutil",
-    srcs = ["netutil.go"],
+    srcs = [
+        "netutil.go",
+        "progress.go",
+    ],
     importpath = "github.com/bazel-contrib/bcr-frontend/pkg/netutil",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_schollz_progressbar_v3//:progressbar"],
+    deps = [
+        "@com_github_schollz_progressbar_v3//:progressbar",
+        "@org_golang_x_term//:term",
+    ],
 )

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"sync"
 	"time"
-
-	"github.com/schollz/progressbar/v3"
 )
 
 const connectionAvailableDuration = 250 * time.Millisecond
@@ -118,18 +116,12 @@ func CheckURLsParallel[T any](desc string, items []T, getURL func(T) string, onR
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
-	bar := progressbar.NewOptions(total,
-		progressbar.OptionSetDescription(desc),
-		progressbar.OptionShowCount(),
-		progressbar.OptionSetWidth(40),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "=",
-			SaucerHead:    ">",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
+	// In non-interactive output the animated bar is suppressed, so emit a
+	// single breadcrumb line per phase instead.
+	if !Interactive() {
+		log.Printf("%s (%d URLs)", desc, total)
+	}
+	bar := NewProgressBar(desc, total)
 
 	urlChan := make(chan struct {
 		index int

--- a/pkg/netutil/progress.go
+++ b/pkg/netutil/progress.go
@@ -1,0 +1,45 @@
+package netutil
+
+import (
+	"io"
+	"os"
+
+	"github.com/schollz/progressbar/v3"
+	"golang.org/x/term"
+)
+
+// Interactive reports whether animated progress output is appropriate: stderr
+// is a terminal and we are not running in CI. Progress bars animate on every
+// update, which is noise in non-interactive logs, so callers should render a
+// single summary line instead when this returns false.
+func Interactive() bool {
+	if os.Getenv("CI") != "" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// NewProgressBar returns the shared-themed animated progress bar when
+// Interactive(), otherwise a silent no-op bar that renders nothing. The
+// returned bar is always safe to call Add/Finish on, so call sites need no
+// branching of their own.
+func NewProgressBar(desc string, total int) *progressbar.ProgressBar {
+	if !Interactive() {
+		return progressbar.NewOptions(total,
+			progressbar.OptionSetVisibility(false),
+			progressbar.OptionSetWriter(io.Discard),
+		)
+	}
+	return progressbar.NewOptions(total,
+		progressbar.OptionSetDescription(desc),
+		progressbar.OptionShowCount(),
+		progressbar.OptionSetWidth(40),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "=",
+			SaucerHead:    ">",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
+}


### PR DESCRIPTION
The bcr gazelle extension rendered schollz/progressbar/v3 bars to stderr unconditionally. Because the library animates on every bar.Add, phases like "Checking attestation URLs" flooded CI logs with a line per URL.

Add a shared netutil.NewProgressBar(desc, total) helper gated on netutil.Interactive() (stderr is a TTY and CI is unset):
- interactive: the existing animated, themed bar (unchanged behavior)
- non-interactive: a silent no-op bar (OptionSetVisibility(false) + io.Discard), so callers can Add/Finish without branching

Route all four bar sites through the helper — CheckURLsParallel (backs the three "Checking ..." phases) and the three github.go bars ("Resolving commit SHAs (ranked)", "Resolving commit SHAs", "Fetching PR authors"). In CI, CheckURLsParallel now logs one "<desc> (N URLs)" breadcrumb per phase; the github.go phases already log a start line. This also de-duplicates the progress-bar theme that was copied across all four sites.

Promotes golang.org/x/term to a direct dependency; regenerates BUILD files (drops the progressbar dep from language/bcr).