### PR TITLE
fix: missing "tag" field on git_override

### DIFF
--- a/build/stack/bazel/registry/v1/bcr.pb.go
+++ b/build/stack/bazel/registry/v1/bcr.pb.go
@@ -1685,6 +1685,7 @@ type GitOverride struct {
 	Patches       []string               `protobuf:"bytes,3,rep,name=patches,proto3" json:"patches,omitempty"`
 	Remote        string                 `protobuf:"bytes,4,opt,name=remote,proto3" json:"remote,omitempty"`
 	Branch        string                 `protobuf:"bytes,5,opt,name=branch,proto3" json:"branch,omitempty"`
+	Tag           string                 `protobuf:"bytes,6,opt,name=tag,proto3" json:"tag,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/build/stack/bazel/registry/v1/bcr.proto
+++ b/build/stack/bazel/registry/v1/bcr.proto
@@ -380,6 +380,8 @@ message GitOverride {
     string remote = 4;
     // Git branch name
     string branch = 5;
+    // Git tag name
+    string tag = 6;
 }
 
 // Override dependency with an archive download

--- a/language/bcr/git_override.go
+++ b/language/bcr/git_override.go
@@ -44,6 +44,9 @@ func makeGitOverrideRule(moduleName string, override *bzpb.GitOverride) *rule.Ru
 	if len(override.Patches) > 0 {
 		r.SetAttr("patches", override.Patches)
 	}
+	if override.Tag != "" {
+		r.SetAttr("tag", override.Tag)
+	}
 	r.SetAttr("visibility", []string{"//visibility:public"})
 	return r
 }

--- a/pkg/modulebazel/modulebazel.go
+++ b/pkg/modulebazel/modulebazel.go
@@ -157,6 +157,7 @@ func addOverride(dep *bzpb.ModuleDependency, moduleName string, overrides map[st
 				Branch:     overrideRule.AttrString("branch"),
 				PatchStrip: parseInt32(overrideRule.AttrString("patch_strip")),
 				Patches:    overrideRule.AttrStrings("patches"),
+				Tag:        overrideRule.AttrString("tag"),
 			},
 		}
 	case "archive_override":

--- a/pkg/modulebazel/predeclared.go
+++ b/pkg/modulebazel/predeclared.go
@@ -101,7 +101,7 @@ func makeBazelDepBuiltin(module *bzpb.ModuleVersion) goStarlarkFunction {
 
 func makeGitOverrideBuiltin(module *bzpb.ModuleVersion) goStarlarkFunction {
 	return func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-		var moduleName, commit, remote, branch string
+		var moduleName, commit, remote, branch, tag string
 		var patchStrip int
 		patches := &starlark.List{}
 
@@ -112,6 +112,7 @@ func makeGitOverrideBuiltin(module *bzpb.ModuleVersion) goStarlarkFunction {
 			"branch?", &branch,
 			"patch_strip?", &patchStrip,
 			"patches?", &patches,
+			"tag?", &tag,
 		); err != nil {
 			return nil, fmt.Errorf("unpack error: %v", err)
 		}
@@ -125,6 +126,7 @@ func makeGitOverrideBuiltin(module *bzpb.ModuleVersion) goStarlarkFunction {
 					Branch:     branch,
 					PatchStrip: int32(patchStrip),
 					Patches:    mustGetStringSlice(patches),
+					Tag:        tag,
 				},
 			},
 		}

--- a/rules/git_override.bzl
+++ b/rules/git_override.bzl
@@ -14,6 +14,7 @@ def _git_override_impl(ctx):
             branch = ctx.attr.branch,
             patch_strip = ctx.attr.patch_strip,
             patches = ctx.attr.patches,
+            tag = ctx.attr.tag,
         ),
     ]
 
@@ -40,6 +41,9 @@ git_override = rule(
         ),
         "patches": attr.string_list(
             doc = "list[str]: Patch file paths",
+        ),
+        "tag": attr.string(
+            doc = "str: Git tag name",
         ),
     },
     provides = [ModuleOverrideInfo, GitOverrideInfo],

--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -152,6 +152,7 @@ GitOverrideInfo = provider(
         "branch": "str: Git branch name",
         "patch_strip": "int: Number of leading path components to strip from patches",
         "patches": "list[str]: Patch file paths",
+        "tag": "str: Git tag name",
     },
 )
 


### PR DESCRIPTION
Closes #537.

I have no idea what I'm doing, I just pattern-matched the `branch` name with a `tag` name.  This changes `make bcr` from failing to passing for me locally.