### PR TITLE
perf: stop loading symbols.pb.gz and packages.pb.gz at boot

### DIFF
--- a/app/bcr/app.js
+++ b/app/bcr/app.js
@@ -38,9 +38,9 @@ const { registryApp, toastSuccess } = goog.require("soy.bcrfrontend.app");
 class RegistryApp extends App {
 	/**
 	 * @param {!Registry} registry
-	 * @param {!Promise<!Registry>} registryWithSymbols
-	 * @param {!Promise<!Registry>} registryWithPackages
-	 * @param {!Promise<*>} ruleUsageIndex resolves to Map<urlKey, Array<TargetRef>>.
+	 * @param {function():!Promise<!Registry>} registryWithSymbols memoized lazy loader.
+	 * @param {function():!Promise<!Registry>} registryWithPackages memoized lazy loader.
+	 * @param {function():!Promise<*>} ruleUsageIndex memoized lazy loader; resolves to Map<urlKey, Array<TargetRef>>.
 	 * @param {function():!Promise<*>} bazelFlagDbLoader memoized lazy loader.
 	 * @param {!RefreshController} refreshController
 	 * @param {?dom.DomHelper=} opt_domHelper
@@ -59,14 +59,17 @@ class RegistryApp extends App {
 		/** @private @const */
 		this.registry_ = registry;
 
-		/** @private @const */
-		this.registryWithSymbols_ = registryWithSymbols;
+		/** @private @const @type {function():!Promise<!Registry>} */
+		this.registryWithSymbolsLoader_ = registryWithSymbols;
 
-		/** @private @const */
-		this.registryWithPackages_ = registryWithPackages;
+		/** @private @const @type {function():!Promise<!Registry>} */
+		this.registryWithPackagesLoader_ = registryWithPackages;
 
-		/** @private @const */
-		this.ruleUsageIndex_ = ruleUsageIndex;
+		/** @private @const @type {function():!Promise<*>} */
+		this.ruleUsageIndexLoader_ = ruleUsageIndex;
+
+		/** @private @type {boolean} */
+		this.symbolsRequested_ = false;
 
 		/** @private @const @type {function():!Promise<*>} */
 		this.bazelFlagDbLoader_ = bazelFlagDbLoader;
@@ -89,7 +92,7 @@ class RegistryApp extends App {
 		/** @const @private @type {!UnifiedSearchHandler} */
 		this.unifiedSearchHandler_ = new UnifiedSearchHandler(
 			this.registry_,
-			this.registryWithSymbols_,
+			this.registryWithSymbolsLoader_,
 		);
 
 		/** @private @type {?SearchComponent} */
@@ -134,29 +137,50 @@ class RegistryApp extends App {
 
 	/**
 	 * Returns the promise that resolves when symbols are loaded and decorated.
+	 * Calling this starts the symbols.pb.gz fetch if it hasn't started yet, so
+	 * only call it from a code path that genuinely needs symbols.
 	 * @override
 	 * @returns {!Promise<!Registry>}
 	 */
 	getRegistryWithSymbols() {
-		return this.registryWithSymbols_;
+		this.symbolsRequested_ = true;
+		return this.registryWithSymbolsLoader_();
+	}
+
+	/**
+	 * Returns the symbols promise, but only if something has already asked for
+	 * symbols for a reason that actually needs them.
+	 *
+	 * The side-pane "Symbols" count is the only consumer. It used to call
+	 * getRegistryWithSymbols() from the home page, the modules list, the
+	 * maintainers page and both bazel pages — which meant ~56MB of protobuf
+	 * was fetched and parsed on nearly every route to render one number. This
+	 * lets those call sites update opportunistically instead.
+	 *
+	 * @returns {?Promise<!Registry>} null if symbols haven't been requested.
+	 */
+	getRegistryWithSymbolsIfLoaded() {
+		return this.symbolsRequested_ ? this.registryWithSymbolsLoader_() : null;
 	}
 
 	/**
 	 * Returns the promise that resolves when packages are loaded and decorated.
+	 * Calling this starts the packages.pb.gz fetch if it hasn't started yet.
 	 * @override
 	 * @returns {!Promise<!Registry>}
 	 */
 	getRegistryWithPackages() {
-		return this.registryWithPackages_;
+		return this.registryWithPackagesLoader_();
 	}
 
 	/**
-	 * Returns the promise that resolves to the rule-usage index.
+	 * Returns the promise that resolves to the rule-usage index. Calling this
+	 * pulls in packages.pb.gz.
 	 * @override
 	 * @returns {!Promise<*>}
 	 */
 	getRuleUsageIndex() {
-		return this.ruleUsageIndex_;
+		return this.ruleUsageIndexLoader_();
 	}
 
 	/**

--- a/app/bcr/app.soy
+++ b/app/bcr/app.soy
@@ -350,7 +350,10 @@ import {
   <a class="Link--primary d-flex flex-items-center mb-2" href="/docs">
     <span class="color-fg-muted">Symbols</span>
     <span class="dotted-leader"></span>
-    <span class="text-bold js-symbols-count">{$totalSymbols}</span>
+    /* Symbols are lazily loaded, so the count is unknown until something
+       pulls symbols.pb.gz in. Render a dash rather than a misleading 0;
+       refreshBcrSidePaneSymbols fills it in if/when symbols arrive. */
+    <span class="text-bold js-symbols-count">{$totalSymbols > 0 ? $totalSymbols : '—'}</span>
   </a>
   <a class="Link--primary d-flex flex-items-center mb-2" href="/bazel/versions">
     <span class="color-fg-muted">Bazel Versions</span>

--- a/app/bcr/bazel.js
+++ b/app/bcr/bazel.js
@@ -234,12 +234,15 @@ class BazelOverviewSelectNav extends SelectNav {
 			() => new BazelVersionsComponent(this.registry_, this.dom_),
 		);
 
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 	}
 }
 
@@ -318,12 +321,15 @@ class BazelVersionDetailComponent extends Component {
 	 */
 	enterDocument() {
 		super.enterDocument();
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 	}
 }
 

--- a/app/bcr/bazel_flags.js
+++ b/app/bcr/bazel_flags.js
@@ -294,12 +294,15 @@ class BazelFlagsListSelectNav extends SelectNav {
 			() => new BazelFlagsCommandsComponent(this.registry_, this.dom_),
 		);
 
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 
 		// Inject counts into the three nav tabs once the DB loads.
 		// addNavTabLazy was called with count=undefined so the Counter badges

--- a/app/bcr/common.js
+++ b/app/bcr/common.js
@@ -56,9 +56,19 @@ class Application {
 
 	/**
 	 * Returns a promise that resolves when symbols are loaded and decorated.
+	 * Calling this starts the symbols.pb.gz fetch if it hasn't started yet, so
+	 * only call it where symbols are genuinely needed.
 	 * @returns {!Promise<*>}
 	 */
 	getRegistryWithSymbols() {}
+
+	/**
+	 * Like getRegistryWithSymbols, but returns null instead of starting the
+	 * fetch when symbols haven't been requested yet. For cosmetic consumers
+	 * (the side-pane symbol count) that shouldn't pull in ~56MB of protobuf.
+	 * @returns {?Promise<*>}
+	 */
+	getRegistryWithSymbolsIfLoaded() {}
 
 	/**
 	 * Returns a promise that resolves when packages (BUILD-file extraction) are

--- a/app/bcr/home.js
+++ b/app/bcr/home.js
@@ -163,12 +163,15 @@ class HomeOverviewSelectNav extends SelectNav {
 			() => new HomeRecentlyAddedComponent(this.registry_, this.dom_),
 		);
 
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 	}
 }
 

--- a/app/bcr/main.js
+++ b/app/bcr/main.js
@@ -30,15 +30,23 @@ async function main(registryDataBase64) {
 	);
 	setupRegistry(registry);
 
-	// Create lazy-loading promise for registry with symbols
-	const registryWithSymbols = createRegistryWithSymbolsPromise(registry);
+	// Memoized loaders for the two big aggregates. Neither is fetched until
+	// something actually asks for it.
+	//
+	// These used to be started here at boot, on every page load and every
+	// route. Together they are ~83MB of protobuf (symbols.pb.gz decompresses
+	// to ~56MB, packages.pb.gz to ~28MB) and they expanded to roughly 684MB
+	// of the ~742MB retained heap -- enough to blow past mobile Safari's
+	// per-tab cap, which killed the WebContent process and put the tab into a
+	// reload/crash loop. The home page needs neither: symbols are for the
+	// search index and the Documentation tab, packages for the Packages tab
+	// and the rule-usage index.
+	const registryWithSymbols = createRegistryWithSymbolsLoader(registry);
+	const registryWithPackages = createRegistryWithPackagesLoader(registry);
 
-	// Same shape for the BUILD-file extraction registry.
-	const registryWithPackages = createRegistryWithPackagesPromise(registry);
-
-	// Derived index: load-coordinate → list of usages. Built once when the
-	// packages.pb.gz fetch resolves.
-	const ruleUsageIndex = registryWithPackages.then(buildRuleUsageIndex);
+	// Derived index: load-coordinate → list of usages. Built on first use,
+	// which also pulls in packages.pb.gz.
+	const ruleUsageIndex = createRuleUsageIndexLoader(registryWithPackages);
 
 	// One-shot lazy loader for the bazel flag db. The first call kicks off
 	// the fetch; subsequent calls reuse the cached promise.
@@ -202,61 +210,98 @@ function decorateRegistryWithPackages(registry, packagesRegistry) {
 }
 
 /**
- * Creates a Promise that fetches packages.pb.gz and decorates the registry.
+ * Builds a memoized loader that fetches packages.pb.gz and decorates the
+ * registry. The fetch starts on the first call, not at boot — see the note in
+ * main() for why that matters.
+ *
  * @param {!Registry} registry The base registry to decorate
- * @returns {!Promise<!Registry>} Promise that resolves to decorated registry
+ * @returns {function():!Promise<!Registry>}
  */
-function createRegistryWithPackagesPromise(registry) {
-	return (async () => {
-		try {
-			const url = metaUrl("bcr:packages-url");
-			if (!url) {
-				throw new Error("packages URL not set in <meta name=bcr:packages-url>");
+function createRegistryWithPackagesLoader(registry) {
+	/** @type {?Promise<!Registry>} */
+	let cached = null;
+	return () => {
+		if (cached) return cached;
+		cached = (async () => {
+			try {
+				const url = metaUrl("bcr:packages-url");
+				if (!url) {
+					throw new Error(
+						"packages URL not set in <meta name=bcr:packages-url>",
+					);
+				}
+				const response = await fetch(url);
+				if (!response.ok) {
+					throw new Error(`Failed to fetch ${url}: ${response.status}`);
+				}
+				const gzipData = new Uint8Array(await response.arrayBuffer());
+				const decompressed = await gzipDecode(gzipData);
+				const packagesRegistry =
+					ModuleRegistryPackages.deserializeBinary(decompressed);
+				decorateRegistryWithPackages(registry, packagesRegistry);
+				return registry;
+			} catch (/** @type {*} */ e) {
+				console.error("Failed to load packages:", e);
+				return registry;
 			}
-			const response = await fetch(url);
-			if (!response.ok) {
-				throw new Error(`Failed to fetch ${url}: ${response.status}`);
-			}
-			const gzipData = new Uint8Array(await response.arrayBuffer());
-			const decompressed = await gzipDecode(gzipData);
-			const packagesRegistry =
-				ModuleRegistryPackages.deserializeBinary(decompressed);
-			decorateRegistryWithPackages(registry, packagesRegistry);
-			return registry;
-		} catch (/** @type {*} */ e) {
-			console.error("Failed to load packages:", e);
-			return registry;
-		}
-	})();
+		})();
+		return cached;
+	};
 }
 
 /**
- * Creates a Promise that fetches symbols.pb.gz and decorates the registry.
+ * Builds a memoized loader that fetches symbols.pb.gz and decorates the
+ * registry. As with packages, nothing is fetched until first use.
+ *
  * @param {!Registry} registry The base registry to decorate
- * @returns {!Promise<!Registry>} Promise that resolves to decorated registry
+ * @returns {function():!Promise<!Registry>}
  */
-function createRegistryWithSymbolsPromise(registry) {
-	return (async () => {
-		try {
-			const url = metaUrl("bcr:symbols-url");
-			if (!url) {
-				throw new Error("symbols URL not set in <meta name=bcr:symbols-url>");
+function createRegistryWithSymbolsLoader(registry) {
+	/** @type {?Promise<!Registry>} */
+	let cached = null;
+	return () => {
+		if (cached) return cached;
+		cached = (async () => {
+			try {
+				const url = metaUrl("bcr:symbols-url");
+				if (!url) {
+					throw new Error("symbols URL not set in <meta name=bcr:symbols-url>");
+				}
+				const response = await fetch(url);
+				if (!response.ok) {
+					throw new Error(`Failed to fetch ${url}: ${response.status}`);
+				}
+				const gzipData = new Uint8Array(await response.arrayBuffer());
+				const decompressed = await gzipDecode(gzipData);
+				const symbolsRegistry =
+					ModuleRegistrySymbols.deserializeBinary(decompressed);
+				decorateRegistryWithSymbols(registry, symbolsRegistry);
+				return registry;
+			} catch (/** @type {*} */ e) {
+				console.error("Failed to load symbols:", e);
+				return registry; // Graceful degradation
 			}
-			const response = await fetch(url);
-			if (!response.ok) {
-				throw new Error(`Failed to fetch ${url}: ${response.status}`);
-			}
-			const gzipData = new Uint8Array(await response.arrayBuffer());
-			const decompressed = await gzipDecode(gzipData);
-			const symbolsRegistry =
-				ModuleRegistrySymbols.deserializeBinary(decompressed);
-			decorateRegistryWithSymbols(registry, symbolsRegistry);
-			return registry;
-		} catch (/** @type {*} */ e) {
-			console.error("Failed to load symbols:", e);
-			return registry; // Graceful degradation
-		}
-	})();
+		})();
+		return cached;
+	};
+}
+
+/**
+ * Builds a memoized loader for the rule-usage index. Deriving it requires the
+ * packages aggregate, so this is what pulls packages.pb.gz in for the Targets
+ * view.
+ *
+ * @param {function():!Promise<!Registry>} packagesLoader
+ * @returns {function():!Promise<*>}
+ */
+function createRuleUsageIndexLoader(packagesLoader) {
+	/** @type {?Promise<*>} */
+	let cached = null;
+	return () => {
+		if (cached) return cached;
+		cached = packagesLoader().then(buildRuleUsageIndex);
+		return cached;
+	};
 }
 
 /**

--- a/app/bcr/maintainers.js
+++ b/app/bcr/maintainers.js
@@ -182,12 +182,15 @@ class MaintainersMapSelectNav extends SelectNav {
 
 		this.enterAllTab();
 
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 	}
 
 	enterAllTab() {

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -1511,12 +1511,15 @@ class ModulesMapSelectNav extends SelectNav {
 		this.enterAllTab();
 		this.enterSearchTab();
 
-		getApplication(this)
-			.getRegistryWithSymbols()
-			.then(() => {
+		// Side-pane symbol count only. Refresh it if symbols happen to be
+		// loaded already, but never fetch symbols.pb.gz just for a number.
+		const symbols = getApplication(this).getRegistryWithSymbolsIfLoaded();
+		if (symbols) {
+			symbols.then(() => {
 				if (this.isDisposed()) return;
 				refreshBcrSidePaneSymbols(this.getElement(), this.registry_);
 			});
+		}
 	}
 
 	enterSearchTab() {

--- a/app/bcr/unified_search.js
+++ b/app/bcr/unified_search.js
@@ -53,16 +53,18 @@ exports.SCOPE_SYMBOLS = SCOPE_SYMBOLS;
 class UnifiedSearchHandler extends EventTarget {
 	/**
 	 * @param {!Registry} registry
-	 * @param {!Promise<!Registry>} registryWithSymbols
+	 * @param {function():!Promise<!Registry>} registryWithSymbolsLoader memoized
+	 *     lazy loader. Invoking it starts the symbols.pb.gz fetch, so it is
+	 *     deliberately not called until the user actually searches.
 	 */
-	constructor(registry, registryWithSymbols) {
+	constructor(registry, registryWithSymbolsLoader) {
 		super();
 
 		/** @private @const @type {!Registry} */
 		this.registry_ = registry;
 
-		/** @private @const @type {!Promise<!Registry>} */
-		this.registryWithSymbols_ = registryWithSymbols;
+		/** @private @const @type {function():!Promise<!Registry>} */
+		this.registryWithSymbolsLoader_ = registryWithSymbolsLoader;
 
 		/** @private @const @type {!Map<string, !Entry>} */
 		this.entries_ = new Map();
@@ -173,6 +175,9 @@ class UnifiedSearchHandler extends EventTarget {
 	 * @return {!Array<string>}
 	 */
 	getActiveKeys() {
+		// First actual match request is what pulls symbols.pb.gz in. See
+		// ensureSymbols_ for why this isn't done at load() time.
+		this.ensureSymbols_();
 		if (this.scope_ === SCOPE_MODULES) {
 			return this.moduleKeys_;
 		}
@@ -183,11 +188,34 @@ class UnifiedSearchHandler extends EventTarget {
 	}
 
 	/**
+	 * Kicks off the symbols fetch exactly once, and indexes symbols when it
+	 * lands. Fire-and-forget: the ScopedMatcher picks up the appended symbol
+	 * keys on the next match request, so the first keystroke searches modules
+	 * only and symbols fold in a moment later without an AC rebuild.
+	 *
+	 * This deliberately does NOT happen in load(). load() runs during boot
+	 * (App wires up the "all" provider immediately), and symbols.pb.gz is
+	 * ~56MB of protobuf that expands to hundreds of MB of JS objects -- enough
+	 * to get the tab killed on mobile Safari before the user has typed
+	 * anything.
+	 *
+	 * @private
+	 */
+	ensureSymbols_() {
+		if (this.symbolsRequested_) return;
+		this.symbolsRequested_ = true;
+		this.registryWithSymbolsLoader_().then((registry) => {
+			this.indexSymbols_(registry);
+			this.provider_.desc = `Search ${this.moduleKeys_.length} modules and ${this.symbolKeys_.length} symbols`;
+		});
+	}
+
+	/**
 	 * Synchronously indexes modules and creates the AC the first time it's
-	 * called. The symbols.pb.gz promise is kicked off but NOT awaited —
-	 * load() resolves as soon as modules are searchable so SearchComponent
-	 * can attach the input handler immediately. The ScopedMatcher picks
-	 * up symbols later without any AC rebuild.
+	 * called. Symbols are NOT requested here — App attaches the "all" provider
+	 * during boot, so fetching them from load() would put ~56MB of protobuf on
+	 * every page load. ensureSymbols_ handles that on the first match request
+	 * instead.
 	 * @return {!Promise<void>}
 	 */
 	async load() {
@@ -197,15 +225,6 @@ class UnifiedSearchHandler extends EventTarget {
 		}
 		if (!this.ac_) {
 			this.createAutoComplete_();
-		}
-		if (!this.symbolsRequested_) {
-			this.symbolsRequested_ = true;
-			// Fire-and-forget. The ScopedMatcher will see the appended symbol
-			// keys on the next match request.
-			this.registryWithSymbols_.then((registry) => {
-				this.indexSymbols_(registry);
-				this.provider_.desc = `Search ${this.moduleKeys_.length} modules and ${this.symbolKeys_.length} symbols`;
-			});
 		}
 	}
 


### PR DESCRIPTION
main() started both aggregate fetches immediately on every page load, on every route. Together they are ~83MB of protobuf (symbols.pb.gz decompresses to ~56MB, packages.pb.gz to ~28MB) and they accounted for ~684MB of the ~742MB retained heap. That is what exceeded mobile Safari's per-tab memory cap: iOS killed the WebContent process with `highwater`, Safari reloaded the tab, and it repeated until Safari gave up.

Both are now memoized lazy loaders, matching createBazelFlagDbLoader. Nothing fetches until a consumer actually asks:

  - Documentation tab / /docs route  -> symbols
  - Packages tab, Targets, rule-usage index -> packages
  - first search keystroke -> symbols

Search needed care. App attaches the "all" provider during boot, so UnifiedSearchHandler.load() runs at boot and used to kick off symbols there. The fetch moved to ensureSymbols_(), triggered from getActiveKeys() on the first real match request. Behaviour is unchanged from the user's side: the first keystroke searches modules and symbols fold in when they land, which is what the ScopedMatcher already did.

The other eager consumer was the side-pane "Symbols" count. Six call sites (home, modules list, maintainers, both bazel pages) awaited symbols purely to fill one number, which is why ~56MB was fetched on nearly every route. They now use getRegistryWithSymbolsIfLoaded(), which refreshes the count if symbols happen to be loaded and never triggers the fetch itself. Since the count is unknown until then, the side pane renders an em-dash instead of a misleading 0.

Measured on the home page (headless Chrome, retained heap after forced GC, serving the production bundle locally):

  before  742.4 MB   (peak 902.1 MB)
  after    58.0 MB   (peak 103.9 MB)

Note the "after" figure is measured with the two assets withheld from the server, which is behaviourally what this change produces on the home route but is not a run of the rebuilt bundle -- that needs bazel.

Follow-up: the side-pane symbol count could be computed at build time (a Registry field or an index.html meta tag) so it stays exact everywhere without loading symbols at all.