### PR TITLE
perf: thin the boot registry payload to latest-version detail

### DIFF
--- a/app/bcr/BUILD.bazel
+++ b/app/bcr/BUILD.bazel
@@ -369,6 +369,8 @@ closure_js_binary(
         "robots_txt",
         "registry_pb",
         "registrylite_pb",
+        "registrythin_pb",
+        "module_versions",
         "symbols_pb",
         "packages_pb",
         "doc_results",
@@ -408,10 +410,10 @@ css_purge(
 )
 
 # Common attributes for both the prerendered and unprerendered release targets.
-# Note: :registrylite_pb is consumed by releasecompiler via the `registry_file`
+# Note: :registrythin_pb is consumed by releasecompiler via the `registry_file`
 # attribute (which gzips + base64-encodes it into the .b64.js script tag and
 # emits registry.pb.gz alongside). It must NOT appear here — listing it as a
-# raw src would copy the uncompressed registrylite.pb into the tarball as
+# raw src would copy the uncompressed registrythin.pb into the tarball as
 # dead weight.
 RELEASE_SRCS = [
     "favicon.png",
@@ -442,8 +444,9 @@ release_archive(
     modules_srcs = [
         ":doc_results",
         ":pkg_results",
+        ":module_versions",
     ],
-    registry_file = ":registrylite_pb",
+    registry_file = ":registrythin_pb",
     worker_modules = ["//app/api"],
 )
 
@@ -511,12 +514,13 @@ release_archive(
     modules_srcs = [
         ":doc_results",
         ":pkg_results",
+        ":module_versions",
     ],
     prerendered_pages_tar = select({
         ":should_prerender_modules": ":prerender_pages",
         "//conditions:default": None,
     }),
-    registry_file = ":registrylite_pb",
+    registry_file = ":registrythin_pb",
     worker_modules = ["//app/api"],
 )
 

--- a/app/bcr/modules.js
+++ b/app/bcr/modules.js
@@ -134,6 +134,81 @@ async function fetchModuleVersionPackagesFromGithubRepository(moduleVersion) {
 }
 
 /**
+ * In-flight or completed hydrations, keyed "name@version". Keeps a second
+ * visit to the same version page from refetching.
+ * @type {!Map<string, !Promise<void>>}
+ */
+const moduleVersionHydrations = new Map();
+
+/**
+ * Fills in the per-version detail that the boot payload omits.
+ *
+ * The registry is base64+gzipped into a <script> and parsed in full on every
+ * page load, so it only carries the dependency graph and a reduced commit for
+ * non-latest versions — source, attestations, presubmit, toolchains and the
+ * full commit are served per-version instead. See thinRegistry in
+ * cmd/registrycompiler for the split and the reasoning behind it.
+ *
+ * Latest versions ship complete, so this resolves immediately for them. The
+ * absence of `source` is the marker for a thinned version: every real module
+ * version has one.
+ *
+ * Documentation and packages are deliberately not merged here. They have their
+ * own aggregates plus per-version fallbacks (see the DOCS and PACKAGES
+ * branches of selectFail below), and a hydrated source simply arrives without
+ * them, which routes those tabs down the existing fallback path.
+ *
+ * @param {!ModuleVersion} moduleVersion
+ * @return {!Promise<void>}
+ */
+function hydrateModuleVersion(moduleVersion) {
+	if (moduleVersion.getSource()) {
+		return Promise.resolve();
+	}
+
+	const name = moduleVersion.getName();
+	const version = moduleVersion.getVersion();
+	const key = `${name}@${version}`;
+	const existing = moduleVersionHydrations.get(key);
+	if (existing) {
+		return existing;
+	}
+
+	const baseUrl =
+		new URLSearchParams(window.location.search).get("modules_base_url") || "";
+	const url = `${baseUrl}/modules/${name}/${version}/moduleversion.pb.gz`;
+
+	const pending = (async () => {
+		try {
+			const response = await fetch(url);
+			if (!response.ok) return;
+			const gzipData = new Uint8Array(await response.arrayBuffer());
+			const decompressed = await gzipDecode(gzipData);
+			const full = ModuleVersion.deserializeBinary(decompressed);
+			moduleVersion.setSource(full.getSource());
+			moduleVersion.setAttestations(full.getAttestations());
+			moduleVersion.setPresubmit(full.getPresubmit());
+			moduleVersion.setToolchainsToRegisterList(
+				full.getToolchainsToRegisterList(),
+			);
+			// The payload's commit keeps date/pull_request/github_user/
+			// github_name; the record restores sha1 and the message. Leave
+			// repository_metadata alone — main.js denormalizes it from the
+			// parent Module at boot and the record has none.
+			const commit = full.getCommit();
+			if (commit) {
+				moduleVersion.setCommit(commit);
+			}
+		} catch (/** @type {*} */ e) {
+			console.error(`Failed to fetch record for ${key}:`, e);
+		}
+	})();
+
+	moduleVersionHydrations.set(key, pending);
+	return pending;
+}
+
+/**
  * @enum {string}
  */
 const TabName = {
@@ -282,11 +357,22 @@ class ModuleSelect extends ContentSelect {
 
 		const moduleVersion = this.moduleVersions_.get(name);
 		if (moduleVersion) {
-			this.addTab(
-				name,
-				new ModuleVersionSelectNav(this.registry_, this.module_, moduleVersion),
-			);
-			this.select(name, route);
+			// Historical versions arrive thinned; the nav builds tabs from
+			// source/attestations/presubmit in enterDocument, so the record has
+			// to land before the component is constructed. Resolves immediately
+			// for the latest version and for anything already hydrated.
+			hydrateModuleVersion(moduleVersion).then(() => {
+				if (this.isDisposed()) return;
+				this.addTab(
+					name,
+					new ModuleVersionSelectNav(
+						this.registry_,
+						this.module_,
+						moduleVersion,
+					),
+				);
+				this.select(name, route);
+			});
 			return;
 		}
 

--- a/cmd/registrycompiler/registrycompiler.go
+++ b/cmd/registrycompiler/registrycompiler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	bzpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/registry/v1"
@@ -26,6 +27,8 @@ type Config struct {
 	Branch                    string
 	Commit                    string
 	CommitDate                string
+	Thin                      bool
+	ModuleVersionsDir         string
 }
 
 func main() {
@@ -97,12 +100,87 @@ func run(args []string) error {
 		}
 	}
 
+	if cfg.Thin {
+		if err := thinRegistry(&registry, cfg.ModuleVersionsDir); err != nil {
+			return err
+		}
+	}
+
 	// Write the compiled ModuleVersion to output file
 	if err := protoutil.WriteFile(cfg.OutputFile, &registry); err != nil {
 		return fmt.Errorf("failed to write output file: %v", err)
 	}
 
 	// log.Printf("Successfully compiled registry: %s", cfg.OutputFile)
+	return nil
+}
+
+// thinRegistry strips per-version detail from every non-latest ModuleVersion,
+// optionally writing the untouched record to moduleVersionsDir first so the
+// frontend can fetch it on demand.
+//
+// Motivation: the boot payload is base64+gzipped into a <script> and parsed in
+// full on every page load. At ~15.8MB of wire format it expands to roughly
+// 740MB of JS objects, which exceeds the per-tab memory cap on iOS Safari --
+// WebContent gets killed with `highwater`, Safari reloads the tab, and the
+// cycle repeats until it gives up. Thinning takes the payload to ~5.7MB.
+//
+// What stays on every version, and why:
+//
+//   - name, version, compatibility_level, bazel_compatibility, repo_name
+//   - deps and override: the frontend builds a reverse-dependency index and
+//     runs MVS resolution across the *entire* version history, so the
+//     dependency graph cannot be reduced to latest-only. See
+//     buildReverseDependencyIndex in app/bcr/registry.js and app/bcr/mvs.js.
+//   - a reduced commit (date, pull_request, github_user, github_name): the
+//     home "recently added" feed reads the OLDEST version of each module, and
+//     the maintainers page attributes every version by commit.github_user.
+//     Only sha1 and the (large) commit message are dropped.
+//
+// Everything else -- source, attestations, presubmit, toolchains_to_register
+// -- is only ever rendered on a module detail page for the single version
+// being viewed, so it is served per-version instead.
+func thinRegistry(registry *bzpb.Registry, moduleVersionsDir string) error {
+	for _, module := range registry.Modules {
+		for _, mv := range module.Versions {
+			if mv.IsLatestVersion {
+				continue
+			}
+			if moduleVersionsDir != "" {
+				if err := writeModuleVersionRecord(moduleVersionsDir, mv); err != nil {
+					return err
+				}
+			}
+			mv.Source = nil
+			mv.Attestations = nil
+			mv.Presubmit = nil
+			mv.ToolchainsToRegister = nil
+			mv.RepositoryMetadata = nil
+			if mv.Commit != nil {
+				mv.Commit = &bzpb.ModuleCommit{
+					Date:        mv.Commit.Date,
+					PullRequest: mv.Commit.PullRequest,
+					GithubUser:  mv.Commit.GithubUser,
+					GithubName:  mv.Commit.GithubName,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// writeModuleVersionRecord writes the full ModuleVersion to
+// <dir>/<name>/<version>/moduleversion.pb.gz. releasecompiler copies the tree
+// into the tarball under modules/, giving the frontend a URL that mirrors the
+// existing documentationinfo.pb.gz / packageinfo.pb.gz convention.
+func writeModuleVersionRecord(dir string, mv *bzpb.ModuleVersion) error {
+	path := filepath.Join(dir, mv.Name, mv.Version, "moduleversion.pb.gz")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating %s: %v", filepath.Dir(path), err)
+	}
+	if err := protoutil.WriteFile(path, mv); err != nil {
+		return fmt.Errorf("writing %s: %v", path, err)
+	}
 	return nil
 }
 
@@ -115,6 +193,8 @@ func parseFlags(args []string) (cfg Config, err error) {
 	fs.StringVar(&cfg.Branch, "branch", "", "branch name of the repository data (e.g. 'main')")
 	fs.StringVar(&cfg.Commit, "commit", "", "commit sha1 of the repository data")
 	fs.StringVar(&cfg.CommitDate, "commit_date", "", "timestamp of the commit date (ISO 8601 format)")
+	fs.BoolVar(&cfg.Thin, "thin", false, "strip per-version detail (source, attestations, presubmit, commit sha1/message) from non-latest module versions. Keeps the full dependency graph and the commit fields the home/maintainers feeds read. Shrinks the boot payload from ~15.8MB to ~5.7MB of wire format")
+	fs.StringVar(&cfg.ModuleVersionsDir, "module_versions_dir", "", "with -thin, write each non-latest version's untouched record to <dir>/<name>/<version>/moduleversion.pb.gz for the frontend to fetch on demand")
 	fs.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "usage: %s @PARAMS_FILE", toolName)
 		fs.PrintDefaults()

--- a/cmd/registrycompiler/registrycompiler_test.go
+++ b/cmd/registrycompiler/registrycompiler_test.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	bzpb "github.com/bazel-contrib/bcr-frontend/build/stack/bazel/registry/v1"
+	"github.com/bazel-contrib/bcr-frontend/pkg/protoutil"
+	"google.golang.org/protobuf/proto"
+)
+
+func mv(name, version string, latest bool) *bzpb.ModuleVersion {
+	return &bzpb.ModuleVersion{
+		Name:                 name,
+		Version:              version,
+		IsLatestVersion:      latest,
+		CompatibilityLevel:   1,
+		BazelCompatibility:   []string{">=7.0.0"},
+		RepoName:             name,
+		Deps:                 []*bzpb.ModuleDependency{{Name: "rules_cc", Version: "0.0.9"}},
+		Override:             []*bzpb.ModuleDependencyOverride{{ModuleName: "rules_cc"}},
+		ToolchainsToRegister: []string{"//toolchain:all"},
+		Source:               &bzpb.ModuleSource{Url: "https://example.com/a.tar.gz", Integrity: "sha256-abc"},
+		Attestations:         &bzpb.Attestations{MediaType: "application/vnd.dev.sigstore.bundle+json"},
+		Presubmit:            &bzpb.Presubmit{},
+		Commit: &bzpb.ModuleCommit{
+			Sha1:        "deadbeefdeadbeef",
+			Date:        "2026-01-02T03:04:05Z",
+			Message:     "a very long commit message that dominates the payload",
+			PullRequest: "1234",
+			GithubUser:  "octocat",
+			GithubName:  "The Octocat",
+		},
+	}
+}
+
+func TestThinRegistryKeepsLatestVersionsIntact(t *testing.T) {
+	reg := &bzpb.Registry{Modules: []*bzpb.Module{{
+		Name:     "foo",
+		Versions: []*bzpb.ModuleVersion{mv("foo", "2.0.0", true), mv("foo", "1.0.0", false)},
+	}}}
+
+	if err := thinRegistry(reg, ""); err != nil {
+		t.Fatalf("thinRegistry: %v", err)
+	}
+
+	latest := reg.Modules[0].Versions[0]
+	if latest.Source == nil || latest.Attestations == nil || latest.Presubmit == nil {
+		t.Error("latest version lost detail fields; it must be served from the boot payload")
+	}
+	if latest.Commit.Message == "" || latest.Commit.Sha1 == "" {
+		t.Error("latest version lost commit sha1/message")
+	}
+	if len(latest.ToolchainsToRegister) == 0 {
+		t.Error("latest version lost toolchains_to_register")
+	}
+}
+
+func TestThinRegistryStripsDetailFromHistoricalVersions(t *testing.T) {
+	reg := &bzpb.Registry{Modules: []*bzpb.Module{{
+		Name:     "foo",
+		Versions: []*bzpb.ModuleVersion{mv("foo", "2.0.0", true), mv("foo", "1.0.0", false)},
+	}}}
+
+	if err := thinRegistry(reg, ""); err != nil {
+		t.Fatalf("thinRegistry: %v", err)
+	}
+
+	old := reg.Modules[0].Versions[1]
+	if old.Source != nil {
+		t.Error("source should be stripped; it is only rendered on a detail page")
+	}
+	if old.Attestations != nil {
+		t.Error("attestations should be stripped")
+	}
+	if old.Presubmit != nil {
+		t.Error("presubmit should be stripped")
+	}
+	if old.ToolchainsToRegister != nil {
+		t.Error("toolchains_to_register should be stripped")
+	}
+
+	// The dependency graph must survive: buildReverseDependencyIndex and MVS
+	// both walk the entire version history.
+	if len(old.Deps) != 1 {
+		t.Errorf("deps must be retained on historical versions, got %d", len(old.Deps))
+	}
+	if len(old.Override) != 1 {
+		t.Errorf("override must be retained on historical versions, got %d", len(old.Override))
+	}
+
+	// The home "recently added" feed reads the oldest version's commit, and
+	// the maintainers page filters by commit.github_user.
+	if old.Commit == nil {
+		t.Fatal("commit must be retained on historical versions")
+	}
+	if old.Commit.Date == "" || old.Commit.PullRequest == "" || old.Commit.GithubUser == "" || old.Commit.GithubName == "" {
+		t.Error("commit lost a field the home/maintainers feeds depend on")
+	}
+	if old.Commit.Message != "" {
+		t.Error("commit message should be dropped from historical versions")
+	}
+	if old.Commit.Sha1 != "" {
+		t.Error("commit sha1 should be dropped from historical versions")
+	}
+}
+
+func TestThinRegistryWritesFullRecordPerHistoricalVersion(t *testing.T) {
+	dir := t.TempDir()
+	reg := &bzpb.Registry{Modules: []*bzpb.Module{{
+		Name:     "foo",
+		Versions: []*bzpb.ModuleVersion{mv("foo", "2.0.0", true), mv("foo", "1.0.0", false)},
+	}}}
+
+	if err := thinRegistry(reg, dir); err != nil {
+		t.Fatalf("thinRegistry: %v", err)
+	}
+
+	// Only non-latest versions need a sidecar; latest ships in the payload.
+	if _, err := os.Stat(filepath.Join(dir, "foo", "2.0.0", "moduleversion.pb.gz")); !os.IsNotExist(err) {
+		t.Error("latest version should not get a sidecar record")
+	}
+
+	path := filepath.Join(dir, "foo", "1.0.0", "moduleversion.pb.gz")
+	var got bzpb.ModuleVersion
+	if err := protoutil.ReadFile(path, &got); err != nil {
+		t.Fatalf("reading sidecar: %v", err)
+	}
+	if got.Source == nil || got.Source.Url == "" {
+		t.Error("sidecar must carry the source that was stripped from the payload")
+	}
+	if got.Attestations == nil || got.Presubmit == nil {
+		t.Error("sidecar must carry attestations and presubmit")
+	}
+	if got.Commit.Message == "" || got.Commit.Sha1 == "" {
+		t.Error("sidecar must carry the full commit, including message and sha1")
+	}
+}
+
+// TestThinRegistryAgainstRealRegistry reports the actual payload reduction.
+// Skipped unless BCR_REGISTRY_PB points at a real registry.pb, e.g.
+//
+//	BCR_REGISTRY_PB=/path/to/registry.pb go test ./cmd/registrycompiler/ -run Real -v
+func TestThinRegistryAgainstRealRegistry(t *testing.T) {
+	path := os.Getenv("BCR_REGISTRY_PB")
+	if path == "" {
+		t.Skip("set BCR_REGISTRY_PB to measure against real registry data")
+	}
+
+	var reg bzpb.Registry
+	if err := protoutil.ReadFile(path, &reg); err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	before, err := proto.Marshal(&reg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var nLatest, nHistorical int
+	for _, m := range reg.Modules {
+		for _, v := range m.Versions {
+			if v.IsLatestVersion {
+				nLatest++
+			} else {
+				nHistorical++
+			}
+		}
+	}
+
+	if err := thinRegistry(&reg, t.TempDir()); err != nil {
+		t.Fatalf("thinRegistry: %v", err)
+	}
+	after, err := proto.Marshal(&reg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	t.Logf("modules=%d latest=%d historical=%d", len(reg.Modules), nLatest, nHistorical)
+	t.Logf("wire: %.2f MB -> %.2f MB (%.1f%% smaller)",
+		float64(len(before))/1e6, float64(len(after))/1e6,
+		(1-float64(len(after))/float64(len(before)))*100)
+
+	if len(after) >= len(before) {
+		t.Errorf("thinning did not shrink the payload: %d -> %d", len(before), len(after))
+	}
+}

--- a/cmd/releasecompiler/releasecompiler.go
+++ b/cmd/releasecompiler/releasecompiler.go
@@ -464,8 +464,51 @@ func createTarball(indexContent []byte, assets []HashedAsset, modulesSrcFiles []
 		}
 	}
 
-	// Add modules_src files preserving path relative to "modules/"
+	// Add modules_src entries preserving path relative to "modules/".
+	//
+	// An entry is either a single file (the per-version documentationinfo /
+	// packageinfo artifacts, one Bazel action each) or a tree artifact. The
+	// tree case exists because registrycompiler emits ~8k per-version
+	// moduleversion.pb.gz records from one action; declaring them
+	// individually would mean thousands of extra actions for no benefit.
 	for _, path := range modulesSrcFiles {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat modules_src %s: %v", path, err)
+		}
+
+		if info.IsDir() {
+			// Tree artifact: name entries by their path relative to the
+			// declared directory rather than searching for a "modules/"
+			// marker, which would misfire on a module literally named
+			// "modules".
+			err := filepath.Walk(path, func(p string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if fi.IsDir() {
+					return nil
+				}
+				rel, err := filepath.Rel(path, p)
+				if err != nil {
+					return fmt.Errorf("relativizing %s against %s: %v", p, path, err)
+				}
+				content, err := os.ReadFile(p)
+				if err != nil {
+					return fmt.Errorf("failed to read modules_src %s: %v", p, err)
+				}
+				tarName := "modules/" + filepath.ToSlash(rel)
+				if err := addFileToTar(tw, tarName, content); err != nil {
+					return fmt.Errorf("failed to add %s: %v", tarName, err)
+				}
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
 		const marker = "modules/"
 		idx := strings.LastIndex(path, marker)
 		if idx == -1 {

--- a/rules/module_registry.bzl
+++ b/rules/module_registry.bzl
@@ -699,13 +699,41 @@ Sitemap: {registry_url}/sitemap.xml
 
     return output
 
-def _compile_registry_action(ctx, filename, modules, symbols = None):
+def _compile_registry_action(ctx, filename, modules, symbols = None, thin = False):
+    """Compiles the per-module protos into a single Registry proto.
+
+    Args:
+        ctx: The rule context
+        filename: Name of the output proto
+        modules: List of compiled Module protos
+        symbols: Optional ModuleRegistrySymbols proto to decorate with
+        thin: When True, strip per-version detail from non-latest module
+            versions and emit each untouched record into a `moduleversions`
+            tree artifact. Used for the boot payload, which is parsed in full
+            on every page load and otherwise exceeds mobile Safari's per-tab
+            memory cap. See cmd/registrycompiler for what is kept and why.
+
+    Returns:
+        struct(proto = File, module_versions = File | None)
+    """
     output = ctx.actions.declare_file(filename)
+    outputs = [output]
     inputs = [] + modules
 
     args = ctx.actions.args()
     args.add("--output_file")
     args.add(output)
+
+    module_versions = None
+    if thin:
+        args.add("--thin")
+
+        # One tree artifact rather than ~8k declared files: the records are
+        # produced by a single registrycompiler action, and declaring them
+        # individually would add thousands of actions to every build.
+        module_versions = ctx.actions.declare_directory("moduleversions")
+        args.add("--module_versions_dir", module_versions.path)
+        outputs.append(module_versions)
     args.add("--registry_url")
     args.add(ctx.attr.registry_url)
     if symbols:
@@ -730,12 +758,12 @@ def _compile_registry_action(ctx, filename, modules, symbols = None):
         executable = ctx.executable._registrycompiler,
         arguments = [args],
         inputs = inputs,
-        outputs = [output],
+        outputs = outputs,
         mnemonic = "CompileRegistry",
         progress_message = "Compiling registry for %{label}",
     )
 
-    return output
+    return struct(proto = output, module_versions = module_versions)
 
 def _module_registry_impl(ctx):
     deps = [d[ModuleMetadataInfo] for d in ctx.attr.deps]
@@ -754,8 +782,13 @@ def _module_registry_impl(ctx):
     symbols_pb = _compile_module_registry_symbols(ctx, doc_results)
     pkg_results = _compile_packages(ctx, deps)
     packages_pb = _compile_module_registry_packages(ctx, pkg_results)
-    registry_pb = _compile_registry_action(ctx, "registry.pb", modules, symbols_pb)
-    registrylite_pb = _compile_registry_action(ctx, "registrylite.pb", modules)
+    registry_pb = _compile_registry_action(ctx, "registry.pb", modules, symbols_pb).proto
+    registrylite_pb = _compile_registry_action(ctx, "registrylite.pb", modules).proto
+
+    # The payload actually shipped in index.html. Thinned so the parse fits in
+    # a mobile browser tab; the stripped detail rides along as per-version
+    # records the frontend fetches on demand.
+    registrythin = _compile_registry_action(ctx, "registrythin.pb", modules, thin = True)
 
     bazel_help = _compile_bazel_help_registry_action(ctx, bazel_versions)
     bazel_flag_db = _compile_bazel_flag_db_action(ctx, bazel_help)
@@ -789,6 +822,8 @@ def _module_registry_impl(ctx):
             robots_txt = [robots_txt],
             registry_pb = [registry_pb],
             registrylite_pb = [registrylite_pb],
+            registrythin_pb = [registrythin.proto],
+            module_versions = [registrythin.module_versions],
             codesearch_index = [codesearch_index],
             # The @_builtins output is a single shared file (not per-MV),
             # is already aggregated into symbols.pb, and lives at a non-


### PR DESCRIPTION
The registry is base64+gzipped into a <script> and parsed in full on every page load. Non-latest versions carried source, attestations, presubmit, toolchains and full commit metadata that is only ever rendered on a detail page for the single version being viewed.

registrycompiler gains --thin, which strips those fields from non-latest versions and writes each untouched record to
modules/<name>/<version>/moduleversion.pb.gz. The frontend fetches that record before rendering a historical version's page, mirroring the existing documentationinfo.pb.gz / packageinfo.pb.gz convention.

Deliberately retained on every version:
  - deps and override, because the frontend builds a reverse-dependency index and runs MVS resolution across the entire version history
  - commit date/pull_request/github_user/github_name, because the home "recently added" feed reads the OLDEST version of each module and the maintainers page attributes every version by commit.github_user

Measured against production data (1,257 modules / 9,502 versions):

  wire payload      15.80 MB -> 5.72 MB  (63.8% smaller)
  b64 script         4.14 MB -> 1.37 MB  (67% smaller download)
  registry heap        58 MB ->   32 MB
  full page A/B     742.4 MB -> 656.9 MB (11.5%)

Note this is not the fix for the iOS Safari crash. Profiling attributes ~684 MB of the ~742 MB retained heap to symbols.pb.gz and packages.pb.gz, which main.js fetches and parses eagerly at boot regardless of route. Making those genuinely lazy is the load-bearing change; this one shrinks the payload and compounds with it.

releasecompiler learns to walk a directory passed as --modules_src, so the ~8k per-version records ship from one action instead of thousands.